### PR TITLE
Fix sidebar visual issues and footer button alignment (#91, #92)

### DIFF
--- a/frontend/src/app/my-school/edit/my-school-edit.scss
+++ b/frontend/src/app/my-school/edit/my-school-edit.scss
@@ -49,7 +49,7 @@
   position: sticky;
   bottom: 0;
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
   gap: var(--ds-spacing-3);
   padding: var(--ds-spacing-4) var(--ds-card-padding);
   margin: 0 calc(var(--ds-card-padding) * -1) calc(var(--ds-card-padding) * -1);

--- a/frontend/src/app/shell/shell.scss
+++ b/frontend/src/app/shell/shell.scss
@@ -67,11 +67,23 @@
   height: var(--ds-spacing-8);
   border-radius: 50%;
   background: var(--mat-sys-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 }
 
-.avatar-letter { font: var(--mat-sys-label-large); color: var(--mat-sys-on-primary); }
+.avatar-letter {
+  font: var(--mat-sys-label-large);
+  color: var(--mat-sys-on-primary);
+  line-height: 1;
+}
 
 // Content
+.shell-content {
+  background: var(--mat-sys-surface-variant);
+}
+
 .shell-page {
   background: var(--mat-sys-surface-variant);
   min-height: calc(100vh - var(--ds-spacing-16));


### PR DESCRIPTION
## Summary
- **#91 — Sidebar visual separation:** Add `surface-variant` background to `shell-content` so the content area contrasts with the white sidebar
- **#91 — Avatar letter centering:** Add flexbox centering + `overflow: hidden` to `.toolbar-avatar` and `line-height: 1` to `.avatar-letter` so the initial is properly centered in the circle
- **#92 — Footer buttons centered:** Change `justify-content: flex-end` to `center` in `.footer-actions` sticky bar

## Test plan
- [x] Sidebar now has visible separation from content area
- [x] Avatar letter "D" is centered in the purple circle
- [x] Cancel / Save Changes buttons are centered in the sticky footer on My School edit page
- [x] Verified visually with Playwright screenshots

Closes #91, closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)