### PR TITLE
Always redirect to dashboard on login and center empty state

### DIFF
--- a/frontend/src/app/auth/login/login.ts
+++ b/frontend/src/app/auth/login/login.ts
@@ -37,11 +37,7 @@ export class LoginComponent {
     effect(() => {
       if (this.auth.isLoggedIn()) {
         const user = this.auth.user();
-        if (user && user.memberships.length === 0) {
-          this.router.navigate(['/my-school/edit']);
-        } else {
-          this.router.navigate(['/dashboard']);
-        }
+        this.router.navigate(['/dashboard']);
       }
     });
   }

--- a/frontend/src/app/dashboard/dashboard.scss
+++ b/frontend/src/app/dashboard/dashboard.scss
@@ -20,6 +20,7 @@
   justify-content: center;
   text-align: center;
   padding: var(--ds-spacing-12) var(--ds-spacing-6);
+  min-height: 60vh;
 }
 
 .empty-state-icon {


### PR DESCRIPTION
## Summary

- Remove special redirect to `/my-school/edit` for users without a school — all users land on `/dashboard` after login
- Fix dashboard empty state vertical centering to match Students and My School pages (`min-height: 60vh`)

## Test plan

- [ ] CI passes
- [x] Frontend builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)