### PR TITLE
Add frontend CI job for Angular tests and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Build & Test
+  backend:
+    name: Backend
     runs-on: ubuntu-latest
 
     steps:
@@ -24,3 +24,30 @@ jobs:
 
       - name: Run tests
         run: ./mvnw verify --batch-mode --no-transfer-progress
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npx ng build


### PR DESCRIPTION
## Summary
- Splits CI into parallel Backend and Frontend jobs
- Frontend job: `npm ci` → `npm test` (Vitest) → `ng build` (production)
- Uses Node 22 with npm dependency caching

## Test plan
- [ ] Backend job still passes
- [ ] Frontend tests pass
- [ ] Frontend production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)