### PR TITLE
Broaden Claude Code permissions for smoother workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,14 +5,26 @@
       "Bash(git push -f*)"
     ],
     "allow": [
-      "Bash(git branch:*)",
-      "Bash(git push:*)",
-      "Bash(git commit:*)",
-      "Bash(./mvnw compile:*)",
-      "Edit(file_path:/home/lr245/IdeaProjects/danceschool/CLAUDE.md)",
-      "Bash(./mvnw clean:*)",
-      "Bash(./mvnw test:*)",
-      "Bash(git add:*)"
+      "Bash(git:*)",
+      "Bash(./mvnw:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(wc:*)",
+      "Bash(which:*)",
+      "Bash(echo:*)",
+      "Bash(pwd:*)",
+      "Bash(tree:*)",
+      "Edit",
+      "Write",
+      "Read",
+      "Glob",
+      "Grep",
+      "mcp__github__*"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Allows all git, Maven, file ops, GitHub MCP, and read-only bash commands
- Force push remains denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)