### PR TITLE
Add Course entity, API, seed data, and backend tests (#124)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
@@ -1,0 +1,95 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.school.School;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Course {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    private School school;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private DanceStyle danceStyle;
+
+    @Enumerated(EnumType.STRING)
+    private CourseLevel level;
+
+    @Enumerated(EnumType.STRING)
+    private CourseType courseType;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private LocalDate startDate;
+
+    @Enumerated(EnumType.STRING)
+    private RecurrenceType recurrenceType;
+
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    private int numberOfSessions;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    private String location;
+
+    private String teachers;
+
+    private int maxParticipants;
+
+    private boolean waitingListEnabled;
+
+    private String enrollmentOpenDate;
+
+    private String enrollmentCloseDate;
+
+    private boolean requireRoleSelection;
+
+    @Enumerated(EnumType.STRING)
+    private RoleBalancingMode roleBalancingMode;
+
+    private Integer roleBalanceThreshold;
+
+    @Enumerated(EnumType.STRING)
+    private PriceModel priceModel;
+
+    private BigDecimal price;
+
+    @Enumerated(EnumType.STRING)
+    private CourseStatus status;
+
+    private LocalDate publishDate;
+
+    private int enrolledStudents;
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
@@ -1,0 +1,23 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/courses")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+
+    @GetMapping("/me")
+    public List<CourseListDto> me(@AuthenticationPrincipal AuthenticatedUser principal) {
+        return courseService.getCoursesByMember(principal.userId());
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseLevel.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseLevel.java
@@ -1,0 +1,7 @@
+package ch.ruppen.danceschool.course;
+
+public enum CourseLevel {
+    BEGINNER,
+    INTERMEDIATE,
+    ADVANCED
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseListDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseListDto.java
@@ -1,0 +1,21 @@
+package ch.ruppen.danceschool.course;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record CourseListDto(
+        Long id,
+        String title,
+        DanceStyle danceStyle,
+        CourseLevel level,
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime,
+        int numberOfSessions,
+        int enrolledStudents,
+        int maxParticipants,
+        BigDecimal price,
+        CourseStatus status
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
@@ -1,0 +1,10 @@
+package ch.ruppen.danceschool.course;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+interface CourseRepository extends JpaRepository<Course, Long> {
+
+    List<Course> findAllBySchoolId(Long schoolId);
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -1,0 +1,77 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.school.SchoolService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courseRepository;
+    private final SchoolService schoolService;
+
+    public List<CourseListDto> getCoursesByMember(Long userId) {
+        School school = schoolService.findSchoolByMember(userId);
+        return courseRepository.findAllBySchoolId(school.getId()).stream()
+                .map(this::toListDto)
+                .toList();
+    }
+
+    public void seedCourse(Long userId, String title, DanceStyle danceStyle, CourseLevel level,
+                           CourseType courseType, String description, java.time.LocalDate startDate,
+                           RecurrenceType recurrenceType, java.time.DayOfWeek dayOfWeek,
+                           int numberOfSessions, java.time.LocalTime startTime, java.time.LocalTime endTime,
+                           String location, String teachers, int maxParticipants, int enrolledStudents,
+                           PriceModel priceModel, java.math.BigDecimal price, CourseStatus status) {
+        School school = schoolService.findSchoolByMember(userId);
+        Course course = new Course();
+        course.setSchool(school);
+        course.setTitle(title);
+        course.setDanceStyle(danceStyle);
+        course.setLevel(level);
+        course.setCourseType(courseType);
+        course.setDescription(description);
+        course.setStartDate(startDate);
+        course.setRecurrenceType(recurrenceType);
+        course.setDayOfWeek(dayOfWeek);
+        course.setNumberOfSessions(numberOfSessions);
+        course.setStartTime(startTime);
+        course.setEndTime(endTime);
+        course.setLocation(location);
+        course.setTeachers(teachers);
+        course.setMaxParticipants(maxParticipants);
+        course.setEnrolledStudents(enrolledStudents);
+        course.setPriceModel(priceModel);
+        course.setPrice(price);
+        course.setStatus(status);
+        courseRepository.save(course);
+    }
+
+    public boolean hasCoursesForMember(Long userId) {
+        School school = schoolService.findSchoolByMember(userId);
+        return !courseRepository.findAllBySchoolId(school.getId()).isEmpty();
+    }
+
+    private CourseListDto toListDto(Course course) {
+        return new CourseListDto(
+                course.getId(),
+                course.getTitle(),
+                course.getDanceStyle(),
+                course.getLevel(),
+                course.getDayOfWeek(),
+                course.getStartTime(),
+                course.getEndTime(),
+                course.getNumberOfSessions(),
+                course.getEnrolledStudents(),
+                course.getMaxParticipants(),
+                course.getPrice(),
+                course.getStatus()
+        );
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseStatus.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseStatus.java
@@ -1,0 +1,8 @@
+package ch.ruppen.danceschool.course;
+
+public enum CourseStatus {
+    DRAFT,
+    ACTIVE,
+    FULL,
+    INACTIVE
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseType.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseType.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.course;
+
+public enum CourseType {
+    PARTNER,
+    SOLO
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/DanceStyle.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/DanceStyle.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.course;
+
+public enum DanceStyle {
+    SALSA,
+    BACHATA
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/PriceModel.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/PriceModel.java
@@ -1,0 +1,5 @@
+package ch.ruppen.danceschool.course;
+
+public enum PriceModel {
+    FIXED_COURSE
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/RecurrenceType.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/RecurrenceType.java
@@ -1,0 +1,5 @@
+package ch.ruppen.danceschool.course;
+
+public enum RecurrenceType {
+    WEEKLY
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/RoleBalancingMode.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/RoleBalancingMode.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.course;
+
+public enum RoleBalancingMode {
+    WARN,
+    BLOCK
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevDataSeeder.java
@@ -1,5 +1,12 @@
 package ch.ruppen.danceschool.shared.security;
 
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseService;
+import ch.ruppen.danceschool.course.CourseStatus;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.course.PriceModel;
+import ch.ruppen.danceschool.course.RecurrenceType;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.school.SchoolUpdateDto;
 import ch.ruppen.danceschool.user.AppUser;
@@ -11,6 +18,11 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 /**
  * Seeds development users and a school on startup so that local dev login
@@ -26,6 +38,7 @@ public class DevDataSeeder implements ApplicationRunner {
 
     private final UserService userService;
     private final SchoolService schoolService;
+    private final CourseService courseService;
 
     @Override
     @Transactional
@@ -47,6 +60,62 @@ public class DevDataSeeder implements ApplicationRunner {
             schoolService.createSchool(school2Dto, owner2.getId());
         }
 
+        seedCourses(owner, owner2);
+
         log.info("Dev data seeded: owner@test.com (School 1), owner2@test.com (School 2)");
+    }
+
+    private void seedCourses(AppUser owner, AppUser owner2) {
+        if (!courseService.hasCoursesForMember(owner.getId())) {
+            courseService.seedCourse(owner.getId(),
+                    "Salsa, Merengue, Bachata Solo", DanceStyle.SALSA, CourseLevel.BEGINNER,
+                    CourseType.SOLO, "Learn the basics of Salsa, Merengue, and Bachata in solo style.",
+                    LocalDate.of(2026, 4, 10), RecurrenceType.WEEKLY, DayOfWeek.FRIDAY,
+                    6, LocalTime.of(19, 30), LocalTime.of(20, 45),
+                    "Studio A", "Maria", 12, 8,
+                    PriceModel.FIXED_COURSE, new BigDecimal("166.50"), CourseStatus.ACTIVE);
+
+            courseService.seedCourse(owner.getId(),
+                    "Bachata Intermediate", DanceStyle.BACHATA, CourseLevel.INTERMEDIATE,
+                    CourseType.PARTNER, "Take your Bachata to the next level with partner work and musicality.",
+                    LocalDate.of(2026, 4, 7), RecurrenceType.WEEKLY, DayOfWeek.TUESDAY,
+                    8, LocalTime.of(19, 0), LocalTime.of(20, 0),
+                    "Studio B", "Carlos", 15, 12,
+                    PriceModel.FIXED_COURSE, new BigDecimal("220.00"), CourseStatus.ACTIVE);
+
+            courseService.seedCourse(owner.getId(),
+                    "Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED,
+                    CourseType.PARTNER, "Advanced Salsa patterns, styling, and performance preparation.",
+                    LocalDate.of(2026, 4, 8), RecurrenceType.WEEKLY, DayOfWeek.WEDNESDAY,
+                    10, LocalTime.of(20, 0), LocalTime.of(21, 15),
+                    "Studio A", "Maria, Carlos", 10, 10,
+                    PriceModel.FIXED_COURSE, new BigDecimal("310.00"), CourseStatus.FULL);
+
+            courseService.seedCourse(owner.getId(),
+                    "Bachata Beginners", DanceStyle.BACHATA, CourseLevel.BEGINNER,
+                    CourseType.PARTNER, "Start your Bachata journey with the fundamentals of partner dancing.",
+                    LocalDate.of(2026, 4, 6), RecurrenceType.WEEKLY, DayOfWeek.MONDAY,
+                    6, LocalTime.of(18, 30), LocalTime.of(19, 45),
+                    "Studio B", "Carlos", 16, 14,
+                    PriceModel.FIXED_COURSE, new BigDecimal("166.50"), CourseStatus.ACTIVE);
+        }
+
+        if (!courseService.hasCoursesForMember(owner2.getId())) {
+            courseService.seedCourse(owner2.getId(),
+                    "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
+                    CourseType.PARTNER, "Introduction to Salsa for complete beginners.",
+                    LocalDate.of(2026, 4, 9), RecurrenceType.WEEKLY, DayOfWeek.THURSDAY,
+                    8, LocalTime.of(18, 0), LocalTime.of(19, 0),
+                    "Main Hall", "Ana", 20, 5,
+                    PriceModel.FIXED_COURSE, new BigDecimal("180.00"), CourseStatus.ACTIVE);
+
+            courseService.seedCourse(owner2.getId(),
+                    "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
+                    CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
+                    LocalDate.of(2026, 4, 11), RecurrenceType.WEEKLY, DayOfWeek.SATURDAY,
+                    6, LocalTime.of(14, 0), LocalTime.of(15, 30),
+                    "Main Hall", "Ana, Luis", 12, 8,
+                    PriceModel.FIXED_COURSE, new BigDecimal("200.00"), CourseStatus.ACTIVE);
+        }
     }
 }

--- a/backend/src/main/resources/db/changelog/009-create-course.yaml
+++ b/backend/src/main/resources/db/changelog/009-create-course.yaml
@@ -1,0 +1,140 @@
+databaseChangeLog:
+  - changeSet:
+      id: 009-create-course
+      author: claude
+      changes:
+        - createTable:
+            tableName: course
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: school_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: title
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dance_style
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: level
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: course_type
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: TEXT
+              - column:
+                  name: start_date
+                  type: DATE
+                  constraints:
+                    nullable: false
+              - column:
+                  name: recurrence_type
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: day_of_week
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: number_of_sessions
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: end_time
+                  type: TIME
+                  constraints:
+                    nullable: false
+              - column:
+                  name: location
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: teachers
+                  type: VARCHAR(255)
+              - column:
+                  name: max_participants
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: waiting_list_enabled
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: enrollment_open_date
+                  type: VARCHAR(255)
+              - column:
+                  name: enrollment_close_date
+                  type: VARCHAR(255)
+              - column:
+                  name: require_role_selection
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+              - column:
+                  name: role_balancing_mode
+                  type: VARCHAR(50)
+              - column:
+                  name: role_balance_threshold
+                  type: INT
+              - column:
+                  name: price_model
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: price
+                  type: DECIMAL(10,2)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: publish_date
+                  type: DATE
+              - column:
+                  name: enrolled_students
+                  type: INT
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: course
+            baseColumnNames: school_id
+            referencedTableName: school
+            referencedColumnNames: id
+            constraintName: fk_course_school

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -15,3 +15,5 @@ databaseChangeLog:
       file: db/changelog/007-structured-address.yaml
   - include:
       file: db/changelog/008-rename-user-role-to-teacher.yaml
+  - include:
+      file: db/changelog/009-create-course.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
@@ -1,0 +1,169 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class CourseControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser testUser;
+    private School school;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createUser("test@example.com", "Test User", "firebase-test");
+        school = createSchoolWithOwner("Test Dance School", testUser);
+        entityManager.flush();
+    }
+
+    @Test
+    void getMe_returnsCourses_whenUserHasCourses() throws Exception {
+        createCourse(school, "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
+                DayOfWeek.MONDAY, LocalTime.of(19, 0), LocalTime.of(20, 0),
+                8, 5, 15, new BigDecimal("180.00"), CourseStatus.ACTIVE);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].title").value("Salsa Beginners"))
+                .andExpect(jsonPath("$[0].danceStyle").value("SALSA"))
+                .andExpect(jsonPath("$[0].level").value("BEGINNER"))
+                .andExpect(jsonPath("$[0].dayOfWeek").value("MONDAY"))
+                .andExpect(jsonPath("$[0].startTime").value("19:00:00"))
+                .andExpect(jsonPath("$[0].endTime").value("20:00:00"))
+                .andExpect(jsonPath("$[0].numberOfSessions").value(8))
+                .andExpect(jsonPath("$[0].enrolledStudents").value(5))
+                .andExpect(jsonPath("$[0].maxParticipants").value(15))
+                .andExpect(jsonPath("$[0].price").value(180.00))
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"));
+    }
+
+    @Test
+    void getMe_returnsEmptyList_whenNoCourses() throws Exception {
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void getMe_returnsMultipleCourses() throws Exception {
+        createCourse(school, "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
+                DayOfWeek.MONDAY, LocalTime.of(19, 0), LocalTime.of(20, 0),
+                8, 5, 15, new BigDecimal("180.00"), CourseStatus.ACTIVE);
+        createCourse(school, "Bachata Advanced", DanceStyle.BACHATA, CourseLevel.ADVANCED,
+                DayOfWeek.WEDNESDAY, LocalTime.of(20, 0), LocalTime.of(21, 15),
+                10, 10, 10, new BigDecimal("310.00"), CourseStatus.FULL);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    void getMe_returns404_whenUserHasNoSchool() throws Exception {
+        AppUser orphan = createUser("orphan@example.com", "Orphan", "firebase-orphan");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(orphan))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getMe_returnsUnauthorized_whenNotAuthenticated() throws Exception {
+        mockMvc.perform(get("/api/courses/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser owner) {
+        School s = new School();
+        s.setName(name);
+        entityManager.persist(s);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(owner);
+        member.setSchool(s);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return s;
+    }
+
+    private void createCourse(School s, String title, DanceStyle danceStyle, CourseLevel level,
+                              DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime,
+                              int sessions, int enrolled, int max, BigDecimal price, CourseStatus status) {
+        Course course = new Course();
+        course.setSchool(s);
+        course.setTitle(title);
+        course.setDanceStyle(danceStyle);
+        course.setLevel(level);
+        course.setCourseType(CourseType.PARTNER);
+        course.setStartDate(LocalDate.of(2026, 4, 7));
+        course.setRecurrenceType(RecurrenceType.WEEKLY);
+        course.setDayOfWeek(dayOfWeek);
+        course.setNumberOfSessions(sessions);
+        course.setStartTime(startTime);
+        course.setEndTime(endTime);
+        course.setLocation("Studio A");
+        course.setMaxParticipants(max);
+        course.setEnrolledStudents(enrolled);
+        course.setPriceModel(PriceModel.FIXED_COURSE);
+        course.setPrice(price);
+        course.setStatus(status);
+        entityManager.persist(course);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
@@ -1,0 +1,152 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class CourseTenantIsolationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser userA;
+    private AppUser userB;
+    private School schoolA;
+    private School schoolB;
+
+    @BeforeEach
+    void setUp() {
+        userA = createUser("user-a@example.com", "User A", "firebase-a");
+        userB = createUser("user-b@example.com", "User B", "firebase-b");
+
+        schoolA = createSchoolWithOwner("School A", userA);
+        schoolB = createSchoolWithOwner("School B", userB);
+
+        createCourse(schoolA, "School A - Salsa");
+        createCourse(schoolA, "School A - Bachata");
+        createCourse(schoolB, "School B - Salsa");
+
+        entityManager.flush();
+    }
+
+    @Test
+    void getMe_returnsOnlyOwnSchoolCourses() throws Exception {
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(userA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].title").value("School A - Salsa"))
+                .andExpect(jsonPath("$[1].title").value("School A - Bachata"));
+
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(userB))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].title").value("School B - Salsa"));
+    }
+
+    @Test
+    void getMe_coOwnerSeesSchoolCourses() throws Exception {
+        AppUser coOwner = createUser("co-owner@example.com", "Co-Owner", "firebase-co");
+        addOwner(schoolA, coOwner);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(coOwner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    void getMe_returns404_forUserWithNoSchool() throws Exception {
+        AppUser orphan = createUser("orphan@example.com", "Orphan", "firebase-orphan");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(authToken(orphan))))
+                .andExpect(status().isNotFound());
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser owner) {
+        School school = new School();
+        school.setName(name);
+        entityManager.persist(school);
+        addOwner(school, owner);
+        return school;
+    }
+
+    private void addOwner(School school, AppUser owner) {
+        SchoolMember member = new SchoolMember();
+        member.setUser(owner);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+    }
+
+    private void createCourse(School school, String title) {
+        Course course = new Course();
+        course.setSchool(school);
+        course.setTitle(title);
+        course.setDanceStyle(DanceStyle.SALSA);
+        course.setLevel(CourseLevel.BEGINNER);
+        course.setCourseType(CourseType.PARTNER);
+        course.setStartDate(LocalDate.of(2026, 4, 7));
+        course.setRecurrenceType(RecurrenceType.WEEKLY);
+        course.setDayOfWeek(DayOfWeek.MONDAY);
+        course.setNumberOfSessions(8);
+        course.setStartTime(LocalTime.of(19, 0));
+        course.setEndTime(LocalTime.of(20, 0));
+        course.setLocation("Studio A");
+        course.setMaxParticipants(15);
+        course.setPriceModel(PriceModel.FIXED_COURSE);
+        course.setPrice(new BigDecimal("180.00"));
+        course.setStatus(CourseStatus.ACTIVE);
+        entityManager.persist(course);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -3,3 +3,10 @@
 - Public URL on R2 Cloudflare S3 Bucket
 - String config for Enums
 - Proper ControllerAdvice
+
+## Course Domain
+
+- **Teachers field** — `Course.teachers` is a plain String (e.g. "Maria, Carlos"). Needs to become a `@ManyToMany` relation to `SchoolMember` (role=TEACHER) when teacher signup/invite flow is built.
+- **Enrollment counts** — `Course.enrolledStudents` is a stored integer, seeded with sample data. Needs to be computed from actual enrollment records when student enrollment is built.
+- **Server-side pagination** — all table endpoints currently return the full list. Payments table will need backend `Pageable` support as transaction volume grows (rule of thumb: >500 rows).
+- **Mobile table layout** — tables are desktop-only. Needs a design decision (horizontal scroll, card layout, or hidden columns) before mobile support.


### PR DESCRIPTION
## Summary
- Add Course entity with all PRD fields (7 enums: DanceStyle, CourseLevel, CourseType, CourseStatus, PriceModel, RecurrenceType, RoleBalancingMode)
- Add Liquibase migration (009-create-course.yaml) with FK to school
- Add `GET /api/courses/me` endpoint with tenant isolation via SchoolService.findSchoolByMember
- Seed 4 courses for School 1 and 2 for School 2 in DevDataSeeder
- Add integration tests: API contract (5 tests) + tenant isolation (3 tests)
- Document tech debt in docs/TECH_DEBT.md (teachers as String, hardcoded enrollment, pagination, mobile tables)

Closes #124

## Test plan
- [x] All 53 backend tests pass (including 8 new course tests)
- [x] Tenant isolation verified: two users see only their own school's courses
- [x] API contract verified: response shape matches CourseListDto fields
- [x] No UI changes — backend only, visual testing skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)