### PR TITLE
Add backend security with OAuth2 and JWT authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,19 @@ danceschool/
 
 Frontend and backend are independent builds — no Maven integration. During development, run `ng serve` with a proxy to the backend API.
 
+## Domain
+
+Multi-tenant B2B SaaS for dance school management. Each **School** is a tenant. See `docs/GLOSSARY.md` for ubiquitous language (DDD-style).
+
+- **Admin portal** (current Angular frontend): for school Owners and Teachers
+- **Student apps** (future): students browse schools, view classes, enroll
+
 ## CI/CD
 
 - **Branch protection** is enabled on `main` — all changes go through PRs
 - CI workflows in `.github/workflows/`: `ci.yml` (tests), `codeql.yml` (code scanning)
-- Frontend deployed on Render (static site), backend deployment TBD
+- **Frontend** deployed on Render (static site): https://danceschool-2g1m.onrender.com/
+- **Backend** deployed on Render (Docker): https://danceschool-api.onrender.com/ (API base: `/api`)
 
 ## Git & GitHub
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -49,6 +49,31 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.12.6</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-aop</artifactId>
     </dependency>
     <dependency>
@@ -90,6 +115,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -14,6 +14,8 @@ Spring Boot 3.5 application (Java 21) for managing a dance school. Uses Maven wr
 
 **Key stack:**
 - Spring Web (REST API), Spring Data JPA (persistence), Spring Validation
+- Spring Security + OAuth2 Client (Google, GitHub social login)
+- JWT authentication (jjwt library, HMAC-SHA256, HTTP-only cookie)
 - Liquibase for database migrations (`src/main/resources/db/changelog/db.changelog-master.yaml`)
 - H2 in-memory database (dev/test)
 - Lombok for boilerplate reduction (configured as annotation processor in maven-compiler-plugin)
@@ -69,6 +71,42 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 - No manual logging in slice code — the aspects cover entry, exit, duration, and errors
 - Use `@Slf4j` when adding loggers to new cross-cutting classes
 - No PII at INFO level (class/method names and durations only, full payloads at DEBUG)
+
+## Security Architecture
+
+### Authentication Flow
+- Backend acts as OAuth2 Client — handles the entire Google/GitHub login redirect flow
+- After OAuth2 success, backend mints its own JWT (HMAC-SHA256, 7-day expiry) containing `userId` and `email`
+- JWT is set as an `AUTH_TOKEN` HTTP-only, Secure, SameSite=None cookie
+- On subsequent requests, `JwtAuthFilter` reads the cookie, validates the JWT, and sets `SecurityContext`
+- Sessions are `IF_REQUIRED` (used briefly during OAuth2 redirect dance, not for ongoing auth)
+
+### Authorization Model
+- Roles are **scoped to a school**, not global — stored in `school_member` table
+- `SchoolMember` links a `User` to a `School` with a `MemberRole` (OWNER, USER)
+- A user with no memberships is in the "needs onboarding" state
+- `GET /api/auth/me` returns the user with their memberships — frontend uses this to route
+
+### Dev Login
+- `POST /api/dev/login` with `{"email": "..."}` — available only when `prod` profile is NOT active
+- Creates/finds a user and sets the same JWT cookie as OAuth2 would
+- Use for local development and Playwright E2E tests
+- CSRF is disabled for `/api/dev/**`
+
+### Configuration (via env vars)
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` — Google OAuth2 credentials
+- `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` — GitHub OAuth credentials
+- `JWT_SECRET` — HMAC-SHA256 signing key (min 32 bytes)
+- `CORS_ALLOWED_ORIGINS` — comma-separated allowed origins (default: `http://localhost:4200`)
+- `FRONTEND_URL` — redirect target after OAuth2 login (default: `http://localhost:4200`)
+
+### Key classes in `shared/security/`
+- `SecurityConfig` — filter chain, CORS, CSRF, OAuth2, authorization rules
+- `JwtUtil` — sign/validate JWTs
+- `JwtAuthFilter` — reads JWT from cookie, sets SecurityContext
+- `JwtCookieUtil` — set/clear/read the AUTH_TOKEN cookie
+- `OAuth2LoginSuccessHandler` — creates user, mints JWT, redirects to frontend
+- `AuthenticatedUser` — principal record (userId, email) available via `@AuthenticationPrincipal`
 
 ## Database Migrations
 

