### PR TITLE
Add landing page: header, hero section, and footer (#84)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,7 +4,12 @@ import { publicGuard } from './shared/auth/public.guard';
 import { unsavedChangesGuard } from './my-school/edit/unsaved-changes.guard';
 
 export const routes: Routes = [
-  { path: '', canActivate: [publicGuard], children: [] },
+  {
+    path: '',
+    pathMatch: 'full',
+    canActivate: [publicGuard],
+    loadComponent: () => import('./landing/landing').then(m => m.LandingComponent),
+  },
   { path: 'login', loadComponent: () => import('./auth/login/login').then(m => m.LoginComponent) },
   {
     path: 'app',

--- a/frontend/src/app/landing/landing.html
+++ b/frontend/src/app/landing/landing.html
@@ -1,0 +1,36 @@
+<div class="landing-page" #pageTop>
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-overlay"></div>
+    <div class="hero-glow"></div>
+
+    <app-public-header
+      (logoClick)="scrollToTop()"
+      (featuresClick)="scrollToFeatures()"
+    />
+
+    <div class="hero-content">
+      <div class="hero-text">
+        <h1 class="hero-heading">
+          Simplify your studio.<br />
+          Amplify your passion.
+        </h1>
+        <p class="hero-subheading">
+          Because you started for the dance. — The no.1 app for managing your dance school
+        </p>
+      </div>
+      <div class="hero-cta">
+        <a class="btn-primary" routerLink="/login">Try for Free</a>
+        <a class="btn-outlined" routerLink="/login">Already have an account?</a>
+      </div>
+    </div>
+
+    <div class="hero-image-placeholder"></div>
+  </section>
+
+  <!-- Features placeholder (implemented in #85) -->
+  <section id="features"></section>
+
+  <!-- Footer -->
+  <app-public-footer />
+</div>

--- a/frontend/src/app/landing/landing.scss
+++ b/frontend/src/app/landing/landing.scss
@@ -1,0 +1,178 @@
+@use "styles/mixins" as ds;
+
+:host {
+  display: block;
+}
+
+.landing-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--ds-landing-bg-end);
+}
+
+// ── Hero Section ──
+
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  height: 900px;
+  overflow: hidden;
+  background: linear-gradient(
+    32deg,
+    var(--ds-landing-bg-start) 14%,
+    var(--ds-landing-bg-mid) 57%,
+    var(--ds-landing-bg-end) 86%
+  );
+
+  @include ds.bp-down(md) {
+    height: auto;
+    min-height: 600px;
+  }
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.2)
+  );
+  pointer-events: none;
+}
+
+.hero-glow {
+  position: absolute;
+  width: 800px;
+  height: 500px;
+  left: 50%;
+  top: calc(50% + 100px);
+  transform: translate(-50%, -50%);
+  background: radial-gradient(
+    ellipse at center,
+    var(--ds-landing-glow) 0%,
+    transparent 100%
+  );
+  pointer-events: none;
+
+  @include ds.bp-down(md) {
+    width: 400px;
+    height: 300px;
+  }
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ds-spacing-6);
+  flex: 1;
+  padding: 0 var(--ds-spacing-20) var(--ds-spacing-20);
+
+  @include ds.bp-down(md) {
+    padding: var(--ds-spacing-12) var(--ds-spacing-6);
+  }
+}
+
+.hero-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ds-spacing-4);
+  text-align: center;
+}
+
+.hero-heading {
+  margin: 0;
+  font-size: var(--mat-sys-display-large-size);
+  line-height: var(--mat-sys-display-large-line-height);
+  font-weight: 700;
+  color: white;
+
+  @include ds.bp-down(md) {
+    font-size: var(--mat-sys-display-small-size);
+    line-height: var(--mat-sys-display-small-line-height);
+  }
+}
+
+.hero-subheading {
+  margin: 0;
+  font-size: var(--mat-sys-body-large-size);
+  line-height: var(--mat-sys-body-large-line-height);
+  color: var(--ds-landing-text-muted);
+
+  @include ds.bp-down(md) {
+    font-size: var(--mat-sys-body-medium-size);
+  }
+}
+
+.hero-cta {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-4);
+
+  @include ds.bp-down(sm) {
+    flex-direction: column;
+    width: 100%;
+  }
+}
+
+.btn-primary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-spacing-3) var(--ds-spacing-8);
+  background: var(--mat-sys-primary);
+  border-radius: var(--ds-radius-lg);
+  font-weight: 600;
+  font-size: var(--mat-sys-body-large-size);
+  color: white;
+  white-space: nowrap;
+  cursor: pointer;
+  text-decoration: none;
+  transition: opacity var(--ds-duration-fast) var(--ds-easing-standard);
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  @include ds.bp-down(sm) {
+    width: 100%;
+  }
+}
+
+.btn-outlined {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-spacing-3) var(--ds-spacing-8);
+  border: 1.5px solid white;
+  border-radius: var(--ds-radius-lg);
+  font-weight: 600;
+  font-size: var(--mat-sys-body-large-size);
+  color: white;
+  white-space: nowrap;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--ds-duration-fast) var(--ds-easing-standard);
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  @include ds.bp-down(sm) {
+    width: 100%;
+  }
+}
+
+.hero-image-placeholder {
+  // Slot for a future dance studio background image.
+  // To add: set background-image on .hero section and adjust overlay opacity.
+}

