### PR TITLE
Restructure sidebar nav with collapsible My School and sub-items (#120)

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -48,7 +48,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "6kB",
-                  "maximumError": "12kB"
+                  "maximumError": "14kB"
                 }
               ],
               "outputHashing": "all",

--- a/frontend/src/app/shell/shell.html
+++ b/frontend/src/app/shell/shell.html
@@ -18,17 +18,50 @@
 
     <!-- Navigation -->
     <mat-nav-list class="sidenav-nav">
-      @for (item of navItems; track item.route) {
-        <a
-          mat-list-item
-          [routerLink]="item.route"
-          routerLinkActive="nav-active"
-          class="nav-item"
-          (click)="closeMobileSidenav()"
-        >
-          <mat-icon matListItemIcon>{{ item.icon }}</mat-icon>
-          <span matListItemTitle>{{ item.label }}</span>
-        </a>
+      @for (item of navItems; track item.label) {
+        @if (item.children) {
+          <!-- Collapsible section -->
+          <div class="nav-section" [class.section-active]="isChildRouteActive(item)">
+            <button
+              mat-list-item
+              class="nav-item nav-parent"
+              (click)="toggleSection()"
+            >
+              <mat-icon matListItemIcon>{{ item.icon }}</mat-icon>
+              <span matListItemTitle>{{ item.label }}</span>
+              <mat-icon class="nav-chevron" [class.chevron-expanded]="mySchoolExpanded()">expand_more</mat-icon>
+            </button>
+
+            @if (mySchoolExpanded()) {
+              <div class="nav-children">
+                @for (child of item.children; track child.route) {
+                  <a
+                    mat-list-item
+                    [routerLink]="child.route"
+                    routerLinkActive="nav-child-active"
+                    class="nav-child"
+                    (click)="closeMobileSidenav()"
+                  >
+                    <span class="nav-child-dot"></span>
+                    <span>{{ child.label }}</span>
+                  </a>
+                }
+              </div>
+            }
+          </div>
+        } @else {
+          <!-- Simple nav item -->
+          <a
+            mat-list-item
+            [routerLink]="item.route"
+            routerLinkActive="nav-active"
+            class="nav-item"
+            (click)="closeMobileSidenav()"
+          >
+            <mat-icon matListItemIcon>{{ item.icon }}</mat-icon>
+            <span matListItemTitle>{{ item.label }}</span>
+          </a>
+        }
       }
     </mat-nav-list>
   </mat-sidenav>

--- a/frontend/src/app/shell/shell.scss
+++ b/frontend/src/app/shell/shell.scss
@@ -36,10 +36,12 @@
 }
 
 // Nav
