### PR TITLE
Add specialties management to edit page (#44)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -3,6 +3,8 @@ package ch.ruppen.danceschool.school;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -38,7 +40,20 @@ public class SchoolService {
         school.setWebsite(dto.website());
         school.setCoverImageUrl(dto.coverImageUrl());
         school.setLogoUrl(dto.logoUrl());
+        replaceSpecialties(school, dto.specialties());
         return schoolRepository.save(school);
+    }
+
+    private void replaceSpecialties(School school, List<String> specialties) {
+        school.getSpecialties().clear();
+        if (specialties != null) {
+            for (String name : specialties) {
+                var specialty = new SchoolSpecialty();
+                specialty.setSchool(school);
+                specialty.setName(name);
+                school.getSpecialties().add(specialty);
+            }
+        }
     }
 
     public SchoolDetailDto toDetailDto(School school) {

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolUpdateDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolUpdateDto.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.URL;
 
+import java.util.List;
+
 public record SchoolUpdateDto(
         @NotBlank String name,
         String tagline,
@@ -16,6 +18,7 @@ public record SchoolUpdateDto(
         @Email String email,
         @URL String website,
         String coverImageUrl,
-        String logoUrl
+        String logoUrl,
+        List<String> specialties
 ) {
 }

--- a/frontend/src/app/my-school/edit/my-school-edit.html
+++ b/frontend/src/app/my-school/edit/my-school-edit.html
@@ -48,7 +48,26 @@
     </div>
     <div class="card specialties-card">
       <h3 class="section-title">Specialties</h3>
-      <p class="empty-hint">Specialty management coming soon</p>
+      <div class="chips">
+        @for (specialty of specialties(); track $index) {
+          <span class="chip chip-primary">
+            {{ specialty }}
+            <button class="chip-remove" (click)="removeSpecialty($index)">
+              <mat-icon>close</mat-icon>
+            </button>
+          </span>
+        }
+        @if (addingSpecialty()) {
+          <input class="specialty-input" #specialtyInput
+                 (keydown.enter)="confirmSpecialty(specialtyInput.value); specialtyInput.value = ''"
+                 (blur)="confirmSpecialty(specialtyInput.value); specialtyInput.value = ''"
+                 placeholder="Type specialty..." />
+        } @else {
+          <button class="chip chip-add" (click)="addingSpecialty.set(true)">
+            <mat-icon>add</mat-icon> Add
+          </button>
+        }
+      </div>
     </div>
   </div>
 

--- a/frontend/src/app/my-school/edit/my-school-edit.scss
+++ b/frontend/src/app/my-school/edit/my-school-edit.scss
@@ -103,6 +103,71 @@
   flex: 1;
 }
 
+// Chips
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-spacing-2);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-spacing-1);
+  padding: var(--ds-spacing-1) var(--ds-spacing-3);
+  border-radius: var(--ds-radius-md);
+  font: var(--mat-sys-label-medium);
+}
+
+.chip-primary {
+  background: var(--mat-sys-primary-container);
+  color: var(--mat-sys-primary);
+}
+
+.chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--mat-sys-primary);
+
+  mat-icon {
+    font-size: var(--ds-spacing-4);
+    width: var(--ds-spacing-4);
+    height: var(--ds-spacing-4);
+  }
+}
+
+.chip-add {
+  background: var(--mat-sys-surface-variant);
+  color: var(--mat-sys-on-surface-variant);
+  cursor: pointer;
+  border: none;
+
+  mat-icon {
+    font-size: var(--ds-spacing-4);
+    width: var(--ds-spacing-4);
+    height: var(--ds-spacing-4);
+  }
+}
+
+.specialty-input {
+  padding: var(--ds-spacing-1) var(--ds-spacing-3);
+  border-radius: var(--ds-radius-md);
+  border: 1px solid var(--mat-sys-outline-variant);
+  font: var(--mat-sys-label-medium);
+  outline: none;
+  background: var(--mat-sys-surface);
+  color: var(--mat-sys-on-surface);
+
+  &:focus {
+    border-color: var(--mat-sys-primary);
+  }
+}
+
 // Location & Contact card
 .contact-card {
   display: flex;

--- a/frontend/src/app/my-school/edit/my-school-edit.ts
+++ b/frontend/src/app/my-school/edit/my-school-edit.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, HostListener, inject, signal, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, inject, signal, OnInit, computed } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { SchoolDetail, SchoolService, SchoolUpdateRequest } from '../school.service';
@@ -14,6 +15,7 @@ import { SchoolDetail, SchoolService, SchoolUpdateRequest } from '../school.serv
     ReactiveFormsModule,
     MatButtonModule,
     MatFormFieldModule,
