### PR TITLE
Add Docker Compose setup for production deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DB_USER=danceschool
+DB_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Docker ###
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Stage 1: Build
+FROM eclipse-temurin:21-jdk-alpine AS build
+WORKDIR /app
+
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+RUN chmod +x mvnw && ./mvnw dependency:go-offline -B
+
+COPY src/ src/
+RUN ./mvnw package -DskipTests -B
+
+# Stage 2: Run
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=build /app/target/*.jar app.jar
+RUN chown app:app app.jar
+
+USER app
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -qO- http://localhost:8080/actuator/health || exit 1
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: danceschool
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d danceschool"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build: .
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/danceschool
+      SPRING_DATASOURCE_USERNAME: ${DB_USER}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+
+volumes:
+  pgdata:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# Stage 1: Build
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npx ng build --configuration=production
+
+# Stage 2: Serve
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # API reverse proxy
+    location /api/ {
+        proxy_pass http://backend:8080/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Actuator (optional, for monitoring)
+    location /actuator/ {
+        proxy_pass http://backend:8080/actuator/;
+        proxy_set_header Host $host;
+    }
+
+    # Swagger UI (optional, remove in hardened prod)
+    location /swagger-ui/ {
+        proxy_pass http://backend:8080/swagger-ui/;
+        proxy_set_header Host $host;
+    }
+
+    location /v3/api-docs {
+        proxy_pass http://backend:8080/v3/api-docs;
+        proxy_set_header Host $host;
+    }
+
+    # Angular SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: validate


### PR DESCRIPTION
## Summary
- Three-container Docker Compose setup: PostgreSQL 16, Spring Boot backend, nginx frontend
- Multi-stage Dockerfiles for both backend (JDK → JRE Alpine) and frontend (Node → nginx Alpine)
- Nginx reverse proxy serves Angular SPA and proxies `/api/`, `/actuator/`, `/swagger-ui/` to backend
- Spring `prod` profile with PostgreSQL datasource (H2 unchanged for local dev)
- Health checks on PostgreSQL and backend (actuator)
- `.env.example` template for DB credentials, `.env` gitignored

## Test plan
- [ ] `docker compose config` validates successfully
- [ ] `docker compose up --build` starts all three services
- [ ] Frontend accessible at `http://localhost`
- [ ] API calls proxied correctly through nginx to backend
- [ ] PostgreSQL data persists across restarts via `pgdata` volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)