### PR TITLE
Remove enrollmentOpenDate and enrollmentCloseDate from Course entity (#133)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
@@ -70,10 +70,6 @@ public class Course {
 
     private boolean waitingListEnabled;
 
-    private String enrollmentOpenDate;
-
-    private String enrollmentCloseDate;
-
     private boolean requireRoleSelection;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/resources/db/changelog/010-drop-enrollment-dates.yaml
+++ b/backend/src/main/resources/db/changelog/010-drop-enrollment-dates.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 010-drop-enrollment-dates
+      author: claude
+      changes:
+        - dropColumn:
+            tableName: course
+            columns:
+              - column:
+                  name: enrollment_open_date
+              - column:
+                  name: enrollment_close_date

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,3 +17,5 @@ databaseChangeLog:
       file: db/changelog/008-rename-user-role-to-teacher.yaml
   - include:
       file: db/changelog/009-create-course.yaml
+  - include:
+      file: db/changelog/010-drop-enrollment-dates.yaml


### PR DESCRIPTION
## Summary
- Remove unused `enrollmentOpenDate` and `enrollmentCloseDate` fields from the `Course` entity
- Add Liquibase migration (`010-drop-enrollment-dates.yaml`) to drop the columns

## Test plan
- [x] All 53 backend tests pass
- [ ] CI passes

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)