### PR TITLE
Add @Transactional(readOnly = true) to CourseService read methods (#128)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -5,6 +5,7 @@ import ch.ruppen.danceschool.school.SchoolService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ public class CourseService {
     private final CourseRepository courseRepository;
     private final SchoolService schoolService;
 
+    @Transactional(readOnly = true)
     public List<CourseListDto> getCoursesByMember(Long userId) {
         School school = schoolService.findSchoolByMember(userId);
         return courseRepository.findAllBySchoolId(school.getId()).stream()
@@ -53,6 +55,7 @@ public class CourseService {
         courseRepository.save(course);
     }
 
+    @Transactional(readOnly = true)
     public boolean hasCoursesForMember(Long userId) {
         School school = schoolService.findSchoolByMember(userId);
         return !courseRepository.findAllBySchoolId(school.getId()).isEmpty();


### PR DESCRIPTION
## Summary
- Adds `@Transactional(readOnly = true)` to `getCoursesByMember()` and `hasCoursesForMember()` in `CourseService`
- Flagged during architecture review (#128) as a low-effort improvement

## Test plan
- [x] All 53 backend tests pass

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)