--- a/frontend/src/app/landing/landing.ts
+++ b/frontend/src/app/landing/landing.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { PublicHeaderComponent } from './public-header';
+import { PublicFooterComponent } from './public-footer';
+
+@Component({
+  selector: 'app-landing',
+  imports: [RouterLink, PublicHeaderComponent, PublicFooterComponent],
+  templateUrl: './landing.html',
+  styleUrl: './landing.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LandingComponent {
+  private pageTop = viewChild<ElementRef>('pageTop');
+
+  scrollToTop(): void {
+    this.pageTop()?.nativeElement.scrollIntoView({ behavior: 'smooth' });
+  }
+
+  scrollToFeatures(): void {
+    document.getElementById('features')?.scrollIntoView({ behavior: 'smooth' });
+  }
+}

--- a/frontend/src/app/landing/public-footer.scss
+++ b/frontend/src/app/landing/public-footer.scss
@@ -1,0 +1,89 @@
+@use "styles/mixins" as ds;
+
+:host {
+  display: block;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-6);
+  padding: var(--ds-spacing-10) var(--ds-spacing-20);
+  background: var(--ds-landing-bg-end);
+
+  @include ds.bp-down(md) {
+    padding: var(--ds-spacing-8) var(--ds-spacing-6);
+  }
+}
+
+.footer-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  @include ds.bp-down(sm) {
+    flex-direction: column;
+    gap: var(--ds-spacing-6);
+  }
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-2);
+}
+
+.logo-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--ds-radius-full);
+  background: var(--ds-landing-logo-accent);
+}
+
+.logo-text {
+  font-weight: 700;
+  font-size: var(--mat-sys-body-large-size);
+  color: white;
+  white-space: nowrap;
+}
+
+.footer-links {
+  display: flex;
+  gap: var(--ds-spacing-8);
+
+  a {
+    font-weight: 500;
+    font-size: var(--mat-sys-label-large-size);
+    color: var(--ds-landing-footer-text);
+    white-space: nowrap;
+    text-decoration: none;
+    cursor: pointer;
+    transition: color var(--ds-duration-fast) var(--ds-easing-standard);
+
+    &:hover {
+      color: white;
+    }
+  }
+
+  @include ds.bp-down(sm) {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--ds-spacing-4);
+  }
+}
+
+.divider {
+  height: 1px;
+  background: var(--ds-landing-footer-divider);
+}
+
+.footer-bottom {
+  display: flex;
+  justify-content: center;
+}
+
+.copyright {
+  font-size: var(--mat-sys-body-small-size);
+  color: var(--ds-landing-footer-text);
+  margin: 0;
+}

--- a/frontend/src/app/landing/public-footer.ts
+++ b/frontend/src/app/landing/public-footer.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-public-footer',
+  imports: [RouterLink],
+  template: `
+    <footer class="footer">
+      <div class="footer-top">
+        <div class="logo">
+          <span class="logo-icon"></span>
+          <span class="logo-text">DanceStudio</span>
+        </div>
+        <nav class="footer-links">
+          <a routerLink="/terms">Terms of Service</a>
+          <a routerLink="/privacy">Privacy Policy</a>
+          <a href="mailto:supportdanceschool&#64;gmail.com">Contact</a>
+        </nav>
+      </div>
+      <div class="divider"></div>
+      <div class="footer-bottom">
+        <p class="copyright">&copy; 2026 DanceStudio. All rights reserved.</p>
+      </div>
+    </footer>
+  `,
+  styleUrl: './public-footer.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PublicFooterComponent {}

