### PR TITLE
Add filter bar and column sorting to Courses page

### DIFF
--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -5,25 +5,52 @@
       <h1 class="page-title">Courses</h1>
       <p class="page-subtitle">Manage your dance courses, schedules, and enrollments</p>
     </div>
-    <button mat-flat-button disabled>
-      <mat-icon>add</mat-icon>
-      Add Course
-    </button>
   </div>
 
-  @if (courses().length > 0) {
+  @if (dataSource.data.length > 0) {
+    <!-- Filter Bar -->
+    <div class="filter-bar">
+      <mat-form-field class="filter-search" appearance="outline" subscriptSizing="dynamic">
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput placeholder="Search courses..." [(ngModel)]="searchText" (ngModelChange)="applyFilter()" />
+      </mat-form-field>
+
+      <mat-form-field class="filter-select" appearance="outline" subscriptSizing="dynamic">
+        <mat-select placeholder="Dance Type" [(ngModel)]="selectedDanceStyle" (ngModelChange)="applyFilter()">
+          <mat-option value="">All Types</mat-option>
+          @for (style of danceStyles; track style) {
+            <mat-option [value]="style">{{ style | titlecase }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field class="filter-select" appearance="outline" subscriptSizing="dynamic">
+        <mat-select placeholder="Level" [(ngModel)]="selectedLevel" (ngModelChange)="applyFilter()">
+          <mat-option value="">All Levels</mat-option>
+          @for (level of levels; track level) {
+            <mat-option [value]="level">{{ level | titlecase }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <button mat-flat-button disabled>
+        <mat-icon>add</mat-icon>
+        Add Course
+      </button>
+    </div>
+
     <!-- Table Card -->
     <div class="ds-table-card">
-      <table mat-table [dataSource]="courses()">
+      <table mat-table [dataSource]="dataSource" matSort>
         <!-- Course Name -->
         <ng-container matColumnDef="title">
-          <th mat-header-cell *matHeaderCellDef>Course Name</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Course Name</th>
           <td mat-cell *matCellDef="let course">{{ course.title }}</td>
         </ng-container>
 
         <!-- Type (Dance Style) -->
         <ng-container matColumnDef="danceStyle">
-          <th mat-header-cell *matHeaderCellDef>Type</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Type</th>
           <td mat-cell *matCellDef="let course">
             <span class="ds-chip" [ngClass]="danceStyleChipClass(course.danceStyle)">
               {{ course.danceStyle | titlecase }}
@@ -33,13 +60,13 @@
 
         <!-- Level -->
         <ng-container matColumnDef="level">
-          <th mat-header-cell *matHeaderCellDef>Level</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Level</th>
           <td mat-cell *matCellDef="let course">{{ course.level | titlecase }}</td>
         </ng-container>
 
         <!-- Schedule -->
         <ng-container matColumnDef="schedule">
-          <th mat-header-cell *matHeaderCellDef>Schedule</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Schedule</th>
           <td mat-cell *matCellDef="let course">
             <div class="ds-cell-primary">{{ formatDay(course.dayOfWeek) }}, {{ formatTime(course.startTime) }} – {{ formatTime(course.endTime) }}</div>
             <div class="ds-cell-secondary">{{ course.numberOfSessions }} sessions × {{ sessionDuration(course.startTime, course.endTime) }} min</div>
@@ -48,19 +75,19 @@
 
         <!-- Enrollment -->
         <ng-container matColumnDef="enrollment">
-          <th mat-header-cell *matHeaderCellDef>Enrollment</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Enrollment</th>
           <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }} / {{ course.maxParticipants }}</td>
         </ng-container>
 
         <!-- Price -->
         <ng-container matColumnDef="price">
-          <th mat-header-cell *matHeaderCellDef>Price</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Price</th>
           <td mat-cell *matCellDef="let course">{{ course.price | currency:'EUR' }}</td>
         </ng-container>
 
         <!-- Status -->
         <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
           <td mat-cell *matCellDef="let course">
             <span class="ds-chip" [ngClass]="statusChipClass(course.status)">
               {{ course.status | titlecase }}
@@ -73,7 +100,7 @@
       </table>
 
       <div class="ds-table-footer">
-        Showing {{ courses().length }} of {{ courses().length }} courses
+        Showing {{ dataSource.filteredData.length }} of {{ totalCount() }} courses
       </div>
     </div>
   } @else {

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -11,6 +11,21 @@
   justify-content: space-between;
 }
 
+// Filter bar
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-4);
+}
+
+.filter-search {
+  flex: 1;
+}
+
+.filter-select {
+  width: 150px;
+}
+
 .title-group {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -1,14 +1,34 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit, ViewChild, computed } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CurrencyPipe, NgClass, TitleCasePipe } from '@angular/common';
-import { MatTableModule } from '@angular/material/table';
+import { FormsModule } from '@angular/forms';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatSortModule, MatSort } from '@angular/material/sort';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
 import { CourseListItem, CourseService } from './course.service';
