### PR TITLE
Fix auth cookie, CSRF, and dev login for local development

### DIFF
--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -77,7 +77,7 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 ### Authentication Flow
 - Backend acts as OAuth2 Client — handles the entire Google/GitHub login redirect flow
 - After OAuth2 success, backend mints its own JWT (HMAC-SHA256, 7-day expiry) containing `userId` and `email`
-- JWT is set as an `AUTH_TOKEN` HTTP-only, Secure, SameSite=None cookie
+- JWT is set as an `AUTH_TOKEN` HTTP-only cookie (Secure+SameSite=None in prod, Lax in dev — controlled by `SECURE_COOKIES` env var)
 - On subsequent requests, `JwtAuthFilter` reads the cookie, validates the JWT, and sets `SecurityContext`
 - Sessions are `IF_REQUIRED` (used briefly during OAuth2 redirect dance, not for ongoing auth)
 
@@ -99,6 +99,12 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 - `JWT_SECRET` — HMAC-SHA256 signing key (min 32 bytes)
 - `CORS_ALLOWED_ORIGINS` — comma-separated allowed origins (default: `http://localhost:4200`)
 - `FRONTEND_URL` — redirect target after OAuth2 login (default: `http://localhost:4200`)
+- `SECURE_COOKIES` — set `true` in prod for Secure+SameSite=None cookies (default: `false` for dev)
+
+### CSRF
+- Uses `CookieCsrfTokenRepository.withHttpOnlyFalse()` — Angular reads the `XSRF-TOKEN` cookie and sends `X-XSRF-TOKEN` header automatically
+- Spring Security 6+ defers CSRF token loading — a `csrfCookieFilter` eagerly loads it so the cookie is set on every response
+- CSRF is disabled for `/api/dev/**` (dev-only endpoints)
 
 ### Key classes in `shared/security/`
 - `SecurityConfig` — filter chain, CORS, CSRF, OAuth2, authorization rules

--- a/backend/src/main/java/ch/ruppen/danceschool/auth/AuthController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/auth/AuthController.java
@@ -1,8 +1,8 @@
 package ch.ruppen.danceschool.auth;
 
+import ch.ruppen.danceschool.shared.security.AppSecurityProperties;
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import ch.ruppen.danceschool.shared.security.JwtCookieUtil;
-import ch.ruppen.danceschool.user.AppUser;
 import ch.ruppen.danceschool.user.UserDto;
 import ch.ruppen.danceschool.user.UserService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final UserService userService;
