### PR TITLE
Add mobile responsiveness to landing page (#87)

### DIFF
--- a/frontend/src/app/landing/landing.scss
+++ b/frontend/src/app/landing/landing.scss
@@ -9,6 +9,7 @@
   flex-direction: column;
   min-height: 100vh;
   background: var(--ds-landing-bg-end);
+  overflow-x: hidden;
 }
 
 // ── Hero Section ──

--- a/frontend/src/app/landing/public-header.scss
+++ b/frontend/src/app/landing/public-header.scss
@@ -45,6 +45,10 @@
   display: flex;
   align-items: center;
   gap: var(--ds-spacing-8);
+
+  @include ds.bp-down(md) {
+    display: none;
+  }
 }
 
 .nav-links {
@@ -59,10 +63,6 @@
     white-space: nowrap;
     cursor: pointer;
     text-decoration: none;
-  }
-
-  @include ds.bp-down(md) {
-    display: none;
   }
 }
 
@@ -110,4 +110,63 @@
   &:hover {
     opacity: 0.9;
   }
+}
+
+// ── Hamburger button (mobile only) ──
+
+.hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--ds-spacing-1);
+  padding: var(--ds-spacing-2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 1;
+
+  @include ds.bp-down(md) {
+    display: flex;
+  }
+}
+
+.hamburger-line {
+  display: block;
+  width: var(--ds-spacing-5);
+  height: 2px;
+  background: white;
+  border-radius: var(--ds-radius-sm);
+}
+
+// ── Mobile menu ──
+
+.mobile-menu {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-4);
+  padding: var(--ds-spacing-4) var(--ds-spacing-6) var(--ds-spacing-6);
+  position: relative;
+  z-index: 1;
+
+  a {
+    font-weight: 500;
+    font-size: var(--mat-sys-body-large-size);
+    color: white;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .btn-login {
+    justify-content: center;
+  }
+
+  .btn-get-started {
+    justify-content: center;
+    color: var(--mat-sys-primary);
+  }
+}
+
+.mobile-menu-divider {
+  height: 1px;
+  background: var(--ds-landing-border-muted);
 }

--- a/frontend/src/app/landing/public-header.ts
+++ b/frontend/src/app/landing/public-header.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, output, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 @Component({
@@ -20,7 +20,26 @@ import { RouterLink } from '@angular/router';
           <a class="btn-get-started" routerLink="/login">Get Started</a>
         </div>
       </div>
+      <button
+        class="hamburger"
+        aria-label="Toggle menu"
+        [attr.aria-expanded]="menuOpen()"
+        (click)="menuOpen.set(!menuOpen())"
+      >
+        <span class="hamburger-line"></span>
+        <span class="hamburger-line"></span>
+        <span class="hamburger-line"></span>
+      </button>
     </header>
+    @if (menuOpen()) {
+      <nav class="mobile-menu">
+        <a (click)="featuresClick.emit(); menuOpen.set(false)">Features</a>
+        <a>Pricing</a>
+        <div class="mobile-menu-divider"></div>
+        <a class="btn-login" routerLink="/login">Login</a>
+        <a class="btn-get-started" routerLink="/login">Get Started</a>
+      </nav>
+    }
   `,
   styleUrl: './public-header.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -28,4 +47,5 @@ import { RouterLink } from '@angular/router';
 export class PublicHeaderComponent {
   logoClick = output<void>();
   featuresClick = output<void>();
+  menuOpen = signal(false);
 }

--- a/frontend/src/app/legal/legal.scss
+++ b/frontend/src/app/legal/legal.scss
@@ -9,6 +9,7 @@
   flex-direction: column;
   min-height: 100vh;
   background: var(--ds-landing-bg-end);
+  overflow-x: hidden;
 }
 
 // ── Header area with dark gradient ──
@@ -38,6 +39,7 @@
   width: 100%;
   margin: 0 auto;
   padding: var(--ds-spacing-12) var(--ds-spacing-20);
+  box-sizing: border-box;
 
   @include ds.bp-down(md) {
     padding: var(--ds-spacing-8) var(--ds-spacing-6);


### PR DESCRIPTION
## Summary
- Add hamburger menu to public header on mobile (< 960px), toggling nav links + Login/Get Started buttons
- Hide desktop header nav and buttons on mobile, replaced by the hamburger dropdown
- Prevent horizontal overflow on landing page and legal pages at mobile viewports
- Fix `box-sizing` on legal page content area to prevent text clipping with padding

Closes #87

## Test plan
- [x] Header collapses into hamburger menu on small screens
- [x] Hamburger opens/closes mobile menu with Features, Pricing, Login, Get Started
- [x] Hero heading scales down, CTA buttons stack vertically on mobile
- [x] Features section single-column layout on mobile
- [x] Footer stacks items vertically on mobile
- [x] No horizontal scrolling at 375px, 390px, 414px viewports
- [x] Legal pages (Terms, Privacy) responsive via shared layout
- [x] Desktop layout unchanged — nav links/buttons visible, no hamburger
- [x] Playwright screenshots taken at all viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)