### PR TITLE
Add SEO meta tags for landing page (#88)

### DIFF
--- a/frontend/src/app/landing/landing.ts
+++ b/frontend/src/app/landing/landing.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, ElementRef, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, viewChild } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
 import { PublicHeaderComponent } from './public-header';
 import { PublicFooterComponent } from './public-footer';
@@ -12,6 +13,10 @@ import { PublicFooterComponent } from './public-footer';
 })
 export class LandingComponent {
   private pageTop = viewChild<ElementRef>('pageTop');
+
+  constructor() {
+    inject(Title).setTitle('DanceStudio — Simplify Your Studio, Amplify Your Passion');
+  }
 
   scrollToTop(): void {
     this.pageTop()?.nativeElement.scrollIntoView({ behavior: 'smooth' });

--- a/frontend/src/app/legal/privacy.ts
+++ b/frontend/src/app/legal/privacy.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { PublicHeaderComponent } from '../landing/public-header';
 import { PublicFooterComponent } from '../landing/public-footer';
@@ -12,6 +13,10 @@ import { PublicFooterComponent } from '../landing/public-footer';
 })
 export class PrivacyComponent {
   private router = inject(Router);
+
+  constructor() {
+    inject(Title).setTitle('Privacy Policy — DanceStudio');
+  }
 
   navigateHome(): void {
     this.router.navigate(['/']);

--- a/frontend/src/app/legal/terms.ts
+++ b/frontend/src/app/legal/terms.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { PublicHeaderComponent } from '../landing/public-header';
 import { PublicFooterComponent } from '../landing/public-footer';
@@ -12,6 +13,10 @@ import { PublicFooterComponent } from '../landing/public-footer';
 })
 export class TermsComponent {
   private router = inject(Router);
+
+  constructor() {
+    inject(Title).setTitle('Terms of Service — DanceStudio');
+  }
 
   navigateHome(): void {
     this.router.navigate(['/']);

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,9 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Frontend</title>
+    <title>DanceStudio — Simplify Your Studio, Amplify Your Passion</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="The #1 app for managing your dance school. Student management, scheduling, analytics, and more." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="DanceStudio — Simplify Your Studio, Amplify Your Passion" />
+    <meta property="og:description" content="The #1 app for managing your dance school. Student management, scheduling, analytics, and more." />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- Set page title: "DanceStudio — Simplify Your Studio, Amplify Your Passion"
- Add meta description for search engine snippets
- Add Open Graph tags (`og:type`, `og:title`, `og:description`) for social media link previews
- Set page-specific titles on Terms ("Terms of Service — DanceStudio") and Privacy ("Privacy Policy — DanceStudio") pages

Closes #88

## Test plan
- [x] Page title shows correctly in browser tab for `/`, `/terms`, `/privacy`
- [x] Meta tags render in built `index.html` source
- [x] Build passes, tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)