### PR TITLE
Fix Angular best practice violations across frontend

### DIFF
--- a/frontend/src/app/auth/login/login.html
+++ b/frontend/src/app/auth/login/login.html
@@ -11,11 +11,11 @@
         } @else if (isDevLogin) {
           <mat-form-field appearance="outline" class="full-width">
             <mat-label>Email</mat-label>
-            <input matInput [(ngModel)]="email" type="email" />
+            <input matInput [formControl]="loginForm.controls.email" type="email" />
           </mat-form-field>
           <mat-form-field appearance="outline" class="full-width">
             <mat-label>Password</mat-label>
-            <input matInput [(ngModel)]="password" type="password" (keyup.enter)="devLogin()" />
+            <input matInput [formControl]="loginForm.controls.password" type="password" (keyup.enter)="devLogin()" />
           </mat-form-field>
           <button mat-flat-button class="full-width" (click)="devLogin()">Sign in</button>
           <div class="quick-login">

--- a/frontend/src/app/auth/login/login.ts
+++ b/frontend/src/app/auth/login/login.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { FormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormControl, FormGroup } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -13,7 +13,7 @@ import { AuthService } from '../../shared/auth/auth.service';
 @Component({
   selector: 'app-login',
   imports: [
-    FormsModule,
+    ReactiveFormsModule,
     MatButtonModule,
     MatCardModule,
     MatFormFieldModule,
@@ -30,25 +30,26 @@ export class LoginComponent {
   private router = inject(Router);
 
   protected isDevLogin = environment.useDevLogin;
-  protected email = 'owner@test.com';
-  protected password = 'password';
+  protected loginForm = new FormGroup({
+    email: new FormControl('owner@test.com', { nonNullable: true }),
+    password: new FormControl('password', { nonNullable: true }),
+  });
 
   constructor() {
     effect(() => {
       if (this.auth.isLoggedIn()) {
-        const user = this.auth.user();
         this.router.navigate(['/app/dashboard']);
       }
     });
   }
 
   devLogin(): void {
-    this.auth.devLogin(this.email, this.password);
+    const { email, password } = this.loginForm.getRawValue();
+    this.auth.devLogin(email, password);
   }
 
   quickLogin(email: string): void {
-    this.email = email;
-    this.password = 'password';
+    this.loginForm.setValue({ email, password: 'password' });
     this.auth.devLogin(email, 'password');
   }
 

--- a/frontend/src/app/my-school/edit/my-school-edit.html
+++ b/frontend/src/app/my-school/edit/my-school-edit.html
@@ -151,7 +151,7 @@
     <div class="gallery-grid">
       @for (image of galleryImages(); track image.url) {
         <div class="gallery-item">
-          <img [src]="image.url" alt="Gallery image" />
+          <img [ngSrc]="image.url" alt="Gallery image" fill />
           <button class="gallery-remove" (click)="removeGalleryImage($index)">
             <mat-icon>close</mat-icon>
           </button>

--- a/frontend/src/app/my-school/edit/my-school-edit.scss
+++ b/frontend/src/app/my-school/edit/my-school-edit.scss
@@ -303,12 +303,6 @@
   aspect-ratio: 4 / 3;
   border-radius: var(--ds-radius-md);
   overflow: hidden;
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
 }
 
 .gallery-remove {

--- a/frontend/src/app/my-school/edit/my-school-edit.ts
+++ b/frontend/src/app/my-school/edit/my-school-edit.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, HostListener, inject, signal, OnInit, WritableSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -8,14 +8,18 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { NgOptimizedImage } from '@angular/common';
 import { GalleryImage, SchoolDetail, SchoolService, SchoolUpdateRequest } from '../school.service';
 import { AuthService } from '../../shared/auth/auth.service';
 
 @Component({
   selector: 'app-my-school-edit',
-  standalone: true,
+  host: {
+    '(window:beforeunload)': 'onBeforeUnload($event)',
+  },
   imports: [
     ReactiveFormsModule,
+    NgOptimizedImage,
     MatButtonModule,
     MatFormFieldModule,
     MatIconModule,
@@ -220,7 +224,6 @@ export class MySchoolEditComponent implements OnInit {
     }
   }
 
-  @HostListener('window:beforeunload', ['$event'])
   onBeforeUnload(event: BeforeUnloadEvent): void {
     if (this.isDirty()) {
       event.preventDefault();

--- a/frontend/src/app/my-school/my-school.html
+++ b/frontend/src/app/my-school/my-school.html
@@ -139,7 +139,7 @@
       <div class="image-grid">
         @for (image of school.galleryImages; track image.url) {
           <div class="image-cell">
-            <img [src]="image.url" alt="Gallery image" />
+            <img [ngSrc]="image.url" alt="Gallery image" fill />
           </div>
         }
       </div>

--- a/frontend/src/app/my-school/my-school.scss
+++ b/frontend/src/app/my-school/my-school.scss
@@ -218,15 +218,10 @@
 }
 
 .image-cell {
+  position: relative;
   border-radius: var(--ds-radius-md);
   overflow: hidden;
   aspect-ratio: 16 / 10;
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
 }
 
 // YouTube Videos

--- a/frontend/src/app/my-school/my-school.ts
+++ b/frontend/src/app/my-school/my-school.ts
@@ -1,4 +1,6 @@
-import { ChangeDetectionStrategy, Component, inject, signal, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NgOptimizedImage } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -6,20 +8,21 @@ import { SchoolDetail, SchoolService } from './school.service';
 
 @Component({
   selector: 'app-my-school',
-  imports: [RouterLink, MatButtonModule, MatIconModule],
+  imports: [NgOptimizedImage, RouterLink, MatButtonModule, MatIconModule],
   templateUrl: './my-school.html',
   styleUrl: './my-school.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MySchoolComponent implements OnInit {
   private schoolService = inject(SchoolService);
+  private destroyRef = inject(DestroyRef);
 
   protected school = signal<SchoolDetail | null>(null);
   protected error = signal(false);
   protected noSchool = signal(false);
 
   ngOnInit(): void {
-    this.schoolService.getMySchool().subscribe({
+    this.schoolService.getMySchool().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (school) => this.school.set(school),
       error: (err) => {
         if (err.status === 404) {

--- a/frontend/src/app/shell/shell.ts
+++ b/frontend/src/app/shell/shell.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
@@ -35,6 +36,7 @@ export class ShellComponent {
   protected user = this.auth.user;
 
   private breakpointObserver = inject(BreakpointObserver);
+  private destroyRef = inject(DestroyRef);
   private sidenav = viewChild<MatSidenav>('sidenav');
 
   protected isDesktop = signal(true);
@@ -46,7 +48,9 @@ export class ShellComponent {
   ];
 
   constructor() {
-    this.breakpointObserver.observe('(min-width: 960px)').subscribe(result => {
+    this.breakpointObserver.observe('(min-width: 960px)').pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(result => {
       this.isDesktop.set(result.matches);
     });
   }


### PR DESCRIPTION
## Summary
- Remove `standalone: true` from `@Component` (default in Angular 21+)
- Replace `@HostListener` with `host` object in decorator (my-school-edit)
- Convert login from template-driven to reactive forms
- Add `NgOptimizedImage` with `fill` for gallery images (view + edit pages)
- Add `takeUntilDestroyed` subscription cleanup (my-school, shell)
- Remove unused variable in login effect

## Test plan
- [x] `ng build` compiles cleanly
- [x] `ng test` — all tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)