--- a/backend/src/main/java/ch/ruppen/danceschool/auth/AuthController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/auth/AuthController.java
@@ -1,0 +1,37 @@
+package ch.ruppen.danceschool.auth;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.security.JwtCookieUtil;
+import ch.ruppen.danceschool.user.AppUser;
+import ch.ruppen.danceschool.user.UserDto;
+import ch.ruppen.danceschool.user.UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto> me(@AuthenticationPrincipal AuthenticatedUser principal) {
+        return userService.findById(principal.userId())
+                .map(userService::toUserDto)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        JwtCookieUtil.clearTokenCookie(response);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/auth/DevLoginController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/auth/DevLoginController.java
@@ -1,0 +1,39 @@
+package ch.ruppen.danceschool.auth;
+
+import ch.ruppen.danceschool.shared.security.JwtCookieUtil;
+import ch.ruppen.danceschool.shared.security.JwtProperties;
+import ch.ruppen.danceschool.shared.security.JwtUtil;
+import ch.ruppen.danceschool.user.AppUser;
+import ch.ruppen.danceschool.user.UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/dev")
+@Profile("!prod")
+@RequiredArgsConstructor
+public class DevLoginController {
+
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> devLogin(@RequestBody DevLoginRequest request, HttpServletResponse response) {
+        AppUser user = userService.findOrCreateOAuthUser("dev", request.email(), request.email(), "Dev User", null);
+
+        String token = jwtUtil.generateToken(user.getId(), user.getEmail());
+        JwtCookieUtil.setTokenCookie(response, token, jwtProperties.expirationDays());
+
+        return ResponseEntity.ok().build();
+    }
+
+    record DevLoginRequest(String email) {
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/school/CreateSchoolUseCase.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/CreateSchoolUseCase.java
@@ -1,0 +1,36 @@
+package ch.ruppen.danceschool.school;
+
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
+import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
+import ch.ruppen.danceschool.user.AppUser;
+import ch.ruppen.danceschool.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CreateSchoolUseCase {
+
+    private final SchoolService schoolService;
+    private final SchoolMemberService schoolMemberService;
+    private final UserService userService;
+
+    @Transactional
+    public SchoolDto execute(SchoolDto dto, Long userId) {
+        AppUser user = userService.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        School school = schoolService.createSchool(dto);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(user);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        schoolMemberService.createMembership(member);
+
+        return schoolService.toDto(school);
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
@@ -1,32 +1,26 @@
 package ch.ruppen.danceschool.school;
 
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/schools")
 @RequiredArgsConstructor
 public class SchoolController {
 
-    private final SchoolService schoolService;
-
-    @GetMapping
-    public List<SchoolDto> list() {
-        return schoolService.findAll();
-    }
+    private final CreateSchoolUseCase createSchoolUseCase;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public SchoolDto create(@Valid @RequestBody SchoolDto dto) {
-        return schoolService.create(dto);
+    public SchoolDto create(@Valid @RequestBody SchoolDto dto, @AuthenticationPrincipal AuthenticatedUser principal) {
+        return createSchoolUseCase.execute(dto, principal.userId());
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -3,8 +3,6 @@ package ch.ruppen.danceschool.school;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class SchoolService {
@@ -12,15 +10,12 @@ public class SchoolService {
     private final SchoolRepository schoolRepository;
     private final SchoolMapper schoolMapper;
 
-    public List<SchoolDto> findAll() {
-        return schoolRepository.findAll().stream()
-                .map(schoolMapper::toDto)
-                .toList();
+    public School createSchool(SchoolDto dto) {
+        School school = schoolMapper.toEntity(dto);
+        return schoolRepository.save(school);
     }
 
-    public SchoolDto create(SchoolDto dto) {
-        School school = schoolMapper.toEntity(dto);
-        School saved = schoolRepository.save(school);
-        return schoolMapper.toDto(saved);
+    public SchoolDto toDto(School school) {
+        return schoolMapper.toDto(school);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/MemberRole.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/MemberRole.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.schoolmember;
+
+public enum MemberRole {
+    OWNER,
+    USER
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/MembershipDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/MembershipDto.java
@@ -1,0 +1,8 @@
+package ch.ruppen.danceschool.schoolmember;
+
+public record MembershipDto(
+        Long schoolId,
+        String schoolName,
+        MemberRole role
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMember.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMember.java
@@ -1,0 +1,40 @@
+package ch.ruppen.danceschool.schoolmember;
+
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class SchoolMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private AppUser user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    private School school;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberRepository.java
@@ -1,0 +1,10 @@
+package ch.ruppen.danceschool.schoolmember;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+interface SchoolMemberRepository extends JpaRepository<SchoolMember, Long> {
+
+    List<SchoolMember> findByUserId(Long userId);
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
@@ -1,0 +1,26 @@
+package ch.ruppen.danceschool.schoolmember;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SchoolMemberService {
+
+    private final SchoolMemberRepository schoolMemberRepository;
+
+    public List<MembershipDto> findMembershipsByUserId(Long userId) {
+        return schoolMemberRepository.findByUserId(userId).stream()
+                .map(member -> new MembershipDto(
+                        member.getSchool().getId(),
+                        member.getSchool().getName(),
+                        member.getRole()))
+                .toList();
+    }
+
+    public SchoolMember createMembership(SchoolMember member) {
+        return schoolMemberRepository.save(member);
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/AppSecurityProperties.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/AppSecurityProperties.java
@@ -1,0 +1,12 @@
+package ch.ruppen.danceschool.shared.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.security")
+public record AppSecurityProperties(
+        List<String> corsAllowedOrigins,
+        String frontendUrl
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/AuthenticatedUser.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/AuthenticatedUser.java
@@ -1,0 +1,4 @@
+package ch.ruppen.danceschool.shared.security;
+
+public record AuthenticatedUser(Long userId, String email) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtAuthFilter.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtAuthFilter.java
@@ -1,0 +1,43 @@
+package ch.ruppen.danceschool.shared.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        JwtCookieUtil.extractToken(request)
+                .flatMap(jwtUtil::validateToken)
+                .ifPresent(this::setAuthentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(Claims claims) {
+        Long userId = Long.parseLong(claims.getSubject());
+        String email = claims.get("email", String.class);
+
+        var principal = new AuthenticatedUser(userId, email);
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtCookieUtil.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtCookieUtil.java
@@ -1,0 +1,50 @@
+package ch.ruppen.danceschool.shared.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+public final class JwtCookieUtil {
+
+    public static final String COOKIE_NAME = "AUTH_TOKEN";
+
+    private JwtCookieUtil() {
+    }
+
+    public static void setTokenCookie(HttpServletResponse response, String token, long maxAgeDays) {
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, token)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofDays(maxAgeDays))
+                .sameSite("None")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void clearTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static Optional<String> extractToken(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> COOKIE_NAME.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtProperties.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtProperties.java
@@ -1,0 +1,10 @@
+package ch.ruppen.danceschool.shared.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.jwt")
+public record JwtProperties(
+        String secret,
+        long expirationDays
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtUtil.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtUtil.java
@@ -1,0 +1,50 @@
+package ch.ruppen.danceschool.shared.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Optional;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey key;
+    private final long expirationDays;
+
+    public JwtUtil(JwtProperties properties) {
+        this.key = Keys.hmacShaKeyFor(properties.secret().getBytes(StandardCharsets.UTF_8));
+        this.expirationDays = properties.expirationDays();
+    }
+
+    public String generateToken(Long userId, String email) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("email", email)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(expirationDays, ChronoUnit.DAYS)))
+                .signWith(key)
+                .compact();
+    }
+
+    public Optional<Claims> validateToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return Optional.of(claims);
+        } catch (JwtException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,59 @@
+package ch.ruppen.danceschool.shared.security;
+
+import ch.ruppen.danceschool.user.AppUser;
+import ch.ruppen.danceschool.user.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+    private final AppSecurityProperties securityProperties;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+        OAuth2User oauthUser = oauthToken.getPrincipal();
+        String provider = oauthToken.getAuthorizedClientRegistrationId();
+
+        String oauthId = oauthUser.getName();
+        String email = oauthUser.getAttribute("email");
+        String name = extractName(oauthUser, provider);
+        String avatarUrl = extractAvatarUrl(oauthUser, provider);
+
+        AppUser user = userService.findOrCreateOAuthUser(provider, oauthId, email, name, avatarUrl);
+
+        String token = jwtUtil.generateToken(user.getId(), user.getEmail());
+        JwtCookieUtil.setTokenCookie(response, token, jwtProperties.expirationDays());
+
+        response.sendRedirect(securityProperties.frontendUrl() + "/auth/callback");
+    }
+
+    private String extractName(OAuth2User oauthUser, String provider) {
+        return switch (provider) {
+            case "github" -> oauthUser.getAttribute("login");
+            default -> oauthUser.getAttribute("name");
+        };
+    }
+
+    private String extractAvatarUrl(OAuth2User oauthUser, String provider) {
+        return switch (provider) {
+            case "github" -> oauthUser.getAttribute("avatar_url");
+            default -> oauthUser.getAttribute("picture");
+        };
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
@@ -1,0 +1,66 @@
+package ch.ruppen.danceschool.shared.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableConfigurationProperties({JwtProperties.class, AppSecurityProperties.class})
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final AppSecurityProperties securityProperties;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+                        .ignoringRequestMatchers("/api/dev/**"))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                        .requestMatchers("/api/dev/**").permitAll()
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll())
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(oAuth2LoginSuccessHandler))
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(securityProperties.corsAllowedOrigins());
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/user/AppUser.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/user/AppUser.java
@@ -1,0 +1,36 @@
+package ch.ruppen.danceschool.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "app_user")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AppUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String name;
+
+    private String avatarUrl;
+
+    @Column(nullable = false)
+    private String oauthProvider;
+
+    @Column(nullable = false)
+    private String oauthId;
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/user/UserDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/user/UserDto.java
@@ -1,0 +1,14 @@
+package ch.ruppen.danceschool.user;
+
+import ch.ruppen.danceschool.schoolmember.MembershipDto;
+
+import java.util.List;
+
+public record UserDto(
+        Long id,
+        String email,
+        String name,
+        String avatarUrl,
+        List<MembershipDto> memberships
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/user/UserRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/user/UserRepository.java
@@ -1,0 +1,12 @@
+package ch.ruppen.danceschool.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+interface UserRepository extends JpaRepository<AppUser, Long> {
+
+    Optional<AppUser> findByOauthProviderAndOauthId(String oauthProvider, String oauthId);
+
+    Optional<AppUser> findByEmail(String email);
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/user/UserService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/user/UserService.java
@@ -1,0 +1,49 @@
+package ch.ruppen.danceschool.user;
+
+import ch.ruppen.danceschool.schoolmember.MembershipDto;
+import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final SchoolMemberService schoolMemberService;
+
+    public AppUser findOrCreateOAuthUser(String provider, String oauthId, String email, String name, String avatarUrl) {
+        return userRepository.findByOauthProviderAndOauthId(provider, oauthId)
+                .map(existing -> {
+                    existing.setEmail(email);
+                    existing.setName(name);
+                    existing.setAvatarUrl(avatarUrl);
+                    return userRepository.save(existing);
+                })
+                .orElseGet(() -> {
+                    AppUser user = new AppUser();
+                    user.setOauthProvider(provider);
+                    user.setOauthId(oauthId);
+                    user.setEmail(email);
+                    user.setName(name);
+                    user.setAvatarUrl(avatarUrl);
+                    return userRepository.save(user);
+                });
+    }
+
+    public Optional<AppUser> findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    public Optional<AppUser> findById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    public UserDto toUserDto(AppUser user) {
+        List<MembershipDto> memberships = schoolMemberService.findMembershipsByUserId(user.getId());
+        return new UserDto(user.getId(), user.getEmail(), user.getName(), user.getAvatarUrl(), memberships);
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,6 +1,26 @@
 spring:
   application:
     name: danceschool
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:placeholder}
+            client-secret: ${GOOGLE_CLIENT_SECRET:placeholder}
+            scope: openid, profile, email
+          github:
+            client-id: ${GITHUB_CLIENT_ID:placeholder}
+            client-secret: ${GITHUB_CLIENT_SECRET:placeholder}
+            scope: read:user, user:email
+
+app:
+  jwt:
+    secret: ${JWT_SECRET:dev-secret-key-that-is-at-least-32-bytes-long-for-hmac-sha256}
+    expiration-days: 7
+  security:
+    cors-allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:4200}
+    frontend-url: ${FRONTEND_URL:http://localhost:4200}
 
 logging:
   level:

--- a/backend/src/main/resources/db/changelog/002-create-user.yaml
+++ b/backend/src/main/resources/db/changelog/002-create-user.yaml
@@ -1,0 +1,40 @@
+databaseChangeLog:
+  - changeSet:
+      id: 002-create-user
+      author: claude
+      changes:
+        - createTable:
+            tableName: app_user
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  name: avatar_url
+                  type: VARCHAR(1000)
+              - column:
+                  name: oauth_provider
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: oauth_id
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: app_user
+            columnNames: oauth_provider, oauth_id
+            constraintName: uk_user_oauth

--- a/backend/src/main/resources/db/changelog/003-create-school-member.yaml
+++ b/backend/src/main/resources/db/changelog/003-create-school-member.yaml
@@ -1,0 +1,46 @@
+databaseChangeLog:
+  - changeSet:
+      id: 003-create-school-member
+      author: claude
+      changes:
+        - createTable:
+            tableName: school_member
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: school_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: school_member
+            baseColumnNames: user_id
+            referencedTableName: app_user
+            referencedColumnNames: id
+            constraintName: fk_school_member_user
+        - addForeignKeyConstraint:
+            baseTableName: school_member
+            baseColumnNames: school_id
+            referencedTableName: school
+            referencedColumnNames: id
+            constraintName: fk_school_member_school
+        - addUniqueConstraint:
+            tableName: school_member
+            columnNames: user_id, school_id
+            constraintName: uk_school_member_user_school

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,7 @@
 databaseChangeLog:
   - include:
       file: db/changelog/001-create-school.yaml
+  - include:
+      file: db/changelog/002-create-user.yaml
+  - include:
+      file: db/changelog/003-create-school-member.yaml

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,21 @@
+# Ubiquitous Language — Danceschool
+
+DDD-style glossary. Canonical naming for code, APIs, and conversation.
+
+| Term           | Definition                                                                                          |
+|----------------|-----------------------------------------------------------------------------------------------------|
+| **School**     | A dance school. The tenant boundary. All data (classes, members) belongs to a school.               |
+| **Owner**      | The person who created/claimed a school. Has full administrative control. A role on `SchoolMember`.  |
+| **Member**     | A user associated with a school in a specific role (Owner, Teacher, User). Modeled as `SchoolMember`. |
+| **Teacher**    | A member role (future). Can manage classes but not school settings.                                  |
+| **Class**      | A dance class offered by a school (e.g., "Salsa Beginners, Monday 19:00"). Created by Owner/Teacher.|
+| **Student**    | An end user of the student-facing apps (future). Browses schools, views classes, enrolls.           |
+| **Enrollment** | A student signing up for a class (future).                                                          |
+
+## Bounded Contexts
+
+| Context              | Audience          | Description                                      |
+|----------------------|-------------------|--------------------------------------------------|
+| **School Management** | Owners, Teachers | Admin portal — manage school, classes, members    |
+| **Discovery**         | Students         | Student apps — browse schools, view classes, enroll |
+| **Identity**          | All              | Authentication, user accounts, OAuth              |


### PR DESCRIPTION
## Summary
- Implement OAuth2 social login (Google, GitHub) with Spring Security as OAuth2 Client
- Backend mints JWT (HMAC-SHA256, 7-day expiry) stored in HTTP-only cookie after OAuth2 success
- School-scoped authorization via `SchoolMember` join table (OWNER/USER roles)
- Dev login endpoint (`POST /api/dev/login`) for local development and E2E tests — disabled in prod
- New vertical slices: `user`, `schoolmember`, `auth`
- Refactored `school` slice: removed public GET endpoint, added authenticated `POST /api/schools` with `CreateSchoolUseCase` (creates school + owner membership)
- Added domain glossary (`docs/GLOSSARY.md`) with ubiquitous language
- All config via env vars: OAuth credentials, JWT secret, CORS origins, frontend URL

## New endpoints
| Endpoint | Auth | Description |
|---|---|---|
| `GET /api/auth/me` | Required | Current user + memberships |
| `POST /api/auth/logout` | Required | Clears JWT cookie |
| `POST /api/schools` | Required | Onboarding — create school as OWNER |
| `POST /api/dev/login` | None (dev only) | Dev/test login with email |

## Test plan
- [x] `mvnw compile` — compiles clean
- [x] `mvnw test` — context loads, Liquibase migrations run, all repositories discovered
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)