### PR TITLE
Architecture review: fix footer logo token (#89)

### DIFF
--- a/frontend/src/app/landing/public-footer.scss
+++ b/frontend/src/app/landing/public-footer.scss
@@ -34,8 +34,8 @@
 }
 
 .logo-icon {
-  width: 28px;
-  height: 28px;
+  width: var(--ds-spacing-8);
+  height: var(--ds-spacing-8);
   border-radius: var(--ds-radius-full);
   background: var(--ds-landing-logo-accent);
 }


### PR DESCRIPTION
## Summary
- Fix footer logo using hardcoded `28px` instead of `var(--ds-spacing-8)` — now consistent with header logo
- Architecture review completed: no critical issues found, documented future improvements in the issue

Closes #89

## Test plan
- [x] Build passes
- [x] Footer logo renders at correct size (32px, same as header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)