### PR TITLE
Add course CRUD endpoints and dance style enum expansion (#134)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
@@ -1,13 +1,21 @@
 package ch.ruppen.danceschool.course;
 
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/courses")
@@ -19,5 +27,26 @@ public class CourseController {
     @GetMapping("/me")
     public List<CourseListDto> me(@AuthenticationPrincipal AuthenticatedUser principal) {
         return courseService.getCoursesByMember(principal.userId());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Map<String, Long> create(@Valid @RequestBody CreateCourseDto dto,
+                                    @AuthenticationPrincipal AuthenticatedUser principal) {
+        Long id = courseService.createCourse(principal.userId(), dto);
+        return Map.of("id", id);
+    }
+
+    @GetMapping("/{id}")
+    public CourseDetailDto getDetail(@PathVariable Long id,
+                                    @AuthenticationPrincipal AuthenticatedUser principal) {
+        return courseService.getCourseDetail(principal.userId(), id);
+    }
+
+    @PutMapping("/{id}")
+    public CourseDetailDto update(@PathVariable Long id,
+                                 @Valid @RequestBody CreateCourseDto dto,
+                                 @AuthenticationPrincipal AuthenticatedUser principal) {
+        return courseService.updateCourse(principal.userId(), id, dto);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
@@ -1,0 +1,34 @@
+package ch.ruppen.danceschool.course;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CourseDetailDto(
+        Long id,
+        String title,
+        DanceStyle danceStyle,
+        CourseLevel level,
+        CourseType courseType,
+        String description,
+        LocalDate startDate,
+        RecurrenceType recurrenceType,
+        DayOfWeek dayOfWeek,
+        int numberOfSessions,
+        LocalTime startTime,
+        LocalTime endTime,
+        String location,
+        String teachers,
+        int maxParticipants,
+        boolean waitingListEnabled,
+        boolean requireRoleSelection,
+        RoleBalancingMode roleBalancingMode,
+        Integer roleBalanceThreshold,
+        PriceModel priceModel,
+        BigDecimal price,
+        CourseStatus status,
+        LocalDate publishDate,
+        int enrolledStudents
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
@@ -3,8 +3,11 @@ package ch.ruppen.danceschool.course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 interface CourseRepository extends JpaRepository<Course, Long> {
 
     List<Course> findAllBySchoolId(Long schoolId);
+
+    Optional<Course> findByIdAndSchoolId(Long id, Long schoolId);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -2,11 +2,14 @@ package ch.ruppen.danceschool.course;
 
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
+import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
+import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -23,6 +26,35 @@ public class CourseService {
         return courseRepository.findAllBySchoolId(school.getId()).stream()
                 .map(this::toListDto)
                 .toList();
+    }
+
+    @Transactional
+    public Long createCourse(Long userId, CreateCourseDto dto) {
+        validateDomainRules(dto, true);
+        School school = schoolService.findSchoolByMember(userId);
+        Course course = new Course();
+        course.setSchool(school);
+        applyDto(course, dto);
+        courseRepository.save(course);
+        return course.getId();
+    }
+
+    @Transactional
+    public CourseDetailDto updateCourse(Long userId, Long courseId, CreateCourseDto dto) {
+        validateDomainRules(dto, false);
+        School school = schoolService.findSchoolByMember(userId);
+        Course course = courseRepository.findByIdAndSchoolId(courseId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
+        applyDto(course, dto);
+        return toDetailDto(course);
+    }
+
+    @Transactional(readOnly = true)
+    public CourseDetailDto getCourseDetail(Long userId, Long courseId) {
+        School school = schoolService.findSchoolByMember(userId);
+        Course course = courseRepository.findByIdAndSchoolId(courseId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
+        return toDetailDto(course);
     }
 
     public void seedCourse(Long userId, String title, DanceStyle danceStyle, CourseLevel level,
@@ -61,6 +93,52 @@ public class CourseService {
         return !courseRepository.findAllBySchoolId(school.getId()).isEmpty();
     }
 
+    private void validateDomainRules(CreateCourseDto dto, boolean isCreate) {
+        if (!dto.startTime().isBefore(dto.endTime())) {
+            throw new DomainRuleViolationException("Start time must be before end time");
+        }
+        if (isCreate && !dto.startDate().isAfter(LocalDate.now())) {
+            throw new DomainRuleViolationException("Start date must be in the future");
+        }
+        if (dto.publishDate() != null && dto.publishDate().isAfter(dto.startDate())) {
+            throw new DomainRuleViolationException("Publish date must not be after start date");
+        }
+        if (dto.courseType() == CourseType.PARTNER && dto.requireRoleSelection()
+                && dto.roleBalancingMode() == null) {
+            throw new DomainRuleViolationException(
+                    "Role balancing mode is required when role selection is enabled for partner courses");
+        }
+        if (dto.roleBalancingMode() == null && dto.roleBalanceThreshold() != null) {
+            throw new DomainRuleViolationException(
+                    "Role balance threshold requires a role balancing mode");
+        }
+    }
+
+    private void applyDto(Course course, CreateCourseDto dto) {
+        course.setTitle(dto.title());
+        course.setDanceStyle(dto.danceStyle());
+        course.setLevel(dto.level());
+        course.setCourseType(dto.courseType());
+        course.setDescription(dto.description());
+        course.setStartDate(dto.startDate());
+        course.setRecurrenceType(dto.recurrenceType());
+        course.setDayOfWeek(dto.dayOfWeek());
+        course.setNumberOfSessions(dto.numberOfSessions());
+        course.setStartTime(dto.startTime());
+        course.setEndTime(dto.endTime());
+        course.setLocation(dto.location());
+        course.setTeachers(dto.teachers());
+        course.setMaxParticipants(dto.maxParticipants());
+        course.setWaitingListEnabled(dto.waitingListEnabled());
+        course.setRequireRoleSelection(dto.requireRoleSelection());
+        course.setRoleBalancingMode(dto.roleBalancingMode());
+        course.setRoleBalanceThreshold(dto.roleBalanceThreshold());
+        course.setPriceModel(dto.priceModel());
+        course.setPrice(dto.price());
+        course.setStatus(dto.status());
+        course.setPublishDate(dto.publishDate());
+    }
+
     private CourseListDto toListDto(Course course) {
         return new CourseListDto(
                 course.getId(),
@@ -75,6 +153,35 @@ public class CourseService {
                 course.getMaxParticipants(),
                 course.getPrice(),
                 course.getStatus()
+        );
+    }
+
+    private CourseDetailDto toDetailDto(Course course) {
+        return new CourseDetailDto(
+                course.getId(),
+                course.getTitle(),
+                course.getDanceStyle(),
+                course.getLevel(),
+                course.getCourseType(),
+                course.getDescription(),
+                course.getStartDate(),
+                course.getRecurrenceType(),
+                course.getDayOfWeek(),
+                course.getNumberOfSessions(),
+                course.getStartTime(),
+                course.getEndTime(),
+                course.getLocation(),
+                course.getTeachers(),
+                course.getMaxParticipants(),
+                course.isWaitingListEnabled(),
+                course.isRequireRoleSelection(),
+                course.getRoleBalancingMode(),
+                course.getRoleBalanceThreshold(),
+                course.getPriceModel(),
+                course.getPrice(),
+                course.getStatus(),
+                course.getPublishDate(),
+                course.getEnrolledStudents()
         );
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
@@ -1,0 +1,38 @@
+package ch.ruppen.danceschool.course;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CreateCourseDto(
+        @NotBlank @Size(max = 255) String title,
+        @NotNull DanceStyle danceStyle,
+        @NotNull CourseLevel level,
+        @NotNull CourseType courseType,
+        String description,
+        @NotNull LocalDate startDate,
+        @NotNull RecurrenceType recurrenceType,
+        @NotNull DayOfWeek dayOfWeek,
+        @Min(1) int numberOfSessions,
+        @NotNull LocalTime startTime,
+        @NotNull LocalTime endTime,
+        @NotBlank String location,
+        String teachers,
+        @Min(1) int maxParticipants,
+        boolean waitingListEnabled,
+        boolean requireRoleSelection,
+        RoleBalancingMode roleBalancingMode,
+        Integer roleBalanceThreshold,
+        @NotNull PriceModel priceModel,
+        @NotNull @DecimalMin("0") BigDecimal price,
+        @NotNull CourseStatus status,
+        LocalDate publishDate
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/DanceStyle.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/DanceStyle.java
@@ -2,5 +2,10 @@ package ch.ruppen.danceschool.course;
 
 public enum DanceStyle {
     SALSA,
-    BACHATA
+    BACHATA,
+    MERENGUE,
+    KIZOMBA,
+    ZOUK,
+    AFRO,
+    OTHER
 }

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
@@ -1,0 +1,405 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class CourseCrudIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private AppUser ownerA;
+    private AppUser ownerB;
+    private School schoolA;
+    private School schoolB;
+
+    @BeforeEach
+    void setUp() {
+        ownerA = createUser("owner-a@example.com", "Owner A", "firebase-a");
+        ownerB = createUser("owner-b@example.com", "Owner B", "firebase-b");
+        schoolA = createSchoolWithOwner("School A", ownerA);
+        schoolB = createSchoolWithOwner("School B", ownerB);
+        entityManager.flush();
+    }
+
+    private String validCourseJson() {
+        return """
+                {
+                  "title": "Salsa Beginners",
+                  "danceStyle": "SALSA",
+                  "level": "BEGINNER",
+                  "courseType": "PARTNER",
+                  "description": "Learn the basics of Salsa",
+                  "startDate": "%s",
+                  "recurrenceType": "WEEKLY",
+                  "dayOfWeek": "MONDAY",
+                  "numberOfSessions": 8,
+                  "startTime": "19:00",
+                  "endTime": "20:00",
+                  "location": "Studio A",
+                  "teachers": "Maria",
+                  "maxParticipants": 15,
+                  "waitingListEnabled": false,
+                  "requireRoleSelection": false,
+                  "priceModel": "FIXED_COURSE",
+                  "price": 180.00,
+                  "status": "DRAFT"
+                }
+                """.formatted(LocalDate.now().plusDays(30));
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void createCourse_returnsCreatedId() throws Exception {
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validCourseJson())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.id").isNumber());
+        }
+
+        @Test
+        void createCourse_persistsAllFields() throws Exception {
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validCourseJson())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isCreated());
+
+            // Verify via GET /me
+            mockMvc.perform(get("/api/courses/me")
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.length()").value(1))
+                    .andExpect(jsonPath("$[0].title").value("Salsa Beginners"))
+                    .andExpect(jsonPath("$[0].danceStyle").value("SALSA"))
+                    .andExpect(jsonPath("$[0].level").value("BEGINNER"));
+        }
+
+        @Test
+        void createCourse_returns400_whenTitleBlank() throws Exception {
+            String json = validCourseJson().replace("\"Salsa Beginners\"", "\"\"");
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.title").exists());
+        }
+
+        @Test
+        void createCourse_returns400_whenRequiredFieldsMissing() throws Exception {
+            String json = """
+                    {
+                      "title": "Test",
+                      "location": "Studio A"
+                    }
+                    """;
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors").exists());
+        }
+
+        @Test
+        void createCourse_returns401_whenNotAuthenticated() throws Exception {
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validCourseJson()))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void createCourse_supportsNewDanceStyles() throws Exception {
+            String json = validCourseJson().replace("\"SALSA\"", "\"KIZOMBA\"");
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isCreated());
+        }
+    }
+
+    @Nested
+    class GetDetail {
+
+        @Test
+        void getDetail_returnsAllFields() throws Exception {
+            Course course = createCourse(schoolA, "Bachata Advanced");
+            entityManager.flush();
+
+            mockMvc.perform(get("/api/courses/{id}", course.getId())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(course.getId()))
+                    .andExpect(jsonPath("$.title").value("Bachata Advanced"))
+                    .andExpect(jsonPath("$.danceStyle").value("BACHATA"))
+                    .andExpect(jsonPath("$.level").value("ADVANCED"))
+                    .andExpect(jsonPath("$.courseType").value("PARTNER"))
+                    .andExpect(jsonPath("$.startDate").exists())
+                    .andExpect(jsonPath("$.recurrenceType").value("WEEKLY"))
+                    .andExpect(jsonPath("$.dayOfWeek").value("WEDNESDAY"))
+                    .andExpect(jsonPath("$.numberOfSessions").value(10))
+                    .andExpect(jsonPath("$.startTime").value("20:00:00"))
+                    .andExpect(jsonPath("$.endTime").value("21:15:00"))
+                    .andExpect(jsonPath("$.location").value("Studio A"))
+                    .andExpect(jsonPath("$.maxParticipants").value(12))
+                    .andExpect(jsonPath("$.waitingListEnabled").value(false))
+                    .andExpect(jsonPath("$.requireRoleSelection").value(false))
+                    .andExpect(jsonPath("$.priceModel").value("FIXED_COURSE"))
+                    .andExpect(jsonPath("$.price").value(310.00))
+                    .andExpect(jsonPath("$.status").value("ACTIVE"))
+                    .andExpect(jsonPath("$.enrolledStudents").value(0));
+        }
+
+        @Test
+        void getDetail_returns404_forOtherSchoolsCourse() throws Exception {
+            Course course = createCourse(schoolB, "School B Course");
+            entityManager.flush();
+
+            mockMvc.perform(get("/api/courses/{id}", course.getId())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void getDetail_returns404_forNonExistentId() throws Exception {
+            mockMvc.perform(get("/api/courses/{id}", 99999)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void updateCourse_returnsUpdatedFields() throws Exception {
+            Course course = createCourse(schoolA, "Original Title");
+            entityManager.flush();
+
+            String updateJson = validCourseJson().replace("\"Salsa Beginners\"", "\"Updated Title\"");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(updateJson)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value("Updated Title"))
+                    .andExpect(jsonPath("$.danceStyle").value("SALSA"));
+        }
+
+        @Test
+        void updateCourse_returns404_forOtherSchoolsCourse() throws Exception {
+            Course course = createCourse(schoolB, "School B Course");
+            entityManager.flush();
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(validCourseJson())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void updateCourse_returns400_whenValidationFails() throws Exception {
+            Course course = createCourse(schoolA, "Test Course");
+            entityManager.flush();
+
+            String json = validCourseJson().replace("\"Salsa Beginners\"", "\"\"");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    class DomainRules {
+
+        @Test
+        void rejects_whenStartTimeNotBeforeEndTime() throws Exception {
+            String json = validCourseJson()
+                    .replace("\"19:00\"", "\"21:00\"")
+                    .replace("\"20:00\"", "\"19:00\"");
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.detail").value("Start time must be before end time"));
+        }
+
+        @Test
+        void rejects_whenStartDateInPast() throws Exception {
+            String json = validCourseJson().replace(
+                    LocalDate.now().plusDays(30).toString(),
+                    LocalDate.now().minusDays(1).toString());
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.detail").value("Start date must be in the future"));
+        }
+
+        @Test
+        void rejects_whenPublishDateAfterStartDate() throws Exception {
+            LocalDate startDate = LocalDate.now().plusDays(30);
+            String json = validCourseJson().replace(
+                    "\"status\": \"DRAFT\"",
+                    "\"status\": \"DRAFT\", \"publishDate\": \"%s\"".formatted(startDate.plusDays(5)));
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.detail").value("Publish date must not be after start date"));
+        }
+
+        @Test
+        void rejects_whenPartnerCourseRequiresRoleButNoMode() throws Exception {
+            String json = validCourseJson()
+                    .replace("\"requireRoleSelection\": false", "\"requireRoleSelection\": true");
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.detail").value(
+                            "Role balancing mode is required when role selection is enabled for partner courses"));
+        }
+
+        @Test
+        void rejects_whenThresholdSetWithoutMode() throws Exception {
+            String json = validCourseJson()
+                    .replace("\"priceModel\"", "\"roleBalanceThreshold\": 3, \"priceModel\"");
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.detail").value(
+                            "Role balance threshold requires a role balancing mode"));
+        }
+
+        @Test
+        void accepts_validPartnerCourseWithRoleSettings() throws Exception {
+            String json = validCourseJson()
+                    .replace("\"requireRoleSelection\": false",
+                            "\"requireRoleSelection\": true, \"roleBalancingMode\": \"WARN\", \"roleBalanceThreshold\": 3");
+
+            mockMvc.perform(post("/api/courses")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isCreated());
+        }
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser owner) {
+        School school = new School();
+        school.setName(name);
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(owner);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return school;
+    }
+
+    private Course createCourse(School school, String title) {
+        Course course = new Course();
+        course.setSchool(school);
+        course.setTitle(title);
+        course.setDanceStyle(DanceStyle.BACHATA);
+        course.setLevel(CourseLevel.ADVANCED);
+        course.setCourseType(CourseType.PARTNER);
+        course.setStartDate(LocalDate.now().plusDays(30));
+        course.setRecurrenceType(RecurrenceType.WEEKLY);
+        course.setDayOfWeek(DayOfWeek.WEDNESDAY);
+        course.setNumberOfSessions(10);
+        course.setStartTime(LocalTime.of(20, 0));
+        course.setEndTime(LocalTime.of(21, 15));
+        course.setLocation("Studio A");
+        course.setMaxParticipants(12);
+        course.setPriceModel(PriceModel.FIXED_COURSE);
+        course.setPrice(new BigDecimal("310.00"));
+        course.setStatus(CourseStatus.ACTIVE);
+        entityManager.persist(course);
+        return course;
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -2,12 +2,13 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import { CourseLevel, CourseStatus, DanceStyle } from '../shared/course-constants';
 
 export interface CourseListItem {
   id: number;
   title: string;
-  danceStyle: 'SALSA' | 'BACHATA';
-  level: 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+  danceStyle: DanceStyle;
+  level: CourseLevel;
   dayOfWeek: string;
   startTime: string;
   endTime: string;
@@ -15,7 +16,7 @@ export interface CourseListItem {
   enrolledStudents: number;
   maxParticipants: number;
   price: number;
-  status: 'DRAFT' | 'ACTIVE' | 'FULL' | 'INACTIVE';
+  status: CourseStatus;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -10,6 +10,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { CourseListItem, CourseService } from './course.service';
+import { DANCE_STYLES, COURSE_LEVELS } from '../shared/course-constants';
 
 interface CourseFilter {
   text: string;
@@ -46,8 +47,8 @@ export class CoursesComponent implements OnInit {
   protected selectedDanceStyle = '';
   protected selectedLevel = '';
 
-  protected danceStyles: string[] = ['SALSA', 'BACHATA'];
-  protected levels: string[] = ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'];
+  protected danceStyles = DANCE_STYLES.map(d => d.value);
+  protected levels = COURSE_LEVELS.map(l => l.value);
 
   protected filteredCount = computed(() => this.dataSource.filteredData.length);
 
@@ -157,6 +158,11 @@ export class CoursesComponent implements OnInit {
     switch (style) {
       case 'BACHATA': return 'ds-chip-primary';
       case 'SALSA': return 'ds-chip-info';
+      case 'MERENGUE': return 'ds-chip-success';
+      case 'KIZOMBA': return 'ds-chip-primary';
+      case 'ZOUK': return 'ds-chip-info';
+      case 'AFRO': return 'ds-chip-success';
+      case 'OTHER': return 'ds-chip-default';
       default: return 'ds-chip-default';
     }
   }

--- a/frontend/src/app/shared/course-constants.ts
+++ b/frontend/src/app/shared/course-constants.ts
@@ -1,0 +1,48 @@
+export type DanceStyle = 'SALSA' | 'BACHATA' | 'MERENGUE' | 'KIZOMBA' | 'ZOUK' | 'AFRO' | 'OTHER';
+export type CourseLevel = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+export type CourseType = 'PARTNER' | 'SOLO';
+export type CourseStatus = 'DRAFT' | 'ACTIVE' | 'FULL' | 'INACTIVE';
+export type RecurrenceType = 'WEEKLY';
+export type PriceModel = 'FIXED_COURSE';
+export type RoleBalancingMode = 'WARN' | 'BLOCK';
+
+export const DANCE_STYLES: { value: DanceStyle; label: string }[] = [
+  { value: 'SALSA', label: 'Salsa' },
+  { value: 'BACHATA', label: 'Bachata' },
+  { value: 'MERENGUE', label: 'Merengue' },
+  { value: 'KIZOMBA', label: 'Kizomba' },
+  { value: 'ZOUK', label: 'Zouk' },
+  { value: 'AFRO', label: 'Afro' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+export const COURSE_LEVELS: { value: CourseLevel; label: string }[] = [
+  { value: 'BEGINNER', label: 'Beginner' },
+  { value: 'INTERMEDIATE', label: 'Intermediate' },
+  { value: 'ADVANCED', label: 'Advanced' },
+];
+
+export const COURSE_TYPES: { value: CourseType; label: string }[] = [
+  { value: 'PARTNER', label: 'Partner' },
+  { value: 'SOLO', label: 'Solo' },
+];
+
+export const COURSE_STATUSES: { value: CourseStatus; label: string }[] = [
+  { value: 'DRAFT', label: 'Draft' },
+  { value: 'ACTIVE', label: 'Active' },
+  { value: 'FULL', label: 'Full' },
+  { value: 'INACTIVE', label: 'Inactive' },
+];
+
+export const RECURRENCE_TYPES: { value: RecurrenceType; label: string }[] = [
+  { value: 'WEEKLY', label: 'Weekly' },
+];
+
+export const PRICE_MODELS: { value: PriceModel; label: string }[] = [
+  { value: 'FIXED_COURSE', label: 'Fixed Course' },
+];
+
+export const ROLE_BALANCING_MODES: { value: RoleBalancingMode; label: string }[] = [
+  { value: 'WARN', label: 'Warn' },
+  { value: 'BLOCK', label: 'Block' },
+];


### PR DESCRIPTION
## Summary
- **Backend**: `POST /api/courses`, `PUT /api/courses/{id}`, `GET /api/courses/{id}` — all tenant-scoped with domain validation (time ordering, future start dates, publish date constraints, partner role coherence)
- **DTOs**: `CreateCourseDto` with Jakarta Bean Validation, `CourseDetailDto` for edit flow
- **Enum expansion**: `DanceStyle` now includes MERENGUE, KIZOMBA, ZOUK, AFRO, OTHER
- **Frontend**: shared `course-constants.ts` with typed enums and label arrays; courses component updated to use new constants and chip colors for new styles
- **Tests**: 16 new integration tests covering happy path, validation errors, tenant isolation, and all 5 domain rule violations

Closes #134

## Test plan
- [x] All 71 backend tests pass (including 16 new CRUD tests)
- [x] Frontend builds successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)