### PR TITLE
Add course creation wizard shell with Details step (#135)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -27,6 +27,7 @@ export const routes: Routes = [
       },
       { path: 'my-school', loadComponent: () => import('./my-school/my-school').then(m => m.MySchoolComponent) },
       { path: 'subscriptions', loadComponent: () => import('./subscriptions/subscriptions').then(m => m.SubscriptionsComponent) },
+      { path: 'courses/create', loadComponent: () => import('./courses/create/course-create').then(m => m.CourseCreateComponent) },
       { path: 'courses', loadComponent: () => import('./courses/courses').then(m => m.CoursesComponent) },
       { path: 'payments', loadComponent: () => import('./payments/payments').then(m => m.PaymentsComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -26,4 +26,8 @@ export class CourseService {
   getCourses(): Observable<CourseListItem[]> {
     return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`);
   }
+
+  createCourse(dto: Record<string, unknown>): Observable<{ id: number }> {
+    return this.http.post<{ id: number }>(`${environment.apiUrl}/api/courses`, dto);
+  }
 }

--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -33,7 +33,7 @@
         </mat-select>
       </mat-form-field>
 
-      <button mat-flat-button disabled>
+      <button mat-flat-button routerLink="/app/courses/create">
         <mat-icon>add</mat-icon>
         Add Course
       </button>
@@ -109,7 +109,7 @@
       <mat-icon class="empty-state-icon">school</mat-icon>
       <h2 class="empty-state-title">No courses yet</h2>
       <p class="empty-state-text">Create your first course to start managing your dance school schedule.</p>
-      <button mat-flat-button disabled>
+      <button mat-flat-button routerLink="/app/courses/create">
         <mat-icon>add</mat-icon>
         Add Course
       </button>

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit,
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CurrencyPipe, NgClass, TitleCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
 import { MatSortModule, MatSort } from '@angular/material/sort';
 import { MatIconModule } from '@angular/material/icon';
@@ -28,7 +29,7 @@ const DAY_ORDER: Record<string, number> = {
   imports: [
     MatTableModule, MatSortModule, MatIconModule, MatButtonModule,
     MatFormFieldModule, MatInputModule, MatSelectModule,
-    FormsModule, CurrencyPipe, TitleCasePipe, NgClass,
+    FormsModule, RouterLink, CurrencyPipe, TitleCasePipe, NgClass,
   ],
   templateUrl: './courses.html',
   styleUrl: './courses.scss',

--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -1,0 +1,129 @@
+<!-- Header -->
+<div class="wizard-header">
+  <a class="back-link" routerLink="/app/courses">← Back to Courses</a>
+  <h1 class="wizard-title">Create New Course</h1>
+</div>
+
+<!-- Wizard Card -->
+<div class="wizard-card">
+  <!-- Stepper -->
+  <div class="stepper">
+    @for (step of steps; track step.label; let i = $index) {
+      @if (i > 0) {
+        <div class="stepper-connector"></div>
+      }
+      <button
+        class="stepper-step"
+        [class.active]="i === currentStep()"
+        [class.completed]="i < currentStep()"
+        [disabled]="i > currentStep()"
+        (click)="goToStep(i)"
+        type="button"
+      >
+        <span class="step-circle">{{ i + 1 }}</span>
+        <span class="step-label">{{ step.label }}</span>
+      </button>
+    }
+  </div>
+
+  <div class="divider"></div>
+
+  <!-- Step Content -->
+  <div class="step-content">
+    @switch (currentStep()) {
+      @case (0) {
+        <!-- Details Step -->
+        <div class="details-step" [formGroup]="detailsGroup">
+          <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Course Title</mat-label>
+            <input matInput formControlName="title" placeholder="e.g. Bachata Fundamentals for Beginners" />
+            @if (detailsGroup.controls.title.hasError('required')) {
+              <mat-error>Course title is required</mat-error>
+            }
+          </mat-form-field>
+
+          <div class="form-row">
+            <mat-form-field class="half-width" appearance="outline">
+              <mat-label>Dance Style</mat-label>
+              <mat-select formControlName="danceStyle">
+                @for (style of danceStyles; track style.value) {
+                  <mat-option [value]="style.value">{{ style.label }}</mat-option>
+                }
+              </mat-select>
+              @if (detailsGroup.controls.danceStyle.hasError('required')) {
+                <mat-error>Dance style is required</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field class="half-width" appearance="outline">
+              <mat-label>Level</mat-label>
+              <mat-select formControlName="level">
+                @for (level of levels; track level.value) {
+                  <mat-option [value]="level.value">{{ level.label }}</mat-option>
+                }
+              </mat-select>
+              @if (detailsGroup.controls.level.hasError('required')) {
+                <mat-error>Level is required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field class="half-width" appearance="outline">
+              <mat-label>Course Type</mat-label>
+              <mat-select formControlName="courseType">
+                @for (type of courseTypes; track type.value) {
+                  <mat-option [value]="type.value">{{ type.label }}</mat-option>
+                }
+              </mat-select>
+              @if (detailsGroup.controls.courseType.hasError('required')) {
+                <mat-error>Course type is required</mat-error>
+              }
+            </mat-form-field>
+            <div class="half-width"></div>
+          </div>
+
+          <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Description</mat-label>
+            <textarea matInput formControlName="description" rows="4"
+                      placeholder="Public description of the course..."></textarea>
+          </mat-form-field>
+        </div>
+      }
+      @case (1) {
+        <div class="placeholder-step">
+          <p>Schedule step — coming soon</p>
+        </div>
+      }
+      @case (2) {
+        <div class="placeholder-step">
+          <p>Registration step — coming soon</p>
+        </div>
+      }
+      @case (3) {
+        <div class="placeholder-step">
+          <p>Pricing step — coming soon</p>
+        </div>
+      }
+      @case (4) {
+        <div class="placeholder-step">
+          <p>Review step — coming soon</p>
+        </div>
+      }
+    }
+  </div>
+
+  <div class="divider"></div>
+
+  <!-- Navigation -->
+  <div class="wizard-nav">
+    @if (currentStep() > 0) {
+      <button mat-button (click)="back()" type="button">Back</button>
+    }
+    <span class="nav-spacer"></span>
+    <button mat-flat-button (click)="next()" type="button"
+            [disabled]="currentStep() === steps.length - 1">
+      Next
+    </button>
+  </div>
+</div>

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -1,0 +1,161 @@
+@use 'styles/mixins' as ds;
+
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-6);
+}
+
+// Header
+.wizard-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+}
+
+.back-link {
+  font: var(--mat-sys-label-large);
+  color: var(--mat-sys-primary);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.wizard-title {
+  font: var(--mat-sys-headline-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+// Wizard Card
+.wizard-card {
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+  padding: var(--ds-spacing-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-8);
+}
+
+// Stepper
+.stepper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.stepper-connector {
+  width: var(--ds-spacing-10);
+  height: 2px;
+  background: var(--mat-sys-outline-variant);
+  flex-shrink: 0;
+}
+
+.stepper-step {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-2);
+  justify-content: center;
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: default;
+
+  &:not([disabled]) {
+    cursor: pointer;
+  }
+}
+
+.step-circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--ds-radius-full);
+  font: var(--mat-sys-label-medium);
+  flex-shrink: 0;
+  background: var(--mat-sys-outline-variant);
+  color: var(--mat-sys-on-surface-variant);
+
+  .active & {
+    background: var(--mat-sys-primary);
+    color: var(--mat-sys-on-primary);
+  }
+
+  .completed & {
+    background: var(--mat-sys-primary);
+    color: var(--mat-sys-on-primary);
+  }
+}
+
+.step-label {
+  font: var(--mat-sys-label-medium);
+  color: var(--mat-sys-on-surface-variant);
+  white-space: nowrap;
+
+  .active & {
+    font: var(--mat-sys-label-large);
+    color: var(--mat-sys-on-surface);
+  }
+}
+
+// Divider
+.divider {
+  height: 1px;
+  background: var(--mat-sys-outline-variant);
+}
+
+// Step content
+.step-content {
+  min-height: var(--ds-spacing-24);
+}
+
+.details-step {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-5);
+}
+
+.form-row {
+  display: flex;
+  gap: var(--ds-spacing-5);
+
+  @include ds.bp-down(sm) {
+    flex-direction: column;
+  }
+}
+
+.full-width {
+  width: 100%;
+}
+
+.half-width {
+  flex: 1;
+  min-width: 0;
+}
+
+.placeholder-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--ds-spacing-24);
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-body-large);
+}
+
+// Navigation
+.wizard-nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.nav-spacer {
+  flex: 1;
+}

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectionStrategy, Component, inject, signal, OnDestroy } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { CourseFormService } from './course-form.service';
+import { CourseService } from '../course.service';
+import { DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES } from '../../shared/course-constants';
+
+interface StepDef {
+  label: string;
+}
+
+@Component({
+  selector: 'app-course-create',
+  imports: [
+    ReactiveFormsModule, RouterLink,
+    MatFormFieldModule, MatInputModule, MatSelectModule,
+    MatButtonModule, MatIconModule,
+  ],
+  providers: [CourseFormService],
+  templateUrl: './course-create.html',
+  styleUrl: './course-create.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CourseCreateComponent implements OnDestroy {
+  private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
+  protected formService = inject(CourseFormService);
+  private courseService = inject(CourseService);
+
+  protected currentStep = signal(0);
+  protected saving = signal(false);
+
+  protected steps: StepDef[] = [
+    { label: 'Details' },
+    { label: 'Schedule' },
+    { label: 'Registration' },
+    { label: 'Pricing' },
+    { label: 'Review' },
+  ];
+
+  protected danceStyles = DANCE_STYLES;
+  protected levels = COURSE_LEVELS;
+  protected courseTypes = COURSE_TYPES;
+
+  protected get detailsGroup() {
+    return this.formService.form.controls.details;
+  }
+
+  protected next(): void {
+    if (!this.formService.isStepValid(this.currentStep())) {
+      this.formService.markStepTouched(this.currentStep());
+      return;
+    }
+    if (this.currentStep() < this.steps.length - 1) {
+      this.currentStep.update(s => s + 1);
+    }
+  }
+
+  protected back(): void {
+    if (this.currentStep() > 0) {
+      this.currentStep.update(s => s - 1);
+    }
+  }
+
+  protected goToStep(index: number): void {
+    // Only allow navigating to completed steps or the current step
+    if (index <= this.currentStep()) {
+      this.currentStep.set(index);
+    }
+  }
+
+  canDeactivate(): boolean {
+    return !this.formService.isDirty() || this.saving();
+  }
+
+  ngOnDestroy(): void {
+    this.formService.reset();
+  }
+}

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+@Injectable()
+export class CourseFormService {
+  readonly form = new FormGroup({
+    details: new FormGroup({
+      title: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+      danceStyle: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+      level: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+      courseType: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+      description: new FormControl('', { nonNullable: true }),
+    }),
+    schedule: new FormGroup({}),
+    registration: new FormGroup({}),
+    pricing: new FormGroup({}),
+  });
+
+  private readonly stepGroups = [
+    this.form.controls.details,
+    this.form.controls.schedule,
+    this.form.controls.registration,
+    this.form.controls.pricing,
+    // Review step has no form group — it displays all data
+  ];
+
+  isStepValid(index: number): boolean {
+    const group = this.stepGroups[index];
+    if (!group) return true; // Review step is always "valid"
+    return group.valid;
+  }
+
+  markStepTouched(index: number): void {
+    const group = this.stepGroups[index];
+    if (group) {
+      group.markAllAsTouched();
+    }
+  }
+
+  isDirty(): boolean {
+    return this.form.dirty;
+  }
+
+  reset(): void {
+    this.form.reset();
+  }
+}


### PR DESCRIPTION
## Summary
- Custom stepper UI with 5 labeled steps (Details, Schedule, Registration, Pricing, Review) matching Figma design
- Details step form: Course Title, Dance Style, Level, Course Type, Description — with Material form fields and validation
- `CourseFormService` with shared `FormGroup` and nested groups per step, step-level validation
- "Add Course" buttons on courses list now navigate to `/app/courses/create`
- `createCourse()` API method added to `CourseService`
- Placeholder content for steps 2-5 (implemented in #136, #137)

Closes #135

## Test plan
- [x] Frontend builds successfully
- [x] Visual E2E: wizard renders with stepper, form fields, and navigation matching Figma
- [x] "Add Course" button navigates to wizard
- [x] "← Back to Courses" link navigates back to courses list
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)