### PR TITLE
Harden backend config and error handling (#102)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
@@ -1,11 +1,10 @@
 package ch.ruppen.danceschool.image;
 
+import ch.ruppen.danceschool.shared.error.ImageUploadException;
 import ch.ruppen.danceschool.shared.storage.ImageStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ProblemDetail;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,7 +31,7 @@ class ImageController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
-    ImageUploadResponse upload(@RequestParam("file") MultipartFile file) throws IOException {
+    ImageUploadResponse upload(@RequestParam("file") MultipartFile file) {
         if (file.isEmpty()) {
             throw new ImageUploadException("File is empty");
         }
@@ -44,20 +43,11 @@ class ImageController {
             throw new ImageUploadException("Only JPEG, PNG, and WebP images are accepted");
         }
 
-        String url = imageStorageService.store(file.getBytes(), file.getOriginalFilename());
-        return new ImageUploadResponse(url);
-    }
-
-    @ExceptionHandler(ImageUploadException.class)
-    ProblemDetail handleImageUpload(ImageUploadException ex) {
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
-        problem.setTitle("Invalid Image Upload");
-        return problem;
-    }
-
-    static class ImageUploadException extends RuntimeException {
-        ImageUploadException(String message) {
-            super(message);
+        try {
+            String url = imageStorageService.store(file.getBytes(), file.getOriginalFilename());
+            return new ImageUploadResponse(url);
+        } catch (IOException e) {
+            throw new ImageUploadException("Failed to read uploaded file", e);
         }
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/error/GlobalExceptionHandler.java
@@ -26,6 +26,13 @@ class GlobalExceptionHandler {
         return problem;
     }
 
+    @ExceptionHandler(ImageUploadException.class)
+    ProblemDetail handleImageUpload(ImageUploadException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setTitle("Invalid Image Upload");
+        return problem;
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/error/ImageUploadException.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/error/ImageUploadException.java
@@ -1,0 +1,12 @@
+package ch.ruppen.danceschool.shared.error;
+
+public class ImageUploadException extends RuntimeException {
+
+    public ImageUploadException(String message) {
+        super(message);
+    }
+
+    public ImageUploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/CloudflareR2ImageStorageService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/CloudflareR2ImageStorageService.java
@@ -1,6 +1,11 @@
 package ch.ruppen.danceschool.shared.storage;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -13,24 +18,42 @@ import java.net.URI;
 import java.util.UUID;
 
 @Slf4j
+@Service
+@Profile("prod")
+@RequiredArgsConstructor
 class CloudflareR2ImageStorageService implements ImageStorageService {
 
-    private final S3Client s3Client;
-    private final String bucket;
-    private final String publicUrl;
+    private final ImageStorageProperties props;
+    private S3Client s3Client;
+    private String bucket;
+    private String publicUrl;
 
-    CloudflareR2ImageStorageService(String endpoint, String accessKey, String secretKey,
-                                    String bucket, String publicUrl) {
-        this.bucket = bucket;
-        this.publicUrl = publicUrl.endsWith("/") ? publicUrl.substring(0, publicUrl.length() - 1) : publicUrl;
+    @PostConstruct
+    void init() {
+        requireNonBlank(props.r2Endpoint(), "app.image-storage.r2-endpoint");
+        requireNonBlank(props.r2AccessKey(), "app.image-storage.r2-access-key");
+        requireNonBlank(props.r2SecretKey(), "app.image-storage.r2-secret-key");
+        requireNonBlank(props.r2Bucket(), "app.image-storage.r2-bucket");
+        requireNonBlank(props.r2PublicUrl(), "app.image-storage.r2-public-url");
+
+        this.bucket = props.r2Bucket();
+        this.publicUrl = stripTrailingSlash(props.r2PublicUrl());
         this.s3Client = S3Client.builder()
-                .endpointOverride(URI.create(endpoint))
+                .endpointOverride(URI.create(props.r2Endpoint()))
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
+                        AwsBasicCredentials.create(props.r2AccessKey(), props.r2SecretKey())))
                 .region(Region.of("auto"))
                 .forcePathStyle(true)
                 .build();
         log.info("Cloudflare R2 image storage initialized for bucket {}", bucket);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        if (s3Client != null) {
+            s3Client.close();
+            log.info("Cloudflare R2 S3Client closed");
+        }
     }
 
     @Override
@@ -70,5 +93,17 @@ class CloudflareR2ImageStorageService implements ImageStorageService {
             case ".webp" -> "image/webp";
             default -> "application/octet-stream";
         };
+    }
+
+    private static void requireNonBlank(String value, String propertyName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(
+                    "Required property '%s' is not set. All R2 properties must be configured for the prod profile."
+                            .formatted(propertyName));
+        }
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/FilesystemImageStorageService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/FilesystemImageStorageService.java
@@ -1,6 +1,10 @@
 package ch.ruppen.danceschool.shared.storage;
 
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -9,14 +13,22 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 @Slf4j
+@Service
+@Profile("!prod")
+@RequiredArgsConstructor
 class FilesystemImageStorageService implements ImageStorageService {
 
-    private final Path storageDir;
-    private final String baseUrl;
+    private final ImageStorageProperties props;
+    private Path storageDir;
+    private String baseUrl;
 
-    FilesystemImageStorageService(String directory, String baseUrl) {
+    @PostConstruct
+    void init() {
+        String directory = props.directory() != null ? props.directory()
+                : System.getProperty("java.io.tmpdir") + "/danceschool-uploads";
         this.storageDir = Path.of(directory);
-        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        this.baseUrl = stripTrailingSlash(
+                props.baseUrl() != null ? props.baseUrl() : "http://localhost:8080/uploads");
         try {
             Files.createDirectories(storageDir);
         } catch (IOException e) {
@@ -59,5 +71,9 @@ class FilesystemImageStorageService implements ImageStorageService {
     private String extractExtension(String filename) {
         int dot = filename.lastIndexOf('.');
         return dot >= 0 ? filename.substring(dot) : "";
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageConfig.java
@@ -3,41 +3,25 @@ package ch.ruppen.danceschool.shared.storage;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableConfigurationProperties(ImageStorageProperties.class)
-public class ImageStorageConfig {
+class ImageStorageConfig {
 
     @Bean
-    public ImageStorageService imageStorageService(ImageStorageProperties props) {
-        String provider = props.provider() != null ? props.provider() : "filesystem";
-        return switch (provider) {
-            case "r2" -> new CloudflareR2ImageStorageService(
-                    props.r2Endpoint(),
-                    props.r2AccessKey(),
-                    props.r2SecretKey(),
-                    props.r2Bucket(),
-                    props.r2PublicUrl());
-            default -> new FilesystemImageStorageService(
-                    props.directory() != null ? props.directory() : System.getProperty("java.io.tmpdir") + "/danceschool-uploads",
-                    props.baseUrl() != null ? props.baseUrl() : "http://localhost:8080/uploads");
-        };
-    }
-
-    @Bean
+    @Profile("!prod")
     WebMvcConfigurer imageResourceConfigurer(ImageStorageProperties props) {
-        String provider = props.provider() != null ? props.provider() : "filesystem";
-        String directory = props.directory() != null ? props.directory() : System.getProperty("java.io.tmpdir") + "/danceschool-uploads";
+        String directory = props.directory() != null ? props.directory()
+                : System.getProperty("java.io.tmpdir") + "/danceschool-uploads";
 
         return new WebMvcConfigurer() {
             @Override
             public void addResourceHandlers(ResourceHandlerRegistry registry) {
-                if ("filesystem".equals(provider)) {
-                    registry.addResourceHandler("/uploads/**")
-                            .addResourceLocations("file:" + directory + "/");
-                }
+                registry.addResourceHandler("/uploads/**")
+                        .addResourceLocations("file:" + directory + "/");
             }
         };
     }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageProperties.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/storage/ImageStorageProperties.java
@@ -4,9 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.image-storage")
 public record ImageStorageProperties(
-        /** "filesystem" or "r2" */
-        String provider,
-
         /** Filesystem provider: directory to store images */
         String directory,
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -12,9 +12,10 @@ app:
   firebase:
     project-id: ${FIREBASE_PROJECT_ID:dance-school-ch}
   image-storage:
-    provider: ${IMAGE_STORAGE_PROVIDER:filesystem}
+    # Filesystem (dev) — used when prod profile is not active
     directory: ${IMAGE_STORAGE_DIRECTORY:${java.io.tmpdir}/danceschool-uploads}
     base-url: ${IMAGE_STORAGE_BASE_URL:http://localhost:8080/uploads}
+    # Cloudflare R2 (prod) — required when prod profile is active
     r2-endpoint: ${R2_ENDPOINT:}
     r2-access-key: ${R2_ACCESS_KEY:}
     r2-secret-key: ${R2_SECRET_KEY:}


### PR DESCRIPTION
## Summary
- Replace string-based `provider` selection with `@Profile("prod")` / `@Profile("!prod")` conditional beans for image storage
- Use `@RequiredArgsConstructor` + `@PostConstruct` for proper Spring DI lifecycle in both storage implementations
- Validate R2 properties at startup with clear error messages (fail-fast instead of runtime NPE)
- Close S3Client on shutdown via `@PreDestroy` to fix resource leak
- Move `ImageUploadException` to `shared/error/` and handle in `GlobalExceptionHandler` for consistency
- Wrap `IOException` in `ImageController` as `ImageUploadException` (no more raw 500s)

Closes #102

## Test plan
- [x] All existing backend tests pass (`./mvnw test`)
- [ ] Verify dev startup still uses filesystem storage (no `prod` profile)
- [ ] Verify prod deployment uses R2 (with `prod` profile and R2 env vars)
- [ ] Verify missing R2 properties cause a clear startup failure in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)