### PR TITLE
Add sticky footer action bar for Save/Cancel on edit page (#66)

### DIFF
--- a/frontend/src/app/my-school/edit/my-school-edit.html
+++ b/frontend/src/app/my-school/edit/my-school-edit.html
@@ -5,12 +5,6 @@
       <h1 class="page-title">My School</h1>
       <p class="page-subtitle">Editing your dance school information</p>
     </div>
-    <div class="header-actions">
-      <button mat-stroked-button (click)="cancel()">Cancel</button>
-      <button mat-flat-button color="primary" (click)="save()" [disabled]="saving()">
-        {{ saving() ? 'Saving...' : 'Save Changes' }}
-      </button>
-    </div>
   </div>
 
   <!-- Hero Card -->
@@ -208,6 +202,14 @@
         <mat-icon>add</mat-icon> Add Video
       </button>
     }
+  </div>
+
+  <!-- Sticky Footer Action Bar -->
+  <div class="footer-actions">
+    <button mat-stroked-button (click)="cancel()">Cancel</button>
+    <button mat-flat-button color="primary" (click)="save()" [disabled]="saving()">
+      {{ saving() ? 'Saving...' : 'Save Changes' }}
+    </button>
   </div>
 } @else {
   <div class="loading">

--- a/frontend/src/app/my-school/edit/my-school-edit.scss
+++ b/frontend/src/app/my-school/edit/my-school-edit.scss
@@ -44,9 +44,22 @@
   margin: 0;
 }
 
-.header-actions {
+// Sticky footer action bar
+.footer-actions {
+  position: sticky;
+  bottom: 0;
   display: flex;
+  justify-content: flex-end;
   gap: var(--ds-spacing-3);
+  padding: var(--ds-spacing-4) var(--ds-card-padding);
+  margin: 0 calc(var(--ds-card-padding) * -1) calc(var(--ds-card-padding) * -1);
+  background: var(--mat-sys-surface);
+  border-top: 1px solid var(--mat-sys-outline-variant);
+  z-index: 10;
+
+  @include ds.bp-down(sm) {
+    flex-direction: column;
+  }
 }
 
 // Section titles


### PR DESCRIPTION
## Summary
- Move Save/Cancel buttons from page header to a sticky footer bar that stays visible at the bottom of the viewport while scrolling
- Improves UX on long edit forms — users no longer need to scroll back to the top to save
- Uses negative margins to extend the footer full-width past the page padding for a clean edge-to-edge look
- Responsive: buttons stack vertically on small screens

Closes #66

## Test plan
- [x] Build compiles successfully
- [x] Visual verification: footer stays pinned at bottom while scrolling (top, middle, bottom positions tested)
- [x] Buttons right-aligned with proper spacing
- [x] Top border separates footer from content
- [ ] Manual test: Save and Cancel buttons function correctly from footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)