+    private final AppSecurityProperties securityProperties;
 
     @GetMapping("/me")
     public ResponseEntity<UserDto> me(@AuthenticationPrincipal AuthenticatedUser principal) {
@@ -31,7 +32,7 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse response) {
-        JwtCookieUtil.clearTokenCookie(response);
+        JwtCookieUtil.clearTokenCookie(response, securityProperties.secureCookies());
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/auth/DevLoginController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/auth/DevLoginController.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.auth;
 
+import ch.ruppen.danceschool.shared.security.AppSecurityProperties;
 import ch.ruppen.danceschool.shared.security.JwtCookieUtil;
 import ch.ruppen.danceschool.shared.security.JwtProperties;
 import ch.ruppen.danceschool.shared.security.JwtUtil;
@@ -23,13 +24,14 @@ public class DevLoginController {
     private final UserService userService;
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;
+    private final AppSecurityProperties securityProperties;
 
     @PostMapping("/login")
     public ResponseEntity<Void> devLogin(@RequestBody DevLoginRequest request, HttpServletResponse response) {
         AppUser user = userService.findOrCreateOAuthUser("dev", request.email(), request.email(), "Dev User", null);
 
         String token = jwtUtil.generateToken(user.getId(), user.getEmail());
-        JwtCookieUtil.setTokenCookie(response, token, jwtProperties.expirationDays());
+        JwtCookieUtil.setTokenCookie(response, token, jwtProperties.expirationDays(), securityProperties.secureCookies());
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/AppSecurityProperties.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/AppSecurityProperties.java
@@ -7,6 +7,7 @@ import java.util.List;
 @ConfigurationProperties(prefix = "app.security")
 public record AppSecurityProperties(
         List<String> corsAllowedOrigins,
-        String frontendUrl
+        String frontendUrl,
+        boolean secureCookies
 ) {
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtCookieUtil.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/JwtCookieUtil.java
@@ -16,26 +16,34 @@ public final class JwtCookieUtil {
     private JwtCookieUtil() {
     }
 
-    public static void setTokenCookie(HttpServletResponse response, String token, long maxAgeDays) {
-        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, token)
+    public static void setTokenCookie(HttpServletResponse response, String token, long maxAgeDays, boolean secure) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(COOKIE_NAME, token)
                 .httpOnly(true)
-                .secure(true)
                 .path("/")
-                .maxAge(Duration.ofDays(maxAgeDays))
-                .sameSite("None")
-                .build();
-        response.addHeader("Set-Cookie", cookie.toString());
+                .maxAge(Duration.ofDays(maxAgeDays));
+
+        if (secure) {
+            builder.secure(true).sameSite("None");
+        } else {
+            builder.sameSite("Lax");
+        }
+
+        response.addHeader("Set-Cookie", builder.build().toString());
     }
 
-    public static void clearTokenCookie(HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, "")
+    public static void clearTokenCookie(HttpServletResponse response, boolean secure) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(COOKIE_NAME, "")
                 .httpOnly(true)
-                .secure(true)
                 .path("/")
-                .maxAge(0)
-                .sameSite("None")
-                .build();
-        response.addHeader("Set-Cookie", cookie.toString());
+                .maxAge(0);
+
+        if (secure) {
+            builder.secure(true).sameSite("None");
+        } else {
+            builder.sameSite("Lax");
+        }
+
+        response.addHeader("Set-Cookie", builder.build().toString());
     }
 
     public static Optional<String> extractToken(HttpServletRequest request) {

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/OAuth2LoginSuccessHandler.java
@@ -38,7 +38,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         AppUser user = userService.findOrCreateOAuthUser(provider, oauthId, email, name, avatarUrl);
 
         String token = jwtUtil.generateToken(user.getId(), user.getEmail());
-        JwtCookieUtil.setTokenCookie(response, token, jwtProperties.expirationDays());
+        JwtCookieUtil.setTokenCookie(response, token, jwtProperties.expirationDays(), securityProperties.secureCookies());
 
         response.sendRedirect(securityProperties.frontendUrl() + "/auth/callback");
     }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
@@ -1,5 +1,9 @@
 package ch.ruppen.danceschool.shared.security;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -10,11 +14,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.OncePerRequestFilter;
 
+import java.io.IOException;
 import java.util.List;
 
 @Configuration
@@ -46,7 +53,8 @@ public class SecurityConfig {
                         .anyRequest().permitAll())
                 .oauth2Login(oauth2 -> oauth2
                         .successHandler(oAuth2LoginSuccessHandler))
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(csrfCookieFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -62,5 +70,19 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
+    }
+
+    private OncePerRequestFilter csrfCookieFilter() {
+        return new OncePerRequestFilter() {
+            @Override
+            protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                            FilterChain filterChain) throws ServletException, IOException {
+                CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+                if (csrfToken != null) {
+                    csrfToken.getToken();
+                }
+                filterChain.doFilter(request, response);
+            }
+        };
     }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -21,6 +21,7 @@ app:
   security:
     cors-allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:4200}
     frontend-url: ${FRONTEND_URL:http://localhost:4200}
+    secure-cookies: ${SECURE_COOKIES:false}
 
 logging:
   level:

--- a/frontend/src/app/shared/auth/auth.service.ts
+++ b/frontend/src/app/shared/auth/auth.service.ts
@@ -74,7 +74,7 @@ export class AuthService {
 
   devLogin(email: string): void {
     this.http.post(this.apiUrl('/api/dev/login'), { email }).subscribe({
-      next: () => this.checkAuth(),
+      next: () => this.router.navigate(['/auth/callback']),
     });
   }
 }


### PR DESCRIPTION
## Summary
- Make cookie Secure/SameSite configurable via `SECURE_COOKIES` env var — `false` (Lax) for dev, `true` (Secure+SameSite=None) for prod
- Fix dev login to navigate to `/auth/callback` after success (was stuck on login page)
- Add CSRF eager-loading filter for Spring Security 6+ (token cookie wasn't being set)

## Bugs found during E2E testing
All three issues were caught by running the full login → onboarding → dashboard flow with Playwright against local backend + frontend.

## Test plan
- [x] E2E: Dev Login → Onboarding → Create School → Dashboard shows "Salsa Bern (OWNER)"
- [x] Backend compiles
- [x] Frontend builds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)