+
+interface CourseFilter {
+  text: string;
+  danceStyle: string;
+  level: string;
+}
+
+const DAY_ORDER: Record<string, number> = {
+  MONDAY: 1, TUESDAY: 2, WEDNESDAY: 3,
+  THURSDAY: 4, FRIDAY: 5, SATURDAY: 6, SUNDAY: 7,
+};
 
 @Component({
   selector: 'app-courses',
-  imports: [MatTableModule, MatIconModule, MatButtonModule, CurrencyPipe, TitleCasePipe, NgClass],
+  imports: [
+    MatTableModule, MatSortModule, MatIconModule, MatButtonModule,
+    MatFormFieldModule, MatInputModule, MatSelectModule,
+    FormsModule, CurrencyPipe, TitleCasePipe, NgClass,
+  ],
   templateUrl: './courses.html',
   styleUrl: './courses.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -17,18 +37,43 @@ export class CoursesComponent implements OnInit {
   private courseService = inject(CourseService);
   private destroyRef = inject(DestroyRef);
 
-  protected courses = signal<CourseListItem[]>([]);
+  protected dataSource = new MatTableDataSource<CourseListItem>([]);
+  protected totalCount = signal(0);
   protected loaded = signal(false);
   protected error = signal(false);
+
+  protected searchText = '';
+  protected selectedDanceStyle = '';
+  protected selectedLevel = '';
+
+  protected danceStyles: string[] = ['SALSA', 'BACHATA'];
+  protected levels: string[] = ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'];
+
+  protected filteredCount = computed(() => this.dataSource.filteredData.length);
 
   protected displayedColumns = [
     'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'price', 'status',
   ];
 
+  @ViewChild(MatSort) set sort(sort: MatSort) {
+    if (sort) {
+      this.dataSource.sort = sort;
+    }
+  }
+
   ngOnInit(): void {
+    this.dataSource.filterPredicate = this.createFilterPredicate();
+    this.dataSource.sortingDataAccessor = (course, column) => {
+      if (column === 'schedule') {
+        return DAY_ORDER[course.dayOfWeek] ?? 0;
+      }
+      return (course as unknown as Record<string, string | number>)[column];
+    };
+
     this.courseService.getCourses().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (courses) => {
-        this.courses.set(courses);
+        this.dataSource.data = courses;
+        this.totalCount.set(courses.length);
         this.loaded.set(true);
       },
       error: () => {
@@ -36,6 +81,48 @@ export class CoursesComponent implements OnInit {
         this.loaded.set(true);
       },
     });
+  }
+
+  protected applyFilter(): void {
+    const filter: CourseFilter = {
+      text: this.searchText.trim().toLowerCase(),
+      danceStyle: this.selectedDanceStyle,
+      level: this.selectedLevel,
+    };
+    // MatTableDataSource.filter is a string — serialize the filter object
+    this.dataSource.filter = JSON.stringify(filter);
+  }
+
+  private createFilterPredicate(): (data: CourseListItem, filter: string) => boolean {
+    return (data: CourseListItem, filter: string): boolean => {
+      const f: CourseFilter = JSON.parse(filter);
+
+      // Dance style dropdown filter
+      if (f.danceStyle && data.danceStyle !== f.danceStyle) {
+        return false;
+      }
+
+      // Level dropdown filter
+      if (f.level && data.level !== f.level) {
+        return false;
+      }
+
+      // Free-text search across text columns
+      if (f.text) {
+        const searchable = [
+          data.title,
+          data.danceStyle,
+          data.level,
+          data.status,
+          data.dayOfWeek,
+        ].join(' ').toLowerCase();
+        if (!searchable.includes(f.text)) {
+          return false;
+        }
+      }
+
+      return true;
+    };
   }
 
   protected formatDay(dayOfWeek: string): string {


### PR DESCRIPTION
## Summary
- Add filter bar with search input, Dance Type dropdown, and Level dropdown that combine via a custom `filterPredicate` on `MatTableDataSource`
- Add `matSort` with `mat-sort-header` on all columns; Schedule column sorts by `dayOfWeek` order
- Footer now shows "Showing X of Y courses" reflecting filtered count
- "Add Course" button moved into filter bar as a disabled placeholder

Closes #127

## Test plan
- [ ] Verify search input filters courses by free text across title, dance style, level, status, and day
- [ ] Verify Dance Type dropdown filters by SALSA or BACHATA
- [ ] Verify Level dropdown filters by BEGINNER, INTERMEDIATE, or ADVANCED
- [ ] Verify filters combine correctly (e.g., text + type + level)
- [ ] Verify clearing filters (selecting "All Types" / "All Levels" / clearing text) restores full list
- [ ] Verify clicking column headers sorts ascending/descending
- [ ] Verify Schedule column sorts by day of week (Mon-Sun), not alphabetically
- [ ] Verify footer count updates when filters are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)