### PR TITLE
Add testing conventions to CLAUDE.md

### DIFF
--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -75,3 +75,13 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 - `CORS_ALLOWED_ORIGINS` — comma-separated (default: `http://localhost:4200`)
 - `DEV_AUTH` — `true` for form login, `false` for Firebase JWT
 - `FIREBASE_PROJECT_ID` — default: `dance-school-ch`
+
+## Testing
+
+**When to write tests:**
+- New API endpoints — integration test (`@SpringBootTest` + `MockMvc`) covering happy path, validation errors, and auth requirements
+- Domain logic in services with business rules beyond simple CRUD
+- Custom `@Query` methods
+- Tenant isolation — only when an endpoint accepts an ID/parameter that could reference another tenant's data. `/me` pattern endpoints are isolated by design.
+
+**Style:** Integration tests over unit tests. Real Spring context, real database. Match existing pattern (`@SpringBootTest` + `MockMvc` + `EntityManager` for setup).

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -87,6 +87,10 @@ Custom design tokens (`--ds-*`) extend Material's system tokens (`--mat-sys-*`).
 4. **Breakpoints:** MUST use mixins `@include ds.bp-up(md)`, `ds.bp-down(sm)`, `ds.bp-between(sm, lg)`. No hardcoded `@media` queries.
 5. **Transitions:** MUST use `--ds-duration-*` and `--ds-easing-*` tokens. No hardcoded durations or easing functions.
 
+## Testing
+
+No unit test convention for now. Components are thin Material wrappers. Visual verification via Playwright covers rendering regressions. Revisit when complexity in frontend grows.
+
 ## Angular Rules
 
 Before writing or modifying Angular code, always call Angular MCP `get_best_practices` (with `workspacePath`) and `list_projects`. Follow those rules — they are version-specific and authoritative.


### PR DESCRIPTION
## Summary
- Add testing strategy section to `backend/src/CLAUDE.md`: when to write integration tests (new endpoints, domain logic, custom queries, tenant isolation for non-`/me` endpoints) and preferred style
- Add testing note to `frontend/CLAUDE.md`: no unit test convention for now, revisit when complexity grows

## Test plan
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)