### PR TITLE
Delete old images from storage when replaced or removed (#80)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.image;
 
+import ch.ruppen.danceschool.shared.storage.ImageStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -1,18 +1,24 @@
 package ch.ruppen.danceschool.school;
 
+import ch.ruppen.danceschool.shared.storage.ImageStorageService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SchoolService {
 
     private final SchoolRepository schoolRepository;
     private final SchoolMapper schoolMapper;
+    private final ImageStorageService imageStorageService;
 
     public School createSchool(SchoolDto dto) {
         School school = schoolMapper.toEntity(dto);
@@ -28,6 +34,8 @@ public class SchoolService {
     }
 
     public School updateSchool(School school, SchoolUpdateDto dto) {
+        deleteReplacedImages(school, dto);
+
         school.setName(dto.name());
         school.setTagline(dto.tagline());
         school.setAbout(dto.about());
@@ -44,6 +52,41 @@ public class SchoolService {
         replaceGalleryImages(school, dto.galleryImages());
         replaceYoutubeVideos(school, dto.youtubeVideos());
         return schoolRepository.save(school);
+    }
+
+    private void deleteReplacedImages(School school, SchoolUpdateDto dto) {
+        deleteImageIfChanged(school.getCoverImageUrl(), dto.coverImageUrl());
+        deleteImageIfChanged(school.getLogoUrl(), dto.logoUrl());
+        deleteRemovedGalleryImages(school, dto.galleryImages());
+    }
+
+    private void deleteImageIfChanged(String oldUrl, String newUrl) {
+        if (oldUrl != null && !oldUrl.isBlank() && !Objects.equals(oldUrl, newUrl)) {
+            deleteImageSafely(oldUrl);
+        }
+    }
+
+    private void deleteRemovedGalleryImages(School school, List<SchoolUpdateDto.GalleryImageDto> newImages) {
+        Set<String> newUrls = newImages != null
+                ? newImages.stream().map(SchoolUpdateDto.GalleryImageDto::url).collect(Collectors.toSet())
+                : Set.of();
+
+        for (SchoolGalleryImage existing : school.getGalleryImages()) {
+            if (!newUrls.contains(existing.getUrl())) {
+                deleteImageSafely(existing.getUrl());
+            }
+        }
+    }
+
+    private void deleteImageSafely(String url) {
+        try {
+            String key = ImageStorageService.extractKey(url);
+            if (key != null) {
+                imageStorageService.delete(key);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to delete old image from storage: {}. Error: {}", url, e.getMessage());
+        }
     }
 
     private void replaceSpecialties(School school, List<String> specialties) {

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/CloudflareR2ImageStorageService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/CloudflareR2ImageStorageService.java
@@ -1,4 +1,4 @@
-package ch.ruppen.danceschool.image;
+package ch.ruppen.danceschool.shared.storage;
 
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/FilesystemImageStorageService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/FilesystemImageStorageService.java
@@ -1,4 +1,4 @@
-package ch.ruppen.danceschool.image;
+package ch.ruppen.danceschool.shared.storage;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageConfig.java
@@ -1,4 +1,4 @@
-package ch.ruppen.danceschool.image;
+package ch.ruppen.danceschool.shared.storage;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -8,10 +8,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableConfigurationProperties(ImageStorageProperties.class)
-class ImageStorageConfig {
+public class ImageStorageConfig {
 
     @Bean
-    ImageStorageService imageStorageService(ImageStorageProperties props) {
+    public ImageStorageService imageStorageService(ImageStorageProperties props) {
         String provider = props.provider() != null ? props.provider() : "filesystem";
         return switch (provider) {
             case "r2" -> new CloudflareR2ImageStorageService(

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageProperties.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageProperties.java
@@ -1,4 +1,4 @@
-package ch.ruppen.danceschool.image;
+package ch.ruppen.danceschool.shared.storage;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageService.java
@@ -1,4 +1,4 @@
-package ch.ruppen.danceschool.image;
+package ch.ruppen.danceschool.shared.storage;
 
 /**
  * Abstraction for storing and deleting uploaded images.
@@ -21,4 +21,19 @@ public interface ImageStorageService {
      * @param key storage key (filename or object key) identifying the image
      */
     void delete(String key);
+
+    /**
+     * Extract the storage key from a public URL.
+     * Both storage implementations use a UUID-based filename as the last path segment.
+     *
+     * @param url public URL of the stored image
+     * @return storage key, or null if the URL is null/empty
+     */
+    static String extractKey(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        int lastSlash = url.lastIndexOf('/');
+        return lastSlash >= 0 ? url.substring(lastSlash + 1) : url;
+    }
 }

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolImageDeletionIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolImageDeletionIntegrationTest.java
@@ -1,0 +1,240 @@
+package ch.ruppen.danceschool.school;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.storage.ImageStorageService;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class SchoolImageDeletionIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private ImageStorageService imageStorageService;
+
+    private AppUser testUser;
+    private School school;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new AppUser();
+        testUser.setEmail("test@example.com");
+        testUser.setName("Test User");
+        testUser.setFirebaseUid("test-firebase-uid");
+        entityManager.persist(testUser);
+
+        school = new School();
+        school.setName("Test School");
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(testUser);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+        entityManager.flush();
+    }
+
+    @Test
+    void updateMe_deletesOldCoverImage_whenReplaced() throws Exception {
+        String oldCoverUrl = imageStorageService.store("old-cover".getBytes(), "cover.jpg");
+        school.setCoverImageUrl(oldCoverUrl);
+        entityManager.merge(school);
+        entityManager.flush();
+
+        Path oldFile = resolveStoredFile(oldCoverUrl);
+        assertThat(oldFile).exists();
+
+        String newCoverUrl = imageStorageService.store("new-cover".getBytes(), "cover2.jpg");
+
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Test School",
+                                  "coverImageUrl": "%s"
+                                }
+                                """.formatted(newCoverUrl)))
+                .andExpect(status().isOk());
+
+        assertThat(oldFile).doesNotExist();
+    }
+
+    @Test
+    void updateMe_deletesOldCoverImage_whenCleared() throws Exception {
+        String oldCoverUrl = imageStorageService.store("cover-data".getBytes(), "cover.jpg");
+        school.setCoverImageUrl(oldCoverUrl);
+        entityManager.merge(school);
+        entityManager.flush();
+
+        Path oldFile = resolveStoredFile(oldCoverUrl);
+        assertThat(oldFile).exists();
+
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Test School",
+                                  "coverImageUrl": null
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        assertThat(oldFile).doesNotExist();
+    }
+
+    @Test
+    void updateMe_deletesOldLogo_whenReplaced() throws Exception {
+        String oldLogoUrl = imageStorageService.store("old-logo".getBytes(), "logo.png");
+        school.setLogoUrl(oldLogoUrl);
+        entityManager.merge(school);
+        entityManager.flush();
+
+        Path oldFile = resolveStoredFile(oldLogoUrl);
+        assertThat(oldFile).exists();
+
+        String newLogoUrl = imageStorageService.store("new-logo".getBytes(), "logo2.png");
+
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Test School",
+                                  "logoUrl": "%s"
+                                }
+                                """.formatted(newLogoUrl)))
+                .andExpect(status().isOk());
+
+        assertThat(oldFile).doesNotExist();
+    }
+
+    @Test
+    void updateMe_deletesRemovedGalleryImages() throws Exception {
+        String galleryUrl1 = imageStorageService.store("gallery1".getBytes(), "g1.jpg");
+        String galleryUrl2 = imageStorageService.store("gallery2".getBytes(), "g2.jpg");
+
+        SchoolGalleryImage img1 = new SchoolGalleryImage();
+        img1.setSchool(school);
+        img1.setUrl(galleryUrl1);
+        img1.setPosition(0);
+        school.getGalleryImages().add(img1);
+
+        SchoolGalleryImage img2 = new SchoolGalleryImage();
+        img2.setSchool(school);
+        img2.setUrl(galleryUrl2);
+        img2.setPosition(1);
+        school.getGalleryImages().add(img2);
+        entityManager.merge(school);
+        entityManager.flush();
+
+        Path file1 = resolveStoredFile(galleryUrl1);
+        Path file2 = resolveStoredFile(galleryUrl2);
+        assertThat(file1).exists();
+        assertThat(file2).exists();
+
+        // Keep only the second image
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Test School",
+                                  "galleryImages": [
+                                    { "url": "%s", "position": 0 }
+                                  ]
+                                }
+                                """.formatted(galleryUrl2)))
+                .andExpect(status().isOk());
+
+        assertThat(file1).doesNotExist();
+        assertThat(file2).exists();
+    }
+
+    @Test
+    void updateMe_succeeds_whenImageDeletionFails() throws Exception {
+        // Set a cover URL that doesn't correspond to a real file —
+        // deletion will fail but the update should still succeed
+        school.setCoverImageUrl("http://localhost:8080/uploads/nonexistent-file.jpg");
+        entityManager.merge(school);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Test School",
+                                  "coverImageUrl": "http://localhost:8080/uploads/new-cover.jpg"
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void updateMe_doesNotDeleteImage_whenUrlUnchanged() throws Exception {
+        String coverUrl = imageStorageService.store("cover-data".getBytes(), "cover.jpg");
+        school.setCoverImageUrl(coverUrl);
+        entityManager.merge(school);
+        entityManager.flush();
+
+        Path file = resolveStoredFile(coverUrl);
+        assertThat(file).exists();
+
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "name": "Updated Name",
+                                  "coverImageUrl": "%s"
+                                }
+                                """.formatted(coverUrl)))
+                .andExpect(status().isOk());
+
+        assertThat(file).exists();
+    }
+
+    private Path resolveStoredFile(String url) {
+        String key = ImageStorageService.extractKey(url);
+        String storageDir = System.getProperty("java.io.tmpdir") + "/danceschool-uploads";
+        return Path.of(storageDir, key);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/shared/storage/ImageStorageServiceTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/shared/storage/ImageStorageServiceTest.java
@@ -1,0 +1,35 @@
+package ch.ruppen.danceschool.shared.storage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImageStorageServiceTest {
+
+    @Test
+    void extractKey_returnsFilename_fromFullUrl() {
+        String url = "http://localhost:8080/uploads/550e8400-e29b-41d4-a716-446655440000.jpg";
+        assertThat(ImageStorageService.extractKey(url)).isEqualTo("550e8400-e29b-41d4-a716-446655440000.jpg");
+    }
+
+    @Test
+    void extractKey_returnsFilename_fromR2Url() {
+        String url = "https://pub-abc123.r2.dev/550e8400-e29b-41d4-a716-446655440000.png";
+        assertThat(ImageStorageService.extractKey(url)).isEqualTo("550e8400-e29b-41d4-a716-446655440000.png");
+    }
+
+    @Test
+    void extractKey_returnsNull_whenUrlIsNull() {
+        assertThat(ImageStorageService.extractKey(null)).isNull();
+    }
+
+    @Test
+    void extractKey_returnsNull_whenUrlIsBlank() {
+        assertThat(ImageStorageService.extractKey("  ")).isNull();
+    }
+
+    @Test
+    void extractKey_returnsInput_whenNoSlash() {
+        assertThat(ImageStorageService.extractKey("some-key.jpg")).isEqualTo("some-key.jpg");
+    }
+}


### PR DESCRIPTION
## Summary

- Move image storage infrastructure (`ImageStorageService`, both implementations, config, properties) from `image/` to `shared/storage/` — follows existing shared infrastructure convention
- Add `ImageStorageService.extractKey()` static utility to extract UUID storage key from public URLs
- Add deletion logic in `SchoolService.updateSchool()` that detects changed/removed cover image, logo, and gallery images and deletes old files from storage
- Deletion failures are logged but do not block the school update (orphaned files preferred over failed saves)
- 6 integration tests for image deletion scenarios + 5 unit tests for key extraction

Closes #80

## Test plan

- [x] Replace cover image → old file deleted from storage
- [x] Clear cover image → old file deleted
- [x] Replace logo → old file deleted
- [x] Remove gallery images → removed files deleted, kept files preserved
- [x] Deletion failure (nonexistent file) → update still succeeds
- [x] Unchanged image URL → file not deleted
- [x] All 37 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)