### PR TITLE
Add Terms of Service and Privacy Policy pages (#86)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -11,6 +11,8 @@ export const routes: Routes = [
     loadComponent: () => import('./landing/landing').then(m => m.LandingComponent),
   },
   { path: 'login', loadComponent: () => import('./auth/login/login').then(m => m.LoginComponent) },
+  { path: 'terms', loadComponent: () => import('./legal/terms').then(m => m.TermsComponent) },
+  { path: 'privacy', loadComponent: () => import('./legal/privacy').then(m => m.PrivacyComponent) },
   {
     path: 'app',
     loadComponent: () => import('./shell/shell').then(m => m.ShellComponent),

--- a/frontend/src/app/legal/legal.scss
+++ b/frontend/src/app/legal/legal.scss
@@ -1,0 +1,114 @@
+@use "styles/mixins" as ds;
+
+:host {
+  display: block;
+}
+
+.legal-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--ds-landing-bg-end);
+}
+
+// ── Header area with dark gradient ──
+
+.legal-hero {
+  position: relative;
+  background: linear-gradient(
+    32deg,
+    var(--ds-landing-bg-start) 14%,
+    var(--ds-landing-bg-mid) 57%,
+    var(--ds-landing-bg-end) 86%
+  );
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2));
+  pointer-events: none;
+}
+
+// ── Legal content area ──
+
+.legal-content {
+  flex: 1;
+  max-width: var(--ds-content-max-width);
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--ds-spacing-12) var(--ds-spacing-20);
+
+  @include ds.bp-down(md) {
+    padding: var(--ds-spacing-8) var(--ds-spacing-6);
+  }
+}
+
+.legal-title {
+  margin: 0 0 var(--ds-spacing-2);
+  font-size: var(--mat-sys-display-small-size);
+  line-height: var(--mat-sys-display-small-line-height);
+  font-weight: 700;
+  color: white;
+
+  @include ds.bp-down(md) {
+    font-size: var(--mat-sys-headline-large-size);
+    line-height: var(--mat-sys-headline-large-line-height);
+  }
+}
+
+.legal-updated {
+  margin: 0 0 var(--ds-spacing-10);
+  font-size: var(--mat-sys-body-medium-size);
+  line-height: var(--mat-sys-body-medium-line-height);
+  color: var(--ds-landing-footer-text);
+}
+
+.legal-section {
+  margin-bottom: var(--ds-spacing-8);
+
+  h2 {
+    margin: 0 0 var(--ds-spacing-3);
+    font-size: var(--mat-sys-title-large-size);
+    line-height: var(--mat-sys-title-large-line-height);
+    font-weight: 600;
+    color: white;
+  }
+
+  h3 {
+    margin: var(--ds-spacing-4) 0 var(--ds-spacing-2);
+    font-size: var(--mat-sys-title-medium-size);
+    line-height: var(--mat-sys-title-medium-line-height);
+    font-weight: 600;
+    color: var(--ds-landing-text-muted);
+  }
+
+  p {
+    margin: 0 0 var(--ds-spacing-3);
+    font-size: var(--mat-sys-body-large-size);
+    line-height: var(--mat-sys-body-large-line-height);
+    color: var(--ds-landing-text-muted);
+  }
+
+  ul {
+    margin: 0 0 var(--ds-spacing-3);
+    padding-left: var(--ds-spacing-6);
+
+    li {
+      margin-bottom: var(--ds-spacing-2);
+      font-size: var(--mat-sys-body-large-size);
+      line-height: var(--mat-sys-body-large-line-height);
+      color: var(--ds-landing-text-muted);
+    }
+  }
+
+  a {
+    color: var(--mat-sys-primary);
+    text-decoration: none;
+    transition: opacity var(--ds-duration-fast) var(--ds-easing-standard);
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+}

--- a/frontend/src/app/legal/privacy.html
+++ b/frontend/src/app/legal/privacy.html
@@ -1,0 +1,137 @@
+<div class="legal-page">
+  <div class="legal-hero">
+    <div class="hero-overlay"></div>
+    <app-public-header
+      (logoClick)="navigateHome()"
+      (featuresClick)="navigateHome()"
+    />
+  </div>
+
+  <div class="legal-content">
+    <h1 class="legal-title">Privacy Policy</h1>
+    <p class="legal-updated">Last updated: April 4, 2026</p>
+
+    <section class="legal-section">
+      <h2>1. Introduction</h2>
+      <p>
+        DanceStudio ("we", "our", or "us") is committed to protecting your privacy. This Privacy
+        Policy explains how we collect, use, disclose, and safeguard your information when you use
+        our platform.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>2. Information We Collect</h2>
+      <h3>Information you provide</h3>
+      <ul>
+        <li>Account information (name, email address)</li>
+        <li>School profile details (school name, description, contact information)</li>
+        <li>Student records (names, enrollment data, attendance)</li>
+        <li>Payment and billing information</li>
+      </ul>
+      <h3>Information collected automatically</h3>
+      <ul>
+        <li>Usage data (pages visited, features used, time spent)</li>
+        <li>Device information (browser type, operating system)</li>
+        <li>IP address and approximate location</li>
+        <li>Cookies and similar tracking technologies</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2>3. How We Use Your Information</h2>
+      <p>We use the information we collect to:</p>
+      <ul>
+        <li>Provide, maintain, and improve the Service</li>
+        <li>Process transactions and manage your account</li>
+        <li>Send service-related communications and updates</li>
+        <li>Analyze usage patterns to enhance user experience</li>
+        <li>Ensure security and prevent fraud</li>
+        <li>Comply with legal obligations</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2>4. Data Sharing</h2>
+      <p>
+        We do not sell your personal information. We may share your data with:
+      </p>
+      <ul>
+        <li>Service providers who assist in operating the platform (hosting, analytics)</li>
+        <li>Legal authorities when required by law or to protect our rights</li>
+        <li>Business partners in the event of a merger, acquisition, or asset sale</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2>5. Data Security</h2>
+      <p>
+        We implement industry-standard security measures to protect your data, including encryption
+        in transit and at rest, regular security audits, and access controls. However, no method of
+        electronic transmission or storage is 100% secure.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>6. Data Retention</h2>
+      <p>
+        We retain your data for as long as your account is active or as needed to provide the
+        Service. When you delete your account, we will delete or anonymize your personal data within
+        30 days, except where retention is required by law.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>7. Your Rights</h2>
+      <p>Depending on your jurisdiction, you may have the right to:</p>
+      <ul>
+        <li>Access and receive a copy of your personal data</li>
+        <li>Correct inaccurate or incomplete data</li>
+        <li>Request deletion of your personal data</li>
+        <li>Object to or restrict certain processing of your data</li>
+        <li>Data portability — receive your data in a structured, machine-readable format</li>
+      </ul>
+      <p>
+        To exercise any of these rights, please contact us at
+        <a href="mailto:supportdanceschool@gmail.com">supportdanceschool&#64;gmail.com</a>.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>8. Cookies</h2>
+      <p>
+        We use essential cookies to maintain your session and preferences. We may also use analytics
+        cookies to understand how users interact with the Service. You can manage cookie preferences
+        through your browser settings.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>9. Children's Privacy</h2>
+      <p>
+        The Service is not directed at children under 16. We do not knowingly collect personal
+        information from children. If you believe we have collected data from a child, please
+        contact us immediately.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>10. Changes to This Policy</h2>
+      <p>
+        We may update this Privacy Policy from time to time. We will notify you of material changes
+        via email or through the Service. Your continued use of the Service after changes
+        constitutes acceptance of the updated policy.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>11. Contact</h2>
+      <p>
+        If you have any questions about this Privacy Policy, please contact us at
+        <a href="mailto:supportdanceschool@gmail.com">supportdanceschool&#64;gmail.com</a>.
+      </p>
+    </section>
+  </div>
+
+  <app-public-footer />
+</div>

--- a/frontend/src/app/legal/privacy.ts
+++ b/frontend/src/app/legal/privacy.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { PublicHeaderComponent } from '../landing/public-header';
+import { PublicFooterComponent } from '../landing/public-footer';
+
+@Component({
+  selector: 'app-privacy',
+  imports: [PublicHeaderComponent, PublicFooterComponent],
+  templateUrl: './privacy.html',
+  styleUrl: './legal.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PrivacyComponent {
+  private router = inject(Router);
+
+  navigateHome(): void {
+    this.router.navigate(['/']);
+  }
+}

--- a/frontend/src/app/legal/terms.html
+++ b/frontend/src/app/legal/terms.html
@@ -1,0 +1,111 @@
+<div class="legal-page">
+  <div class="legal-hero">
+    <div class="hero-overlay"></div>
+    <app-public-header
+      (logoClick)="navigateHome()"
+      (featuresClick)="navigateHome()"
+    />
+  </div>
+
+  <div class="legal-content">
+    <h1 class="legal-title">Terms of Service</h1>
+    <p class="legal-updated">Last updated: April 4, 2026</p>
+
+    <section class="legal-section">
+      <h2>1. Acceptance of Terms</h2>
+      <p>
+        By accessing or using DanceStudio ("the Service"), you agree to be bound by these Terms of
+        Service. If you do not agree to these terms, please do not use the Service.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>2. Description of Service</h2>
+      <p>
+        DanceStudio is a cloud-based platform for dance school management, providing tools for
+        student enrollment, scheduling, attendance tracking, and school administration. The Service
+        is provided on a multi-tenant software-as-a-service (SaaS) basis.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>3. User Accounts</h2>
+      <p>
+        To use the Service, you must create an account and provide accurate, complete information.
+        You are responsible for maintaining the confidentiality of your account credentials and for
+        all activities that occur under your account.
+      </p>
+      <p>
+        You agree to notify us immediately of any unauthorized use of your account or any other
+        breach of security.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>4. Acceptable Use</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>Use the Service for any unlawful purpose or in violation of any applicable laws</li>
+        <li>Upload or transmit viruses, malware, or other harmful code</li>
+        <li>Attempt to gain unauthorized access to any part of the Service</li>
+        <li>Interfere with or disrupt the Service or its infrastructure</li>
+        <li>Use the Service to send unsolicited communications (spam)</li>
+      </ul>
+    </section>
+
+    <section class="legal-section">
+      <h2>5. Data Ownership</h2>
+      <p>
+        You retain all rights to the data you input into the Service. DanceStudio does not claim
+        ownership over your content. We will only access your data as necessary to provide and
+        improve the Service, or as required by law.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>6. Service Availability</h2>
+      <p>
+        We strive to maintain high availability of the Service but do not guarantee uninterrupted
+        access. The Service may be temporarily unavailable due to maintenance, updates, or
+        circumstances beyond our control.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>7. Limitation of Liability</h2>
+      <p>
+        To the maximum extent permitted by law, DanceStudio shall not be liable for any indirect,
+        incidental, special, consequential, or punitive damages, or any loss of profits or revenue,
+        whether incurred directly or indirectly.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>8. Termination</h2>
+      <p>
+        We may suspend or terminate your access to the Service at any time, with or without cause,
+        and with or without notice. Upon termination, your right to use the Service will immediately
+        cease.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>9. Changes to Terms</h2>
+      <p>
+        We reserve the right to modify these Terms at any time. We will notify users of material
+        changes via email or through the Service. Your continued use of the Service after changes
+        constitutes acceptance of the updated Terms.
+      </p>
+    </section>
+
+    <section class="legal-section">
+      <h2>10. Contact</h2>
+      <p>
+        If you have any questions about these Terms, please contact us at
+        <a href="mailto:supportdanceschool@gmail.com">supportdanceschool&#64;gmail.com</a>.
+      </p>
+    </section>
+  </div>
+
+  <app-public-footer />
+</div>

--- a/frontend/src/app/legal/terms.ts
+++ b/frontend/src/app/legal/terms.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { PublicHeaderComponent } from '../landing/public-header';
+import { PublicFooterComponent } from '../landing/public-footer';
+
+@Component({
+  selector: 'app-terms',
+  imports: [PublicHeaderComponent, PublicFooterComponent],
+  templateUrl: './terms.html',
+  styleUrl: './legal.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TermsComponent {
+  private router = inject(Router);
+
+  navigateHome(): void {
+    this.router.navigate(['/']);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `/terms` and `/privacy` routes with static legal content pages
- Dark-themed styling consistent with the landing page aesthetic
- Both pages use the shared `PublicHeaderComponent` and `PublicFooterComponent`
- Footer links on the landing page now correctly navigate to these pages

Closes #86

## Test plan
- [x] `/terms` renders Terms of Service page with boilerplate legal content
- [x] `/privacy` renders Privacy Policy page with boilerplate legal content
- [x] Both pages use shared public layout (header + footer)
- [x] Dark-themed styling matches landing page
- [x] Footer links navigate correctly to legal pages
- [x] No authentication required
- [x] Build passes, tests pass
- [x] Visual verification via Playwright screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)