+    MatIconModule,
     MatInputModule,
     MatSnackBarModule,
   ],
@@ -29,6 +31,9 @@ export class MySchoolEditComponent implements OnInit {
 
   protected saving = signal(false);
   protected loading = signal(true);
+  protected specialties = signal<string[]>([]);
+  protected addingSpecialty = signal(false);
+  private specialtiesDirty = false;
 
   protected form = this.fb.group({
     name: ['', Validators.required],
@@ -70,6 +75,7 @@ export class MySchoolEditComponent implements OnInit {
     this.schoolService.updateMySchool(data).subscribe({
       next: () => {
         this.form.markAsPristine();
+        this.specialtiesDirty = false;
         this.router.navigate(['/my-school']);
       },
       error: (err) => {
@@ -87,15 +93,29 @@ export class MySchoolEditComponent implements OnInit {
     this.router.navigate(['/my-school']);
   }
 
+  protected removeSpecialty(index: number): void {
+    this.specialties.update(s => s.filter((_, i) => i !== index));
+    this.specialtiesDirty = true;
+  }
+
+  protected confirmSpecialty(value: string): void {
+    const trimmed = value.trim();
+    if (trimmed) {
+      this.specialties.update(s => [...s, trimmed]);
+      this.specialtiesDirty = true;
+    }
+    this.addingSpecialty.set(false);
+  }
+
   @HostListener('window:beforeunload', ['$event'])
   onBeforeUnload(event: BeforeUnloadEvent): void {
-    if (this.form.dirty) {
+    if (this.form.dirty || this.specialtiesDirty) {
       event.preventDefault();
     }
   }
 
   canDeactivate(): boolean {
-    return !this.form.dirty;
+    return !this.form.dirty && !this.specialtiesDirty;
   }
 
   private patchForm(school: SchoolDetail): void {
@@ -113,7 +133,9 @@ export class MySchoolEditComponent implements OnInit {
       coverImageUrl: school.coverImageUrl ?? '',
       logoUrl: school.logoUrl ?? '',
     });
+    this.specialties.set([...(school.specialties ?? [])]);
     this.form.markAsPristine();
+    this.specialtiesDirty = false;
   }
 
   private buildRequest(): SchoolUpdateRequest {
@@ -131,6 +153,7 @@ export class MySchoolEditComponent implements OnInit {
       website: v.website || null,
       coverImageUrl: v.coverImageUrl || null,
       logoUrl: v.logoUrl || null,
+      specialties: this.specialties(),
     };
   }
 

--- a/frontend/src/app/my-school/school.service.ts
+++ b/frontend/src/app/my-school/school.service.ts
@@ -58,4 +58,5 @@ export interface SchoolUpdateRequest {
   website: string | null;
   coverImageUrl: string | null;
   logoUrl: string | null;
+  specialties: string[];
 }


### PR DESCRIPTION
## Summary
- **Backend:** Add `specialties` (List<String>) to `SchoolUpdateDto`, replace collection wholesale on update
- **Frontend:** Removable chips with inline "+ Add" text input (Enter/blur confirms, empty discarded), design token compliant styling, unsaved changes tracking

Closes #44

## Test plan
- [x] 26 backend tests pass
- [x] Frontend builds successfully
- [x] Chip add/remove interaction verified via DOM snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)