### PR TITLE
Add My School view page with all sections (#33)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -11,6 +11,7 @@ export const routes: Routes = [
       { path: 'onboarding', loadComponent: () => import('./onboarding/onboarding').then(m => m.OnboardingComponent) },
       { path: 'dashboard', loadComponent: () => import('./dashboard/dashboard').then(m => m.DashboardComponent) },
       { path: 'students', loadComponent: () => import('./students/students').then(m => m.StudentsComponent) },
+      { path: 'my-school', loadComponent: () => import('./my-school/my-school').then(m => m.MySchoolComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
     ],
   },

--- a/frontend/src/app/my-school/my-school.html
+++ b/frontend/src/app/my-school/my-school.html
@@ -1,0 +1,150 @@
+@if (school(); as school) {
+  <!-- Header -->
+  <div class="page-header">
+    <div class="title-group">
+      <h1 class="page-title">My School</h1>
+      <p class="page-subtitle">Manage your dance school information and settings</p>
+    </div>
+    <button mat-stroked-button routerLink="/my-school/edit">Edit</button>
+  </div>
+
+  <!-- Hero Card -->
+  <div class="card hero-card">
+    <div class="cover-image" [style.background-image]="school.coverImageUrl ? 'url(' + school.coverImageUrl + ')' : ''">
+      @if (!school.coverImageUrl) {
+        <div class="cover-placeholder"></div>
+      }
+    </div>
+    <div class="school-info">
+      <div class="school-logo">
+        @if (school.logoUrl) {
+          <img [src]="school.logoUrl" [alt]="school.name + ' logo'" />
+        } @else {
+          <mat-icon class="logo-placeholder-icon">school</mat-icon>
+        }
+      </div>
+      <div class="name-group">
+        <h2 class="school-name">{{ school.name }}</h2>
+        @if (school.tagline) {
+          <p class="school-tagline">{{ school.tagline }}</p>
+        } @else {
+          <p class="empty-hint">No tagline added yet</p>
+        }
+      </div>
+    </div>
+  </div>
+
+  <!-- About & Specialties Row -->
+  <div class="about-specialties-row">
+    <!-- About Card -->
+    <div class="card about-card">
+      <h3 class="section-title">About</h3>
+      @if (school.about) {
+        <p class="about-text">{{ school.about }}</p>
+      } @else {
+        <p class="empty-hint">No description added yet. Tell potential students about your school.</p>
+      }
+    </div>
+
+    <!-- Specialties Card -->
+    <div class="card specialties-card">
+      <h3 class="section-title">Specialties</h3>
+      @if (school.specialties.length > 0) {
+        <div class="chips">
+          @for (specialty of school.specialties; track specialty) {
+            <span class="chip chip-primary">{{ specialty }}</span>
+          }
+        </div>
+      } @else {
+        <p class="empty-hint">No specialties added yet</p>
+      }
+    </div>
+  </div>
+
+  <!-- Location & Contact Card -->
+  <div class="card contact-card">
+    <h3 class="section-title">Location & Contact</h3>
+    @if (school.address || school.phone || school.email || school.website) {
+      <div class="contact-columns">
+        <div class="contact-column">
+          <div class="contact-field">
+            <span class="contact-label">Address</span>
+            @if (school.address) {
+              @for (line of school.address.split(', '); track line) {
+                <span class="contact-value">{{ line }}</span>
+              }
+            } @else {
+              <span class="empty-hint">No address added yet</span>
+            }
+          </div>
+        </div>
+        <div class="contact-column">
+          <div class="contact-field">
+            <span class="contact-label">Phone</span>
+            @if (school.phone) {
+              <span class="contact-value">{{ school.phone }}</span>
+            } @else {
+              <span class="empty-hint">Not provided</span>
+            }
+          </div>
+          <div class="contact-field">
+            <span class="contact-label">Email</span>
+            @if (school.email) {
+              <span class="contact-value">{{ school.email }}</span>
+            } @else {
+              <span class="empty-hint">Not provided</span>
+            }
+          </div>
+          <div class="contact-field">
+            <span class="contact-label">Website</span>
+            @if (school.website) {
+              <span class="contact-value">{{ school.website }}</span>
+            } @else {
+              <span class="empty-hint">Not provided</span>
+            }
+          </div>
+        </div>
+      </div>
+    } @else {
+      <p class="empty-hint">No contact information added yet</p>
+    }
+  </div>
+
+  <!-- Gallery Card -->
+  <div class="card">
+    <h3 class="section-title">Gallery</h3>
+    @if (school.galleryImages.length > 0) {
+      <div class="image-grid">
+        @for (image of school.galleryImages; track image.url) {
+          <div class="image-cell">
+            <img [src]="image.url" alt="Gallery image" />
+          </div>
+        }
+      </div>
+    } @else {
+      <p class="empty-hint">No images added yet. Add photos to showcase your school.</p>
+    }
+  </div>
+
+  <!-- YouTube Videos Card -->
+  <div class="card">
+    <h3 class="section-title">YouTube Videos</h3>
+    @if (school.youtubeVideos.length > 0) {
+      <div class="videos-row">
+        @for (video of school.youtubeVideos; track video.url) {
+          <a class="video-thumbnail" [href]="video.url" target="_blank" rel="noopener">
+            <div class="play-button">▶</div>
+          </a>
+        }
+      </div>
+    } @else {
+      <p class="empty-hint">No videos added yet. Link YouTube videos to promote your school.</p>
+    }
+  </div>
+} @else if (error()) {
+  <p class="error-text">Could not load school information. Please try again later.</p>
+} @else {
+  <div class="loading">
+    <p>Loading school information...</p>
+  </div>
+}

--- a/frontend/src/app/my-school/my-school.scss
+++ b/frontend/src/app/my-school/my-school.scss
@@ -1,0 +1,290 @@
+@use 'styles/mixins' as ds;
+
+// Card pattern (from design system rules)
+.card {
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+  padding: var(--ds-card-padding);
+}
+
+// Page header
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.title-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+}
+
+.page-title {
+  font: var(--mat-sys-headline-small);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.page-subtitle {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}
+
+// Section titles
+.section-title {
+  font: var(--mat-sys-title-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+// Empty state hints
+.empty-hint {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}
+
+// Hero card
+.hero-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.cover-image {
+  height: 200px;
+  background-size: cover;
+  background-position: center;
+}
+
+.cover-placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(to right, var(--mat-sys-primary), #9c6af0);
+}
+
+.school-info {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-5);
+  padding: var(--ds-spacing-4) var(--ds-card-padding) var(--ds-spacing-5);
+}
+
+.school-logo {
+  width: var(--ds-spacing-20);
+  height: var(--ds-spacing-20);
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--mat-sys-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .logo-placeholder-icon {
+    font-size: var(--ds-spacing-10);
+    width: var(--ds-spacing-10);
+    height: var(--ds-spacing-10);
+    color: var(--mat-sys-on-primary);
+  }
+}
+
+.name-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-1);
+  min-width: 0;
+}
+
+.school-name {
+  font: var(--mat-sys-headline-small);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.school-tagline {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}
+
+// About & Specialties row
+.about-specialties-row {
+  display: flex;
+  gap: var(--ds-card-padding);
+
+  @include ds.bp-down(md) {
+    flex-direction: column;
+  }
+}
+
+.about-card {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-3);
+}
+
+.about-text {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+  line-height: 1.6;
+}
+
+.specialties-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-3);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-spacing-2);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--ds-spacing-1) var(--ds-spacing-3);
+  border-radius: var(--ds-radius-md);
+  font: var(--mat-sys-label-medium);
+}
+
+.chip-primary {
+  background: var(--mat-sys-primary-container);
+  color: var(--mat-sys-primary);
+}
+
+// Location & Contact card
+.contact-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-5);
+}
+
+.contact-columns {
+  display: flex;
+  gap: var(--ds-spacing-12);
+
+  @include ds.bp-down(md) {
+    flex-direction: column;
+    gap: var(--ds-spacing-6);
+  }
+}
+
+.contact-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-4);
+}
+
+.contact-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.contact-label {
+  font: var(--mat-sys-label-small);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.contact-value {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface);
+}
+
+// Gallery
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--ds-spacing-3);
+
+  @include ds.bp-down(md) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.image-cell {
+  border-radius: var(--ds-radius-md);
+  overflow: hidden;
+  aspect-ratio: 16 / 10;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+// YouTube Videos
+.videos-row {
+  display: flex;
+  gap: var(--ds-spacing-4);
+
+  @include ds.bp-down(md) {
+    flex-direction: column;
+  }
+}
+
+.video-thumbnail {
+  flex: 1;
+  height: 180px;
+  background: #202020;
+  border-radius: var(--ds-radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  overflow: hidden;
+}
+
+.play-button {
+  width: var(--ds-spacing-12);
+  height: var(--ds-spacing-12);
+  border-radius: var(--ds-spacing-6);
+  background: red;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font: var(--mat-sys-title-medium);
+}
+
+// Loading / error states
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: var(--ds-spacing-12);
+
+  p {
+    font: var(--mat-sys-body-large);
+    color: var(--mat-sys-on-surface-variant);
+  }
+}
+
+.error-text {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-error, #b00020);
+  text-align: center;
+  padding: var(--ds-spacing-12);
+}
+
+// Host layout
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-card-padding);
+}

