### PR TITLE
Add Courses page with mat-table, service, and empty state (#125)

### DIFF
--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface CourseListItem {
+  id: number;
+  title: string;
+  danceStyle: 'SALSA' | 'BACHATA';
+  level: 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+  numberOfSessions: number;
+  enrolledStudents: number;
+  maxParticipants: number;
+  price: number;
+  status: 'DRAFT' | 'ACTIVE' | 'FULL' | 'INACTIVE';
+}
+
+@Injectable({ providedIn: 'root' })
+export class CourseService {
+  private http = inject(HttpClient);
+
+  getCourses(): Observable<CourseListItem[]> {
+    return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`);
+  }
+}

--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -1,0 +1,97 @@
+@if (loaded() && !error()) {
+  <!-- Page Header -->
+  <div class="page-header">
+    <div class="title-group">
+      <h1 class="page-title">Courses</h1>
+      <p class="page-subtitle">Manage your dance school courses</p>
+    </div>
+    <button mat-flat-button disabled>
+      <mat-icon>add</mat-icon>
+      Add Course
+    </button>
+  </div>
+
+  @if (courses().length > 0) {
+    <!-- Table Card -->
+    <div class="card">
+      <table mat-table [dataSource]="courses()">
+        <!-- Course Name -->
+        <ng-container matColumnDef="title">
+          <th mat-header-cell *matHeaderCellDef>Course Name</th>
+          <td mat-cell *matCellDef="let course">{{ course.title }}</td>
+        </ng-container>
+
+        <!-- Type (Dance Style) -->
+        <ng-container matColumnDef="danceStyle">
+          <th mat-header-cell *matHeaderCellDef>Type</th>
+          <td mat-cell *matCellDef="let course">
+            <span class="chip" [class]="danceStyleChipClass(course.danceStyle)">
+              {{ course.danceStyle | titlecase }}
+            </span>
+          </td>
+        </ng-container>
+
+        <!-- Level -->
+        <ng-container matColumnDef="level">
+          <th mat-header-cell *matHeaderCellDef>Level</th>
+          <td mat-cell *matCellDef="let course">{{ course.level | titlecase }}</td>
+        </ng-container>
+
+        <!-- Schedule -->
+        <ng-container matColumnDef="schedule">
+          <th mat-header-cell *matHeaderCellDef>Schedule</th>
+          <td mat-cell *matCellDef="let course">
+            <div class="cell-primary">{{ formatDay(course.dayOfWeek) }} {{ formatTime(course.startTime) }}–{{ formatTime(course.endTime) }}</div>
+            <div class="cell-secondary">{{ course.numberOfSessions }} sessions</div>
+          </td>
+        </ng-container>
+
+        <!-- Enrollment -->
+        <ng-container matColumnDef="enrollment">
+          <th mat-header-cell *matHeaderCellDef>Enrollment</th>
+          <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }}/{{ course.maxParticipants }}</td>
+        </ng-container>
+
+        <!-- Price -->
+        <ng-container matColumnDef="price">
+          <th mat-header-cell *matHeaderCellDef>Price</th>
+          <td mat-cell *matCellDef="let course">{{ course.price | currency:'EUR' }}</td>
+        </ng-container>
+
+        <!-- Status -->
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let course">
+            <span class="chip" [class]="statusChipClass(course.status)">
+              {{ course.status | titlecase }}
+            </span>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+
+      <div class="table-footer">
+        Showing {{ courses().length }} of {{ courses().length }} courses
+      </div>
+    </div>
+  } @else {
+    <!-- Empty State -->
+    <div class="empty-state">
+      <mat-icon class="empty-state-icon">school</mat-icon>
+      <h2 class="empty-state-title">No courses yet</h2>
+      <p class="empty-state-text">Create your first course to start managing your dance school schedule.</p>
+      <button mat-flat-button disabled>
+        <mat-icon>add</mat-icon>
+        Add Course
+      </button>
+    </div>
+  }
+} @else if (error()) {
+  <p class="error-text">Could not load courses. Please try again later.</p>
+} @else {
+  <div class="loading">
+    <p>Loading courses...</p>
+  </div>
+}

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -1,0 +1,139 @@
+@use 'styles/mixins' as ds;
+
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-card-padding);
+}
+
+// Card pattern
+.card {
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+  overflow: hidden;
+}
+
+// Page header
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.title-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+}
+
+.page-title {
+  font: var(--mat-sys-headline-small);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.page-subtitle {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}
+
+// Chip styles
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--ds-spacing-1) var(--ds-spacing-3);
+  border-radius: var(--ds-radius-md);
+  font: var(--mat-sys-label-medium);
+}
+
+.chip-success {
+  background: var(--ds-color-success-container);
+  color: var(--ds-color-success);
+}
+
+.chip-primary {
+  background: var(--mat-sys-primary-container);
+  color: var(--mat-sys-primary);
+}
+
+.chip-info {
+  background: var(--ds-color-info-container);
+  color: var(--ds-color-info);
+}
+
+.chip-default {
+  background: var(--mat-sys-surface-variant);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+// Multi-line cell
+.cell-primary {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface);
+}
+
+.cell-secondary {
+  font: var(--mat-sys-body-small);
+  color: var(--mat-sys-on-surface-variant);
+  margin-top: var(--ds-spacing-half);
+}
+
+// Table footer
+.table-footer {
+  padding: var(--ds-spacing-3) var(--ds-card-padding);
+  font: var(--mat-sys-body-small);
+  color: var(--mat-sys-on-surface-variant);
+  border-top: 1px solid var(--mat-sys-outline-variant);
+}
+
+// Empty state
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--ds-spacing-12) var(--ds-spacing-6);
+}
+
+.empty-state-icon {
+  font-size: var(--ds-spacing-16);
+  width: var(--ds-spacing-16);
+  height: var(--ds-spacing-16);
+  color: var(--mat-sys-on-surface-variant);
+  margin-bottom: var(--ds-spacing-4);
+}
+
+.empty-state-title {
+  font: var(--mat-sys-headline-small);
+  color: var(--mat-sys-on-surface);
+  margin: 0 0 var(--ds-spacing-2);
+}
+
+.empty-state-text {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0 0 var(--ds-spacing-6);
+  max-width: 400px;
+}
+
+// Loading / error states
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: var(--ds-spacing-12);
+
+  p {
+    font: var(--mat-sys-body-large);
+    color: var(--mat-sys-on-surface-variant);
+  }
+}
+
+.error-text {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-error);
+  text-align: center;
+  padding: var(--ds-spacing-12);
+}

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -1,36 +1,70 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CurrencyPipe, TitleCasePipe } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { CourseListItem, CourseService } from './course.service';
 
 @Component({
   selector: 'app-courses',
-  imports: [MatIconModule],
-  template: `
-    <div class="placeholder">
-      <mat-icon class="placeholder-icon">construction</mat-icon>
-      <h2>Courses</h2>
-      <p>Coming soon!</p>
-    </div>
-  `,
-  styles: `
-    .placeholder {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      min-height: var(--ds-spacing-24);
-      color: var(--mat-sys-on-surface-variant);
-      text-align: center;
-    }
-    .placeholder-icon {
-      font-size: var(--ds-spacing-12);
-      width: var(--ds-spacing-12);
-      height: var(--ds-spacing-12);
-      margin-bottom: var(--ds-spacing-4);
-      opacity: 0.4;
-    }
-    h2 { font: var(--mat-sys-headline-small); color: var(--mat-sys-on-surface); margin: 0 0 var(--ds-spacing-2); }
-    p { font: var(--mat-sys-body-large); margin: 0; }
-  `,
+  imports: [MatTableModule, MatIconModule, MatButtonModule, CurrencyPipe, TitleCasePipe],
+  templateUrl: './courses.html',
+  styleUrl: './courses.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CoursesComponent {}
+export class CoursesComponent implements OnInit {
+  private courseService = inject(CourseService);
+  private destroyRef = inject(DestroyRef);
+
+  protected courses = signal<CourseListItem[]>([]);
+  protected loaded = signal(false);
+  protected error = signal(false);
+
+  protected displayedColumns = [
+    'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'price', 'status',
+  ];
+
+  ngOnInit(): void {
+    this.courseService.getCourses().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (courses) => {
+        this.courses.set(courses);
+        this.loaded.set(true);
+      },
+      error: () => {
+        this.error.set(true);
+        this.loaded.set(true);
+      },
+    });
+  }
+
+  protected formatDay(dayOfWeek: string): string {
+    const days: Record<string, string> = {
+      MONDAY: 'Mon', TUESDAY: 'Tue', WEDNESDAY: 'Wed',
+      THURSDAY: 'Thu', FRIDAY: 'Fri', SATURDAY: 'Sat', SUNDAY: 'Sun',
+    };
+    return days[dayOfWeek] ?? dayOfWeek;
+  }
+
+  protected formatTime(time: string): string {
+    return time.substring(0, 5);
+  }
+
+  protected statusChipClass(status: string): string {
+    switch (status) {
+      case 'ACTIVE': return 'chip-success';
+      case 'FULL': return 'chip-info';
+      case 'DRAFT': return 'chip-default';
+      case 'INACTIVE': return 'chip-default';
+      default: return 'chip-default';
+    }
+  }
+
+  protected danceStyleChipClass(style: string): string {
+    switch (style) {
+      case 'BACHATA': return 'chip-primary';
+      case 'SALSA': return 'chip-info';
+      default: return 'chip-default';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `CourseService` calling `GET /api/courses/me`
- Replace placeholder `CoursesComponent` with full `mat-table` showing 7 columns: Course Name, Type (chip), Level, Schedule (multi-line), Enrollment, Price, Status (chip)
- Add empty state with icon and message when no courses exist
- Page header with "Courses" title, subtitle, and disabled "Add Course" button

Closes #125

## Test plan
- [x] Frontend builds successfully
- [x] Visual verification: logged in as Owner 1, navigated to `/app/courses`, screenshot confirms 4 courses display correctly with chips, multi-line schedule, enrollment counts, pricing, and status
- [x] Sidebar "Courses" link navigates correctly and shows active state

🤖 Generated with [Claude Code](https://claude.com/claude-code)