-.sidenav-nav { padding: var(--ds-spacing-3) var(--ds-spacing-4); }
+.sidenav-nav {
+  padding: var(--ds-spacing-3) var(--ds-spacing-4);
+}
 
 .nav-item {
-  border-radius: var(--ds-spacing-2) !important;
+  border-radius: var(--ds-radius-md) !important;
   margin-bottom: var(--ds-spacing-1);
   &.nav-active {
     background: var(--mat-sys-primary) !important;
@@ -48,6 +50,68 @@
   }
   mat-icon { color: var(--mat-sys-on-surface-variant); opacity: 0.6; }
   span[matListItemTitle] { font: var(--mat-sys-label-large); color: var(--mat-sys-on-surface); }
+}
+
+// Collapsible section
+.nav-section {
+  &.section-active > .nav-parent {
+    mat-icon:first-of-type { opacity: 1; }
+  }
+}
+
+.nav-parent {
+  cursor: pointer;
+}
+
+.nav-chevron {
+  transition: transform var(--ds-duration-fast) var(--ds-easing-standard);
+  opacity: 0.5 !important;
+  font-size: var(--ds-spacing-4) !important;
+  width: var(--ds-spacing-4) !important;
+  height: var(--ds-spacing-4) !important;
+
+  &.chevron-expanded {
+    transform: rotate(180deg);
+  }
+}
+
+// Sub-items
+.nav-children {
+  padding-top: var(--ds-spacing-half);
+}
+
+.nav-child {
+  // 44px = 12px parent padding + 20px icon + 12px gap
+  padding-left: calc(var(--ds-spacing-3) + var(--ds-spacing-5) + var(--ds-spacing-3)) !important;
+  padding-right: var(--ds-spacing-3) !important;
+  border-radius: var(--ds-radius-md) !important;
+  height: var(--ds-spacing-10) !important;
+
+  span:not(.nav-child-dot) {
+    font: var(--mat-sys-body-small);
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  &.nav-child-active {
+    span:not(.nav-child-dot) {
+      color: var(--mat-sys-primary);
+      font-weight: 600;
+    }
+    .nav-child-dot {
+      background: var(--mat-sys-primary);
+      opacity: 0.8;
+    }
+  }
+}
+
+.nav-child-dot {
+  width: var(--ds-spacing-1-5);
+  height: var(--ds-spacing-1-5);
+  border-radius: var(--ds-radius-sm);
+  background: var(--mat-sys-on-surface-variant);
+  opacity: 0.4;
+  flex-shrink: 0;
+  margin-right: var(--ds-spacing-3);
 }
 
 // Toolbar

--- a/frontend/src/app/shell/shell.ts
+++ b/frontend/src/app/shell/shell.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -9,10 +9,16 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { AuthService } from '../shared/auth/auth.service';
 
+interface NavChild {
+  label: string;
+  route: string;
+}
+
 interface NavItem {
   label: string;
   icon: string;
-  route: string;
+  route?: string;
+  children?: NavChild[];
 }
 
 @Component({
@@ -35,16 +41,25 @@ export class ShellComponent {
   protected auth = inject(AuthService);
   protected user = this.auth.user;
 
+  private router = inject(Router);
   private breakpointObserver = inject(BreakpointObserver);
   private destroyRef = inject(DestroyRef);
   private sidenav = viewChild<MatSidenav>('sidenav');
 
   protected isDesktop = signal(true);
+  protected mySchoolExpanded = signal(true);
 
   protected navItems: NavItem[] = [
     { label: 'Dashboard', icon: 'dashboard', route: '/app/dashboard' },
-    { label: 'Students', icon: 'people', route: '/app/students' },
-    { label: 'My School', icon: 'business', route: '/app/my-school' },
+    {
+      label: 'My School', icon: 'business', children: [
+        { label: 'Profile', route: '/app/my-school' },
+        { label: 'Subscriptions', route: '/app/subscriptions' },
+        { label: 'Students', route: '/app/students' },
+      ],
+    },
+    { label: 'Courses', icon: 'school', route: '/app/courses' },
+    { label: 'Payments', icon: 'payments', route: '/app/payments' },
   ];
 
   constructor() {
@@ -53,6 +68,20 @@ export class ShellComponent {
     ).subscribe(result => {
       this.isDesktop.set(result.matches);
     });
+  }
+
+  protected toggleSection(): void {
+    this.mySchoolExpanded.update(v => !v);
+  }
+
+  protected isChildRouteActive(item: NavItem): boolean {
+    if (!item.children) return false;
+    return item.children.some(child => this.router.isActive(child.route, {
+      paths: 'subset',
+      queryParams: 'subset',
+      fragment: 'ignored',
+      matrixParams: 'ignored',
+    }));
   }
 
   protected closeMobileSidenav(): void {

--- a/frontend/src/styles/_tokens.scss
+++ b/frontend/src/styles/_tokens.scss
@@ -4,7 +4,9 @@
 
 :root {
   // ── Spacing scale (4px base) ──
+  --ds-spacing-half: 2px;
   --ds-spacing-1: 4px;
+  --ds-spacing-1-5: 6px;
   --ds-spacing-2: 8px;
   --ds-spacing-3: 12px;
   --ds-spacing-4: 16px;


### PR DESCRIPTION
## Summary
- Restructure sidebar navigation to match Figma design (node `8:27`)
- "My School" becomes a collapsible parent with chevron toggle and 3 sub-items: Profile, Subscriptions, Students
- Add Courses and Payments as new top-level nav entries
- Sub-items styled with dot indicators, indented layout, and active route highlighting
- Add `--ds-spacing-half` (2px) and `--ds-spacing-1-5` (6px) design tokens for sub-item dot sizing
- Bump component style budget from 12kB to 14kB to accommodate expanded shell styles

## Test plan
- [x] Build passes (`ng build`)
- [x] Visual verification: sidebar renders with correct hierarchy
- [x] Sub-item click navigates to correct route (Students → `/app/students`)
- [x] Active sub-item highlighted in primary color
- [x] Collapse/expand toggle hides/shows sub-items with chevron rotation
- [x] Top-level items (Dashboard, Courses, Payments) still work as direct links

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)