### PR TITLE
Move authenticated routes under /app prefix (#83)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,15 +1,17 @@
 import { Routes } from '@angular/router';
 import { authGuard } from './shared/auth/auth.guard';
+import { publicGuard } from './shared/auth/public.guard';
 import { unsavedChangesGuard } from './my-school/edit/unsaved-changes.guard';
 
 export const routes: Routes = [
+  { path: '', canActivate: [publicGuard], children: [] },
   { path: 'login', loadComponent: () => import('./auth/login/login').then(m => m.LoginComponent) },
   {
-    path: '',
+    path: 'app',
     loadComponent: () => import('./shell/shell').then(m => m.ShellComponent),
     canActivate: [authGuard],
     children: [
-{ path: 'dashboard', loadComponent: () => import('./dashboard/dashboard').then(m => m.DashboardComponent) },
+      { path: 'dashboard', loadComponent: () => import('./dashboard/dashboard').then(m => m.DashboardComponent) },
       { path: 'students', loadComponent: () => import('./students/students').then(m => m.StudentsComponent) },
       {
         path: 'my-school/edit',
@@ -20,5 +22,5 @@ export const routes: Routes = [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
     ],
   },
-  { path: '**', redirectTo: 'login' },
+  { path: '**', redirectTo: '' },
 ];

--- a/frontend/src/app/auth/login/login.ts
+++ b/frontend/src/app/auth/login/login.ts
@@ -37,7 +37,7 @@ export class LoginComponent {
     effect(() => {
       if (this.auth.isLoggedIn()) {
         const user = this.auth.user();
-        this.router.navigate(['/dashboard']);
+        this.router.navigate(['/app/dashboard']);
       }
     });
   }

--- a/frontend/src/app/dashboard/dashboard.html
+++ b/frontend/src/app/dashboard/dashboard.html
@@ -11,7 +11,7 @@
       <mat-icon class="empty-state-icon">business</mat-icon>
       <h2 class="empty-state-title">Set up your school to get started</h2>
       <p class="empty-state-text">Create your dance school profile to begin managing students, classes, and more.</p>
-      <a mat-flat-button routerLink="/my-school/edit">Create School</a>
+      <a mat-flat-button routerLink="/app/my-school/edit">Create School</a>
     </div>
   }
 </div>

--- a/frontend/src/app/my-school/edit/my-school-edit.ts
+++ b/frontend/src/app/my-school/edit/my-school-edit.ts
@@ -115,7 +115,7 @@ export class MySchoolEditComponent implements OnInit {
         if (this.creationMode()) {
           this.auth.checkAuth();
         }
-        this.router.navigate(['/my-school']);
+        this.router.navigate(['/app/my-school']);
       },
       error: (err) => {
         this.saving.set(false);
@@ -129,7 +129,7 @@ export class MySchoolEditComponent implements OnInit {
   }
 
   protected cancel(): void {
-    this.router.navigate(['/my-school']);
+    this.router.navigate(['/app/my-school']);
   }
 
   protected removeSpecialty(index: number): void {

--- a/frontend/src/app/my-school/my-school.html
+++ b/frontend/src/app/my-school/my-school.html
@@ -5,7 +5,7 @@
       <h1 class="page-title">My School</h1>
       <p class="page-subtitle">Manage your dance school information and settings</p>
     </div>
-    <button mat-stroked-button routerLink="/my-school/edit">Edit</button>
+    <button mat-stroked-button routerLink="/app/my-school/edit">Edit</button>
   </div>
 
   <!-- Hero Card -->
@@ -168,7 +168,7 @@
     <mat-icon class="empty-state-icon">business</mat-icon>
     <h2 class="empty-state-title">Set up your school to get started</h2>
     <p class="empty-state-text">Create your dance school profile to begin managing students, classes, and more.</p>
-    <a mat-flat-button routerLink="/my-school/edit">Create School</a>
+    <a mat-flat-button routerLink="/app/my-school/edit">Create School</a>
   </div>
 } @else if (error()) {
   <p class="error-text">Could not load school information. Please try again later.</p>

--- a/frontend/src/app/shared/auth/public.guard.ts
+++ b/frontend/src/app/shared/auth/public.guard.ts
@@ -1,0 +1,21 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { filter, map, take } from 'rxjs';
+import { AuthService } from './auth.service';
+
+/** Redirects logged-in users to /app/dashboard; lets unauthenticated users through. */
+export const publicGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  if (auth.isChecked()) {
+    return auth.isLoggedIn() ? router.createUrlTree(['/app/dashboard']) : true;
+  }
+
+  return toObservable(auth.isChecked).pipe(
+    filter((checked) => checked),
+    take(1),
+    map(() => auth.isLoggedIn() ? router.createUrlTree(['/app/dashboard']) : true),
+  );
+};

--- a/frontend/src/app/shell/shell.ts
+++ b/frontend/src/app/shell/shell.ts
@@ -40,9 +40,9 @@ export class ShellComponent {
   protected isDesktop = signal(true);
 
   protected navItems: NavItem[] = [
-    { label: 'Dashboard', icon: 'dashboard', route: '/dashboard' },
-    { label: 'Students', icon: 'people', route: '/students' },
-    { label: 'My School', icon: 'business', route: '/my-school' },
+    { label: 'Dashboard', icon: 'dashboard', route: '/app/dashboard' },
+    { label: 'Students', icon: 'people', route: '/app/students' },
+    { label: 'My School', icon: 'business', route: '/app/my-school' },
   ];
 
   constructor() {

--- a/frontend/src/app/students/students.ts
+++ b/frontend/src/app/students/students.ts
@@ -18,7 +18,7 @@ import { AuthService } from '../shared/auth/auth.service';
         <mat-icon class="empty-state-icon">business</mat-icon>
         <h2 class="empty-state-title">Set up your school to get started</h2>
         <p class="empty-state-text">Create your dance school profile to begin managing students.</p>
-        <a mat-flat-button routerLink="/my-school/edit">Create School</a>
+        <a mat-flat-button routerLink="/app/my-school/edit">Create School</a>
       </div>
     }
   `,


### PR DESCRIPTION
## Summary
- All authenticated routes now live under `/app/*` (`/app/dashboard`, `/app/students`, `/app/my-school`, `/app/my-school/edit`)
- New `publicGuard` redirects logged-in users from `/` to `/app/dashboard`
- Catch-all `**` redirects to `/` instead of `/login`
- Updated all internal navigation links (shell sidebar, login redirect, edit page, empty states)

Closes #83

## Test plan
- [x] Frontend builds successfully
- [x] Existing tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)