### PR TITLE
Expand School data model and add GET /api/schools/me endpoint

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/school/School.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/School.java
@@ -1,12 +1,19 @@
 package ch.ruppen.danceschool.school;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,4 +32,26 @@ public class School {
     private String phone;
 
     private String email;
+
+    private String tagline;
+
+    @Column(columnDefinition = "TEXT")
+    private String about;
+
+    private String website;
+
+    private String coverImageUrl;
+
+    private String logoUrl;
+
+    @OneToMany(mappedBy = "school", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchoolSpecialty> specialties = new ArrayList<>();
+
+    @OneToMany(mappedBy = "school", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("position")
+    private List<SchoolGalleryImage> galleryImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "school", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("position")
+    private List<SchoolYoutubeVideo> youtubeVideos = new ArrayList<>();
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
@@ -1,10 +1,12 @@
 package ch.ruppen.danceschool.school;
 
+import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,10 +19,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class SchoolController {
 
     private final CreateSchoolUseCase createSchoolUseCase;
+    private final SchoolService schoolService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public SchoolDto create(@Valid @RequestBody SchoolDto dto, @AuthenticationPrincipal AuthenticatedUser principal) {
         return createSchoolUseCase.execute(dto, principal.userId());
+    }
+
+    @GetMapping("/me")
+    public SchoolDetailDto me(@AuthenticationPrincipal AuthenticatedUser principal) {
+        School school = schoolService.findByOwnerUserId(principal.userId())
+                .orElseThrow(() -> new ResourceNotFoundException("School", principal.userId()));
+        return schoolService.toDetailDto(school);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolDetailDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolDetailDto.java
@@ -1,0 +1,26 @@
+package ch.ruppen.danceschool.school;
+
+import java.util.List;
+
+public record SchoolDetailDto(
+        Long id,
+        String name,
+        String tagline,
+        String about,
+        String address,
+        String phone,
+        String email,
+        String website,
+        String coverImageUrl,
+        String logoUrl,
+        List<String> specialties,
+        List<GalleryImageDto> galleryImages,
+        List<YoutubeVideoDto> youtubeVideos
+) {
+
+    public record GalleryImageDto(String url, int position) {
+    }
+
+    public record YoutubeVideoDto(String url, int position) {
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolGalleryImage.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolGalleryImage.java
@@ -1,0 +1,34 @@
+package ch.ruppen.danceschool.school;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+class SchoolGalleryImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    private School school;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Column(nullable = false)
+    private int position;
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolMapper.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolMapper.java
@@ -2,6 +2,7 @@ package ch.ruppen.danceschool.school;
 
 import ch.ruppen.danceschool.config.MapStructConfig;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 @Mapper(config = MapStructConfig.class)
@@ -9,7 +10,25 @@ interface SchoolMapper {
 
     SchoolDto toDto(School school);
 
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "tagline", ignore = true)
+    @Mapping(target = "about", ignore = true)
+    @Mapping(target = "website", ignore = true)
+    @Mapping(target = "coverImageUrl", ignore = true)
+    @Mapping(target = "logoUrl", ignore = true)
+    @Mapping(target = "specialties", ignore = true)
+    @Mapping(target = "galleryImages", ignore = true)
+    @Mapping(target = "youtubeVideos", ignore = true)
     School toEntity(SchoolDto dto);
 
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "tagline", ignore = true)
+    @Mapping(target = "about", ignore = true)
+    @Mapping(target = "website", ignore = true)
+    @Mapping(target = "coverImageUrl", ignore = true)
+    @Mapping(target = "logoUrl", ignore = true)
+    @Mapping(target = "specialties", ignore = true)
+    @Mapping(target = "galleryImages", ignore = true)
+    @Mapping(target = "youtubeVideos", ignore = true)
     void updateEntity(SchoolDto dto, @MappingTarget School school);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolRepository.java
@@ -1,6 +1,12 @@
 package ch.ruppen.danceschool.school;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 interface SchoolRepository extends JpaRepository<School, Long> {
+
+    @Query("SELECT s FROM School s JOIN SchoolMember m ON m.school = s WHERE m.user.id = :userId AND m.role = ch.ruppen.danceschool.schoolmember.MemberRole.OWNER")
+    Optional<School> findByOwnerUserId(Long userId);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -3,6 +3,8 @@ package ch.ruppen.danceschool.school;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class SchoolService {
@@ -17,5 +19,33 @@ public class SchoolService {
 
     public SchoolDto toDto(School school) {
         return schoolMapper.toDto(school);
+    }
+
+    public Optional<School> findByOwnerUserId(Long userId) {
+        return schoolRepository.findByOwnerUserId(userId);
+    }
+
+    public SchoolDetailDto toDetailDto(School school) {
+        return new SchoolDetailDto(
+                school.getId(),
+                school.getName(),
+                school.getTagline(),
+                school.getAbout(),
+                school.getAddress(),
+                school.getPhone(),
+                school.getEmail(),
+                school.getWebsite(),
+                school.getCoverImageUrl(),
+                school.getLogoUrl(),
+                school.getSpecialties().stream()
+                        .map(SchoolSpecialty::getName)
+                        .toList(),
+                school.getGalleryImages().stream()
+                        .map(img -> new SchoolDetailDto.GalleryImageDto(img.getUrl(), img.getPosition()))
+                        .toList(),
+                school.getYoutubeVideos().stream()
+                        .map(vid -> new SchoolDetailDto.YoutubeVideoDto(vid.getUrl(), vid.getPosition()))
+                        .toList()
+        );
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolSpecialty.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolSpecialty.java
@@ -1,0 +1,31 @@
+package ch.ruppen.danceschool.school;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+class SchoolSpecialty {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    private School school;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolYoutubeVideo.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolYoutubeVideo.java
@@ -1,0 +1,34 @@
+package ch.ruppen.danceschool.school;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+class SchoolYoutubeVideo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    private School school;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Column(nullable = false)
+    private int position;
+}

--- a/backend/src/main/resources/db/changelog/005-expand-school.yaml
+++ b/backend/src/main/resources/db/changelog/005-expand-school.yaml
@@ -1,0 +1,126 @@
+databaseChangeLog:
+  - changeSet:
+      id: 005-add-school-profile-columns
+      author: claude
+      changes:
+        - addColumn:
+            tableName: school
+            columns:
+              - column:
+                  name: tagline
+                  type: VARCHAR(255)
+              - column:
+                  name: about
+                  type: TEXT
+              - column:
+                  name: website
+                  type: VARCHAR(500)
+              - column:
+                  name: cover_image_url
+                  type: VARCHAR(1000)
+              - column:
+                  name: logo_url
+                  type: VARCHAR(1000)
+
+  - changeSet:
+      id: 005-create-school-specialty
+      author: claude
+      changes:
+        - createTable:
+            tableName: school_specialty
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: school_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: school_specialty
+            baseColumnNames: school_id
+            referencedTableName: school
+            referencedColumnNames: id
+            constraintName: fk_school_specialty_school
+
+  - changeSet:
+      id: 005-create-school-gallery-image
+      author: claude
+      changes:
+        - createTable:
+            tableName: school_gallery_image
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: school_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: url
+                  type: VARCHAR(1000)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: position
+                  type: INT
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: school_gallery_image
+            baseColumnNames: school_id
+            referencedTableName: school
+            referencedColumnNames: id
+            constraintName: fk_school_gallery_image_school
+
+  - changeSet:
+      id: 005-create-school-youtube-video
+      author: claude
+      changes:
+        - createTable:
+            tableName: school_youtube_video
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: school_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: url
+                  type: VARCHAR(1000)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: position
+                  type: INT
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: school_youtube_video
+            baseColumnNames: school_id
+            referencedTableName: school
+            referencedColumnNames: id
+            constraintName: fk_school_youtube_video_school

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/003-create-school-member.yaml
   - include:
       file: db/changelog/004-simplify-user.yaml
+  - include:
+      file: db/changelog/005-expand-school.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolControllerIntegrationTest.java
@@ -1,0 +1,148 @@
+package ch.ruppen.danceschool.school;
+
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class SchoolControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new AppUser();
+        testUser.setEmail("test@example.com");
+        testUser.setName("Test User");
+        testUser.setUsername("testuser");
+        entityManager.persist(testUser);
+        entityManager.flush();
+    }
+
+    @Test
+    void getMe_returnsSchoolDetail_whenUserIsOwner() throws Exception {
+        School school = new School();
+        school.setName("Test Dance School");
+        school.setTagline("Dance with us");
+        school.setAbout("A great school");
+        school.setAddress("123 Main St");
+        school.setPhone("+1 555-1234");
+        school.setEmail("school@example.com");
+        school.setWebsite("www.testschool.com");
+        entityManager.persist(school);
+
+        SchoolSpecialty specialty = new SchoolSpecialty();
+        specialty.setSchool(school);
+        specialty.setName("Bachata");
+        school.getSpecialties().add(specialty);
+
+        SchoolGalleryImage image = new SchoolGalleryImage();
+        image.setSchool(school);
+        image.setUrl("https://example.com/image1.jpg");
+        image.setPosition(0);
+        school.getGalleryImages().add(image);
+
+        SchoolYoutubeVideo video = new SchoolYoutubeVideo();
+        video.setSchool(school);
+        video.setUrl("https://www.youtube.com/watch?v=abc123");
+        video.setPosition(0);
+        school.getYoutubeVideos().add(video);
+        entityManager.merge(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(testUser);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(school.getId()))
+                .andExpect(jsonPath("$.name").value("Test Dance School"))
+                .andExpect(jsonPath("$.tagline").value("Dance with us"))
+                .andExpect(jsonPath("$.about").value("A great school"))
+                .andExpect(jsonPath("$.address").value("123 Main St"))
+                .andExpect(jsonPath("$.phone").value("+1 555-1234"))
+                .andExpect(jsonPath("$.email").value("school@example.com"))
+                .andExpect(jsonPath("$.website").value("www.testschool.com"))
+                .andExpect(jsonPath("$.coverImageUrl").isEmpty())
+                .andExpect(jsonPath("$.logoUrl").isEmpty())
+                .andExpect(jsonPath("$.specialties[0]").value("Bachata"))
+                .andExpect(jsonPath("$.galleryImages[0].url").value("https://example.com/image1.jpg"))
+                .andExpect(jsonPath("$.galleryImages[0].position").value(0))
+                .andExpect(jsonPath("$.youtubeVideos[0].url").value("https://www.youtube.com/watch?v=abc123"))
+                .andExpect(jsonPath("$.youtubeVideos[0].position").value(0));
+    }
+
+    @Test
+    void getMe_returnsEmptyCollections_whenSchoolHasNoRelatedData() throws Exception {
+        School school = new School();
+        school.setName("Empty School");
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(testUser);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Empty School"))
+                .andExpect(jsonPath("$.tagline").doesNotExist())
+                .andExpect(jsonPath("$.specialties").isArray())
+                .andExpect(jsonPath("$.specialties").isEmpty())
+                .andExpect(jsonPath("$.galleryImages").isArray())
+                .andExpect(jsonPath("$.galleryImages").isEmpty())
+                .andExpect(jsonPath("$.youtubeVideos").isArray())
+                .andExpect(jsonPath("$.youtubeVideos").isEmpty());
+    }
+
+    @Test
+    void getMe_returns404_whenUserHasNoSchool() throws Exception {
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getMe_returnsForbidden_whenNotAuthenticated() throws Exception {
+        mockMvc.perform(get("/api/schools/me"))
+                .andExpect(status().isForbidden());
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}


### PR DESCRIPTION
## Summary

- Expand `School` entity with new profile fields: `tagline`, `about`, `website`, `coverImageUrl`, `logoUrl`
- Add join tables for specialties, gallery images, and YouTube videos (with position ordering)
- Add `GET /api/schools/me` endpoint returning the full school profile for the authenticated owner
- Liquibase migrations for all schema changes
- Integration tests covering: success with data, success with empty collections, 404 for no school, 403 for unauthenticated

Closes #32

## Test plan

- [x] All backend tests pass locally (`./mvnw test`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)