--- a/frontend/src/app/my-school/my-school.ts
+++ b/frontend/src/app/my-school/my-school.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { SchoolDetail, SchoolService } from './school.service';
+
+@Component({
+  selector: 'app-my-school',
+  imports: [RouterLink, MatButtonModule, MatIconModule],
+  templateUrl: './my-school.html',
+  styleUrl: './my-school.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MySchoolComponent implements OnInit {
+  private schoolService = inject(SchoolService);
+
+  protected school = signal<SchoolDetail | null>(null);
+  protected error = signal(false);
+
+  ngOnInit(): void {
+    this.schoolService.getMySchool().subscribe({
+      next: (school) => this.school.set(school),
+      error: () => this.error.set(true),
+    });
+  }
+}

--- a/frontend/src/app/my-school/school.service.ts
+++ b/frontend/src/app/my-school/school.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface GalleryImage {
+  url: string;
+  position: number;
+}
+
+export interface YoutubeVideo {
+  url: string;
+  position: number;
+}
+
+export interface SchoolDetail {
+  id: number;
+  name: string;
+  tagline: string | null;
+  about: string | null;
+  address: string | null;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+  coverImageUrl: string | null;
+  logoUrl: string | null;
+  specialties: string[];
+  galleryImages: GalleryImage[];
+  youtubeVideos: YoutubeVideo[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class SchoolService {
+  private http = inject(HttpClient);
+
+  getMySchool(): Observable<SchoolDetail> {
+    return this.http.get<SchoolDetail>(`${environment.apiUrl}/api/schools/me`);
+  }
+}

--- a/frontend/src/app/shell/shell.ts
+++ b/frontend/src/app/shell/shell.ts
@@ -42,6 +42,7 @@ export class ShellComponent {
   protected navItems: NavItem[] = [
     { label: 'Dashboard', icon: 'dashboard', route: '/dashboard' },
     { label: 'Students', icon: 'people', route: '/students' },
+    { label: 'My School', icon: 'business', route: '/my-school' },
   ];
 
   constructor() {

--- a/frontend/src/styles/_mixins.scss
+++ b/frontend/src/styles/_mixins.scss
@@ -1,4 +1,6 @@
 // Responsive breakpoint mixins — aligned with Material's internal breakpoints.
+@use 'sass:map';
+@use 'sass:math';
 
 $breakpoints: (
   sm: 600px,
@@ -10,7 +12,7 @@ $breakpoints: (
 /// Apply styles at viewport width >= $name breakpoint.
 /// Usage: @include bp-up(md) { ... }
 @mixin bp-up($name) {
-  $value: map-get($breakpoints, $name);
+  $value: map.get($breakpoints, $name);
   @media (min-width: $value) {
     @content;
   }
@@ -19,7 +21,7 @@ $breakpoints: (
 /// Apply styles at viewport width < $name breakpoint.
 /// Usage: @include bp-down(sm) { ... }
 @mixin bp-down($name) {
-  $value: map-get($breakpoints, $name);
+  $value: map.get($breakpoints, $name);
   @media (max-width: $value - 0.02px) {
     @content;
   }
@@ -28,8 +30,8 @@ $breakpoints: (
 /// Apply styles between two breakpoints.
 /// Usage: @include bp-between(sm, lg) { ... }
 @mixin bp-between($lower, $upper) {
-  $min: map-get($breakpoints, $lower);
-  $max: map-get($breakpoints, $upper);
+  $min: map.get($breakpoints, $lower);
+  $max: map.get($breakpoints, $upper);
   @media (min-width: $min) and (max-width: $max - 0.02px) {
     @content;
   }


### PR DESCRIPTION
## Summary

- Adds read-only My School page at `/my-school` displaying full school profile from `GET /api/schools/me`
- Implements all 6 sections: Hero (cover + logo + name + tagline), About, Specialties, Location & Contact, Gallery, YouTube Videos
- Each section shows informational empty-state hints when data is absent
- Adds "My School" as third sidebar nav item with `routerLinkActive` highlighting
- Fixes Sass mixin barrel re-export by migrating `_mixins.scss` to modern `sass:map` module syntax

## Files changed

- `frontend/src/app/my-school/` — new component (template, styles, TypeScript) + SchoolService
- `frontend/src/app/app.routes.ts` — lazy-loaded `/my-school` route
- `frontend/src/app/shell/shell.ts` — "My School" nav item
- `frontend/src/styles/_mixins.scss` — fix `map-get` → `map.get` for Sass module compatibility

## Test plan

- [x] Build succeeds (`ng build`)
- [x] Visual verification via Playwright — page renders with correct layout, all sections visible
- [x] Empty state hints display for sections without data
- [x] Sidebar nav item highlights when active
- [ ] CI passes

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)