### PR TITLE
Add cross-tenant isolation tests, rename USER to TEACHER (#100)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Multi-tenant B2B SaaS for dance school management. Each **School** is a tenant. 
 
 ### Authentication Strategy
 
-- **Local dev:** Spring Security form login with in-memory users (`owner@test.com` / `password` as OWNER, `user@test.com` / `password` as USER). Dev users and a school are seeded on startup by `DevDataSeeder` — no onboarding needed.
+- **Local dev:** Spring Security form login with in-memory users (`owner@test.com` / `password` and `owner2@test.com` / `password`, both OWNER). Dev users and two separate schools are seeded on startup by `DevDataSeeder` — no onboarding needed.
 - **Production:** Firebase JWT auth (Google sign-in via Firebase SDK). Stateless, token-based. Activated by setting `app.security.dev-auth=false` and configuring the `prod` Spring profile.
 - **Future:** OAuth/social login for all users (owners, teachers, students) via a managed provider (Auth0, Clerk, or similar). Decision pending on provider choice.
 
@@ -58,13 +58,13 @@ When verifying frontend changes visually (layout, styling, component rendering),
 
 ### 2. Log in
 
-- **Dev credentials:** `owner@test.com` / `password` (OWNER role) or `user@test.com` / `password` (USER role)
-- The login page shows a simple email/password form with quick-login buttons for each role
+- **Dev credentials:** `owner@test.com` / `password` (School 1) or `owner2@test.com` / `password` (School 2)
+- The login page shows a simple email/password form with quick-login buttons for each owner
 - Use Playwright MCP to fill the form or click a quick-login button
 
 ### 3. Handle fresh database state
 
-The backend uses H2 in-memory, so every restart is a clean slate. However, `DevDataSeeder` automatically seeds dev users + a school on startup, so login lands directly in the app shell — no onboarding step needed.
+The backend uses H2 in-memory, so every restart is a clean slate. However, `DevDataSeeder` automatically seeds two dev users with separate schools on startup, so login lands directly in the app shell — no onboarding step needed.
 
 ### 4. Navigate and screenshot
 

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -64,11 +64,11 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 ## Security
 
 ### Auth modes (controlled by `app.security.dev-auth` property)
-- **Dev** (`dev-auth: true`, default): form login with session auth. `DevDataSeeder` seeds users + school on startup. `@AuthenticationPrincipal AuthenticatedUser` works identically to prod.
+- **Dev** (`dev-auth: true`, default): form login with session auth. `DevDataSeeder` seeds two owners with separate schools on startup. `@AuthenticationPrincipal AuthenticatedUser` works identically to prod.
 - **Prod** (`dev-auth: false`): stateless Firebase JWT. First request auto-creates the user from token claims.
 
 ### Authorization
-- Roles are **scoped to a school**, not global — stored in `school_member` table (OWNER, USER)
+- Roles are **scoped to a school**, not global — stored in `school_member` table (OWNER, TEACHER)
 - A user with no memberships is in the "needs onboarding" state
 
 ### Configuration (env vars)

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
@@ -28,7 +28,7 @@ public class SchoolController {
 
     @GetMapping("/me")
     public SchoolDetailDto me(@AuthenticationPrincipal AuthenticatedUser principal) {
-        return schoolService.getByOwnerUserId(principal.userId());
+        return schoolService.getByMemberUserId(principal.userId());
     }
 
     @PutMapping("/me")

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 interface SchoolRepository extends JpaRepository<School, Long> {
 
-    @Query("SELECT s FROM School s JOIN SchoolMember m ON m.school = s WHERE m.user.id = :userId AND m.role = ch.ruppen.danceschool.schoolmember.MemberRole.OWNER")
-    Optional<School> findByOwnerUserId(Long userId);
+    @Query("SELECT s FROM School s JOIN SchoolMember m ON m.school = s WHERE m.user.id = :userId")
+    Optional<School> findByMemberUserId(Long userId);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -46,23 +46,23 @@ public class SchoolService {
         return toDetailDto(saved);
     }
 
-    public boolean hasSchoolByOwner(Long userId) {
-        return schoolRepository.findByOwnerUserId(userId).isPresent();
+    public boolean hasSchoolByMember(Long userId) {
+        return schoolRepository.findByMemberUserId(userId).isPresent();
     }
 
-    public SchoolDetailDto getByOwnerUserId(Long userId) {
-        return toDetailDto(findSchoolByOwner(userId));
+    public SchoolDetailDto getByMemberUserId(Long userId) {
+        return toDetailDto(findSchoolByMember(userId));
     }
 
     public SchoolDetailDto updateSchool(Long userId, SchoolUpdateDto dto) {
-        School school = findSchoolByOwner(userId);
+        School school = findSchoolByMember(userId);
         deleteReplacedImages(school, dto);
         applyDto(school, dto);
         return toDetailDto(schoolRepository.save(school));
     }
 
-    public School findSchoolByOwner(Long userId) {
-        return schoolRepository.findByOwnerUserId(userId)
+    public School findSchoolByMember(Long userId) {
+        return schoolRepository.findByMemberUserId(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("School", userId));
     }
 

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/MemberRole.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/MemberRole.java
@@ -2,5 +2,5 @@ package ch.ruppen.danceschool.schoolmember;
 
 public enum MemberRole {
     OWNER,
-    USER
+    TEACHER
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevDataSeeder.java
@@ -1,11 +1,7 @@
 package ch.ruppen.danceschool.shared.security;
 
-import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.school.SchoolUpdateDto;
-import ch.ruppen.danceschool.schoolmember.MemberRole;
-import ch.ruppen.danceschool.schoolmember.SchoolMember;
-import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
 import ch.ruppen.danceschool.user.AppUser;
 import ch.ruppen.danceschool.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -30,28 +26,27 @@ public class DevDataSeeder implements ApplicationRunner {
 
     private final UserService userService;
     private final SchoolService schoolService;
-    private final SchoolMemberService schoolMemberService;
 
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
         AppUser owner = userService.findOrCreateByFirebaseUid("dev-owner", "owner@test.com", "Dev Owner");
-        AppUser user = userService.findOrCreateByFirebaseUid("dev-user", "user@test.com", "Dev User");
+        AppUser owner2 = userService.findOrCreateByFirebaseUid("dev-owner-2", "owner2@test.com", "Dev Owner 2");
 
-        if (!schoolService.hasSchoolByOwner(owner.getId())) {
+        if (!schoolService.hasSchoolByMember(owner.getId())) {
             var schoolDto = new SchoolUpdateDto("Dev Dance School", null, null, null, "Zurich",
                     null, "Switzerland", null, "info@devdanceschool.com", null, null, null,
                     null, null, null);
             schoolService.createSchool(schoolDto, owner.getId());
-
-            School school = schoolService.findSchoolByOwner(owner.getId());
-            SchoolMember member = new SchoolMember();
-            member.setUser(user);
-            member.setSchool(school);
-            member.setRole(MemberRole.USER);
-            schoolMemberService.createMembership(member);
         }
 
-        log.info("Dev data seeded: owner@test.com (OWNER), user@test.com (USER)");
+        if (!schoolService.hasSchoolByMember(owner2.getId())) {
+            var school2Dto = new SchoolUpdateDto("Other Dance School", null, null, null, "Bern",
+                    null, "Switzerland", null, "info@otherdanceschool.com", null, null, null,
+                    null, null, null);
+            schoolService.createSchool(school2Dto, owner2.getId());
+        }
+
+        log.info("Dev data seeded: owner@test.com (School 1), owner2@test.com (School 2)");
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevSecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevSecurityConfig.java
@@ -73,12 +73,12 @@ public class DevSecurityConfig {
                 .password(passwordEncoder.encode("password"))
                 .roles("USER")
                 .build();
-        var user = User.builder()
-                .username("user@test.com")
+        var owner2 = User.builder()
+                .username("owner2@test.com")
                 .password(passwordEncoder.encode("password"))
                 .roles("USER")
                 .build();
-        return new InMemoryUserDetailsManager(owner, user);
+        return new InMemoryUserDetailsManager(owner, owner2);
     }
 
     @Bean

--- a/backend/src/main/resources/db/changelog/008-rename-user-role-to-teacher.yaml
+++ b/backend/src/main/resources/db/changelog/008-rename-user-role-to-teacher.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 008-rename-user-role-to-teacher
+      author: lruppe
+      changes:
+        - update:
+            tableName: school_member
+            columns:
+              - column:
+                  name: role
+                  value: TEACHER
+            where: role = 'USER'

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -13,3 +13,5 @@ databaseChangeLog:
       file: db/changelog/006-firebase-auth.yaml
   - include:
       file: db/changelog/007-structured-address.yaml
+  - include:
+      file: db/changelog/008-rename-user-role-to-teacher.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolTenantIsolationTest.java
@@ -1,0 +1,167 @@
+package ch.ruppen.danceschool.school;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class SchoolTenantIsolationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser userA;
+    private AppUser userB;
+    private School schoolA;
+    private School schoolB;
+
+    @BeforeEach
+    void setUp() {
+        userA = createUser("user-a@example.com", "User A", "firebase-a");
+        userB = createUser("user-b@example.com", "User B", "firebase-b");
+
+        schoolA = createSchoolWithOwner("School A", userA);
+        schoolB = createSchoolWithOwner("School B", userB);
+
+        entityManager.flush();
+    }
+
+    @Test
+    void getMe_returnsOwnSchool_notOtherTenantSchool() throws Exception {
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(userA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("School A"))
+                .andExpect(jsonPath("$.id").value(schoolA.getId()));
+
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(userB))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("School B"))
+                .andExpect(jsonPath("$.id").value(schoolB.getId()));
+    }
+
+    @Test
+    void updateMe_updatesOwnSchool_notOtherTenantSchool() throws Exception {
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(userA)))
+                        .contentType("application/json")
+                        .content("""
+                                { "name": "School A Updated" }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("School A Updated"));
+
+        // Verify school B is untouched
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(userB))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("School B"));
+    }
+
+    @Test
+    void getMe_returns404_forUserWithNoSchool() throws Exception {
+        AppUser orphan = createUser("orphan@example.com", "Orphan", "firebase-orphan");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(orphan))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void multipleOwnersCanAccessSameSchool() throws Exception {
+        AppUser coOwner = createUser("co-owner@example.com", "Co-Owner", "firebase-co");
+        addOwner(schoolA, coOwner);
+        entityManager.flush();
+
+        // Both owners see the same school
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(userA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(schoolA.getId()));
+
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(coOwner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(schoolA.getId()));
+    }
+
+    @Test
+    void coOwnerCanUpdateSharedSchool() throws Exception {
+        AppUser coOwner = createUser("co-owner@example.com", "Co-Owner", "firebase-co");
+        addOwner(schoolA, coOwner);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/schools/me")
+                        .with(authentication(authToken(coOwner)))
+                        .contentType("application/json")
+                        .content("""
+                                { "name": "Updated by Co-Owner" }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Updated by Co-Owner"));
+
+        // Original owner sees the update
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(authToken(userA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Updated by Co-Owner"));
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser owner) {
+        School school = new School();
+        school.setName(name);
+        entityManager.persist(school);
+        addOwner(school, owner);
+        return school;
+    }
+
+    private void addOwner(School school, AppUser owner) {
+        SchoolMember member = new SchoolMember();
+        member.setUser(owner);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -48,7 +48,7 @@ Angular 21 application using Angular Material for UI components.
 - Session-based auth — browser session cookie handles authentication automatically
 - `authInterceptor` adds `withCredentials: true` (no Bearer token)
 - Login page shows email/password form with quick-login buttons for Owner and User roles
-- Dev users: `owner@test.com` / `password` (OWNER), `user@test.com` / `password` (USER)
+- Dev users: `owner@test.com` / `password` (School 1), `owner2@test.com` / `password` (School 2)
 
 **Prod mode** (`useDevLogin: false` — set in `environment.prod.ts`):
 - Firebase SDK (`firebase` npm package) handles Google sign-in and token management

--- a/frontend/src/app/auth/login/login.html
+++ b/frontend/src/app/auth/login/login.html
@@ -20,8 +20,8 @@
           <button mat-flat-button class="full-width" (click)="devLogin()">Sign in</button>
           <div class="quick-login">
             <span class="quick-login-label">Quick login:</span>
-            <button mat-stroked-button (click)="quickLogin('owner@test.com')">Owner</button>
-            <button mat-stroked-button (click)="quickLogin('user@test.com')">User</button>
+            <button mat-stroked-button (click)="quickLogin('owner@test.com')">Owner 1</button>
+            <button mat-stroked-button (click)="quickLogin('owner2@test.com')">Owner 2</button>
           </div>
         } @else {
           <button mat-flat-button class="google-button" (click)="signInWithGoogle()">

--- a/frontend/src/app/shared/auth/auth.service.ts
+++ b/frontend/src/app/shared/auth/auth.service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../../environments/environment';
 export interface Membership {
   schoolId: number;
   schoolName: string;
-  role: 'OWNER' | 'USER';
+  role: 'OWNER' | 'TEACHER';
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- **Cross-tenant isolation tests**: 5 integration tests proving user A cannot read/update user B's school, multi-owner access works, and users without schools get 404
- **Rename USER role to TEACHER** in `MemberRole` enum + Liquibase migration — USER was unused, TEACHER prepares for Phase 1 roadmap
- **Simplify school resolution**: removed role filter from `SchoolRepository` query — any `SchoolMember` row grants access, not just OWNER role. This makes the `/me` endpoints work for all members.
- **Dev seed data**: two separate schools with two owners (instead of one school with owner+user) so tenant isolation is testable locally
- **Updated CLAUDE.md files** and frontend login quick-buttons to reflect new dev credentials

Closes #100

## Test plan
- [x] All 45 backend tests pass (including 5 new tenant isolation tests)
- [ ] CI passes
- [ ] Quick-login buttons work for both Owner 1 and Owner 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)