--- a/frontend/src/app/landing/public-header.scss
+++ b/frontend/src/app/landing/public-header.scss
@@ -1,0 +1,113 @@
+@use "styles/mixins" as ds;
+
+:host {
+  display: block;
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--ds-spacing-4) var(--ds-spacing-20);
+  position: relative;
+  z-index: 1;
+
+  @include ds.bp-down(md) {
+    padding: var(--ds-spacing-4) var(--ds-spacing-6);
+  }
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-2);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.logo-icon {
+  width: var(--ds-spacing-8);
+  height: var(--ds-spacing-8);
+  border-radius: var(--ds-radius-full);
+  background: white;
+  opacity: 0.9;
+}
+
+.logo-text {
+  font-weight: 700;
+  font-size: var(--mat-sys-title-medium-size);
+  color: white;
+  white-space: nowrap;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-8);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-6);
+
+  a {
+    font-weight: 500;
+    font-size: var(--mat-sys-body-large-size);
+    color: white;
+    white-space: nowrap;
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  @include ds.bp-down(md) {
+    display: none;
+  }
+}
+
+.header-buttons {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-3);
+}
+
+.btn-login {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-spacing-2) var(--ds-spacing-5);
+  border: 1px solid var(--ds-landing-border-muted);
+  border-radius: var(--ds-radius-md);
+  font-weight: 500;
+  font-size: var(--mat-sys-label-large-size);
+  color: white;
+  white-space: nowrap;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--ds-duration-fast) var(--ds-easing-standard);
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.btn-get-started {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-spacing-2) var(--ds-spacing-5);
+  background: white;
+  border-radius: var(--ds-radius-md);
+  font-weight: 600;
+  font-size: var(--mat-sys-label-large-size);
+  color: var(--mat-sys-primary);
+  white-space: nowrap;
+  cursor: pointer;
+  text-decoration: none;
+  transition: opacity var(--ds-duration-fast) var(--ds-easing-standard);
+
+  &:hover {
+    opacity: 0.9;
+  }
+}

--- a/frontend/src/app/landing/public-header.ts
+++ b/frontend/src/app/landing/public-header.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, output } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-public-header',
+  imports: [RouterLink],
+  template: `
+    <header class="header">
+      <a class="logo" (click)="logoClick.emit()">
+        <span class="logo-icon"></span>
+        <span class="logo-text">DanceStudio</span>
+      </a>
+      <div class="header-right">
+        <nav class="nav-links">
+          <a (click)="featuresClick.emit()">Features</a>
+          <a>Pricing</a>
+        </nav>
+        <div class="header-buttons">
+          <a class="btn-login" routerLink="/login">Login</a>
+          <a class="btn-get-started" routerLink="/login">Get Started</a>
+        </div>
+      </div>
+    </header>
+  `,
+  styleUrl: './public-header.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PublicHeaderComponent {
+  logoClick = output<void>();
+  featuresClick = output<void>();
+}

--- a/frontend/src/styles/_tokens.scss
+++ b/frontend/src/styles/_tokens.scss
@@ -43,6 +43,17 @@
   // ── Shadows ──
   --ds-shadow-sm: 0 2px 4px rgb(0 0 0 / 0.1);
 
+  // ── Landing page ──
+  --ds-landing-bg-start: #2e1459;
+  --ds-landing-bg-mid: #140a26;
+  --ds-landing-bg-end: #0d051a;
+  --ds-landing-text-muted: rgba(255, 255, 255, 0.9);
+  --ds-landing-border-muted: rgba(255, 255, 255, 0.5);
+  --ds-landing-footer-text: #9991a6;
+  --ds-landing-footer-divider: #33264d;
+  --ds-landing-logo-accent: #f5c73d;
+  --ds-landing-glow: rgba(98, 50, 201, 0.15);
+
   // ── Motion ──
   --ds-duration-fast: 150ms;
   --ds-duration-normal: 250ms;


### PR DESCRIPTION
## Summary
- New `LandingComponent` at `/` with dark gradient hero, heading, subheading, and CTA buttons
- Reusable `PublicHeaderComponent` and `PublicFooterComponent` for shared public layout
- Landing-specific design tokens (`--ds-landing-*`) added to `_tokens.scss`
- Fixes the `publicGuard` redirect issue (replaces empty `children: []` with a real component)
- All CTA/nav buttons route to `/login`, footer links to `/terms`, `/privacy`, and `mailto:`

Closes #84

## Test plan
- [x] Frontend builds successfully
- [x] Existing tests pass
- [x] Visual verification via Playwright screenshot — matches Figma design
- [x] Login/Get Started/Try for Free buttons navigate to `/login`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)