### PR TITLE
Add /start-issue skill for automated issue workflow

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,50 @@
+Start working on a GitHub issue end-to-end: from loading the issue through implementation, visual verification, and merging.
+
+## Input
+
+The user provides a GitHub issue number as an argument (e.g., `/start-issue 100`).
+
+## Phase 1 — Setup
+
+1. **Load the issue:** `gh issue view <number>` (include comments for full context)
+2. **Create worktree:** Use `EnterWorktree` with a descriptive name derived from the issue (e.g., `100-multi-tenancy-isolation`)
+3. **Install frontend deps:** Run `npm install` in `frontend/` (fresh worktrees need this)
+4. **Create branch:** Create a feature branch from main
+
+## Phase 2 — Planning
+
+Assess whether the issue is trivial or non-trivial:
+- **Trivial** (typo, single-file change, config tweak): skip planning, go straight to implementation
+- **Non-trivial** (multi-file, new feature, architectural change): enter plan mode, produce a step-by-step implementation plan, then exit plan mode and proceed
+
+## Phase 3 — Implementation
+
+Implement the changes according to the plan (or directly for trivial issues). Follow all project conventions in CLAUDE.md files. Run builds and tests as you go:
+- **Frontend:** `npx ng build`, `npx ng test --browsers chromium --no-watch`
+- **Backend:** `cd backend && ./mvnw test`
+
+## Phase 4 — Visual Verification
+
+**Always run this for frontend changes.** Skip only if the issue is purely backend with no UI impact.
+
+1. **Start backend:** `cd backend && ./mvnw spring-boot:run` (background)
+2. **Start frontend:** Angular MCP `devserver.start` (workspace: `frontend/`)
+3. **Wait for both** to be ready
+4. **Login:** Use Playwright MCP to navigate to the app and log in with `owner@test.com` / `password` (click the Owner quick-login button)
+5. **Navigate and screenshot:** Visit all pages affected by the change. Take screenshots to verify visual correctness.
+6. **Stop servers:** Stop the frontend devserver (Angular MCP `devserver.stop`) and kill the backend process
+
+## Phase 5 — Ship
+
+1. **Commit:** Stage changed files and commit with a clear message describing the change
+2. **Rebase:** `git fetch origin main && git rebase origin/main` — resolve conflicts if any
+3. **Push:** `git push` (or `git push --force-with-lease` after rebase)
+4. **Create PR:** `gh pr create` with a summary and test plan
+5. **Watch CI:** `gh pr checks <number> --watch`
+6. **Merge:** `gh pr merge <number> --squash --delete-branch` once CI passes
+
+## Important
+
+- **Do not stop to ask** between phases unless genuinely blocked (e.g., ambiguous requirements, failing tests you can't diagnose, merge conflicts needing user judgment)
+- **Auto-merge** is the default — no manual review needed
+- Follow all conventions in root, frontend, and backend CLAUDE.md files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ danceschool/
 └── .mcp.json          ← MCP server config (Angular CLI + Playwright browser)
 ```
 
-Frontend and backend are independent builds. During development, use Angular MCP `devserver.start` with a proxy to the backend API.
+Frontend and backend are independent builds — no Maven integration. During development, use Angular MCP `devserver.start` with a proxy to the backend API.
 
 ## Domain
 
@@ -35,6 +35,20 @@ Multi-tenant B2B SaaS for dance school management. Each **School** is a tenant. 
 - **Frontend** deployed on Render (static site): https://danceschool-2g1m.onrender.com/
 - **Backend** deployed on Render (Docker): https://danceschool-api.onrender.com/ (API base: `/api`)
 
+## Issue Workflow
+
+Use `/start-issue <number>` to work on a GitHub issue. This runs the full automated lifecycle:
+
+**Setup** → load issue, create worktree + branch, install deps
+**Plan** → enter plan mode for non-trivial issues (use judgment to skip for trivial fixes)
+**Implement** → code, build, test
+**Visual E2E** → start both servers, login via Playwright, screenshot affected pages
+**Ship** → commit, rebase, push, PR, watch CI, squash merge
+
+**Do not stop between phases** unless genuinely blocked. Auto-merge after CI passes — no manual review needed.
+
+See `.claude/commands/start-issue.md` for the full step-by-step.
+
 ## Git & GitHub
 
 - **GitHub repo:** `lruppe/danceschool`
@@ -43,12 +57,11 @@ Multi-tenant B2B SaaS for dance school management. Each **School** is a tenant. 
 - **All changes go through PRs** — never commit directly to `main`
 - **Always work in a worktree** — use Claude Code's built-in worktree tools (`EnterWorktree`) or `claude --worktree <name>`. This creates worktrees at `.claude/worktrees/<name>/` inside the project. Do NOT use raw `git worktree add` to create worktrees outside the project directory — external worktrees break MCP tool context and file watching.
 - **Fresh worktrees need setup** — always run `npm install` in `frontend/` before building or starting the dev server in a new worktree
-- **Workflow:** pull main → create worktree → create branch → commit → rebase on main → push → create PR → `gh pr checks <number> --watch` → squash merge → pull main
 - **Auto-merge:** merge immediately after CI passes, no manual review needed
 
 ## Visual Testing Workflow
 
-When verifying frontend changes visually (layout, styling, component rendering), follow this workflow:
+Required for all frontend changes. Skip only for purely backend issues with no UI impact.
 
 ### 1. Start both servers
 
@@ -60,7 +73,7 @@ When verifying frontend changes visually (layout, styling, component rendering),
 
 - **Dev credentials:** `owner@test.com` / `password` (School 1) or `owner2@test.com` / `password` (School 2)
 - The login page shows a simple email/password form with quick-login buttons for each owner
-- Use Playwright MCP to fill the form or click a quick-login button
+- Use Playwright MCP to click a quick-login button
 
 ### 3. Handle fresh database state
 
@@ -71,6 +84,11 @@ The backend uses H2 in-memory, so every restart is a clean slate. However, `DevD
 - Use Playwright `browser_navigate` to the relevant page
 - Use `browser_take_screenshot` to visually verify layout and styling
 - **Always take a final screenshot before committing** style or layout changes
+
+### 5. Stop servers
+
+- Stop the frontend devserver: Angular MCP `devserver.stop`
+- Kill the backend process
 
 ## Working Rules
 


### PR DESCRIPTION
## Summary
- Add `/start-issue <number>` skill that runs the full automated lifecycle: load issue → create worktree → plan → implement → visual E2E → ship and merge
- Streamline root CLAUDE.md: add Issue Workflow section, add server stop step to visual testing, remove redundant workflow description from Git section

## Test plan
- [ ] CI passes
- [ ] `/start-issue` skill is available in new conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)