### PR TITLE
Add sub-issue linking and GitHub MCP to project config

### DIFF
--- a/.claude/commands/prd-to-issues.md
+++ b/.claude/commands/prd-to-issues.md
@@ -111,6 +111,10 @@ This is a post-implementation review, not a blocker for shipping.
 - Blocked by #<all-other-slice-issue-numbers>
 ```
 
+### 6. Link sub-issues to the parent PRD
+
+After all issues are created, link each one as a **sub-issue** of the parent PRD issue using the `sub_issue_write` MCP tool (method: `add`). This makes the PRD act as an epic with a trackable checklist of child issues.
+
 Do NOT close or modify the parent PRD issue.
 
 $ARGUMENTS

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,10 +1,17 @@
 {
   "permissions": {
     "allow": [
+      "mcp__plugin_figma_figma__use_figma",
+      "Bash(pkill -f \"spring-boot:run\")",
+      "Bash(pkill -f \"danceschool.*java\")",
+      "mcp__plugin_figma_figma__get_screenshot",
+      "Bash(pkill -f \"danceschool\")",
+      "Bash(done)",
       "mcp__plugin_figma_figma__get_metadata",
       "mcp__plugin_figma_figma__get_screenshot",
       "mcp__plugin_figma_figma__get_variable_defs",
       "Bash(node:*)"
     ]
   }
+
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,13 @@
     "playwright": {
       "command": "npx",
       "args": ["-y", "@playwright/mcp@latest"]
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add step 6 to `/prd-to-issues` command: link created issues as sub-issues to the parent PRD using `sub_issue_write` MCP tool
- Move GitHub MCP server from local `.claude.json` to project `.mcp.json` with `${GITHUB_TOKEN}` env var (keeps PAT out of repo)
- Update local settings permissions

## Test plan
- [ ] Verify GitHub MCP connects with `GITHUB_TOKEN` env var set
- [ ] Run `/prd-to-issues` and confirm sub-issues are linked to parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)