### PR TITLE
Simplify course scheduling: derive dayOfWeek, add endDate (#175)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
@@ -58,6 +58,8 @@ public class Course {
 
     private int numberOfSessions;
 
+    private LocalDate endDate;
+
     private LocalTime startTime;
 
     private LocalTime endTime;

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
@@ -16,6 +16,7 @@ public record CourseDetailDto(
         RecurrenceType recurrenceType,
         DayOfWeek dayOfWeek,
         int numberOfSessions,
+        LocalDate endDate,
         LocalTime startTime,
         LocalTime endTime,
         String location,

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseListDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseListDto.java
@@ -2,6 +2,7 @@ package ch.ruppen.danceschool.course;
 
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record CourseListDto(
@@ -13,6 +14,7 @@ public record CourseListDto(
         LocalTime startTime,
         LocalTime endTime,
         int numberOfSessions,
+        LocalDate endDate,
         int enrolledStudents,
         int maxParticipants,
         BigDecimal price,

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -105,8 +106,9 @@ public class CourseService {
         course.setDescription(dto.description());
         course.setStartDate(dto.startDate());
         course.setRecurrenceType(dto.recurrenceType());
-        course.setDayOfWeek(dto.dayOfWeek());
+        course.setDayOfWeek(dto.startDate().getDayOfWeek());
         course.setNumberOfSessions(dto.numberOfSessions());
+        course.setEndDate(calculateEndDate(dto.startDate(), dto.recurrenceType(), dto.numberOfSessions()));
         course.setStartTime(dto.startTime());
         course.setEndTime(dto.endTime());
         course.setLocation(dto.location());
@@ -122,6 +124,13 @@ public class CourseService {
         course.setPublishDate(dto.publishDate());
     }
 
+    private LocalDate calculateEndDate(LocalDate startDate, RecurrenceType recurrenceType, int numberOfSessions) {
+        int intervalWeeks = switch (recurrenceType) {
+            case WEEKLY -> 1;
+        };
+        return startDate.plusWeeks((long) (numberOfSessions - 1) * intervalWeeks);
+    }
+
     private CourseListDto toListDto(Course course) {
         return new CourseListDto(
                 course.getId(),
@@ -132,6 +141,7 @@ public class CourseService {
                 course.getStartTime(),
                 course.getEndTime(),
                 course.getNumberOfSessions(),
+                course.getEndDate(),
                 course.getEnrolledStudents(),
                 course.getMaxParticipants(),
                 course.getPrice(),
@@ -151,6 +161,7 @@ public class CourseService {
                 course.getRecurrenceType(),
                 course.getDayOfWeek(),
                 course.getNumberOfSessions(),
+                course.getEndDate(),
                 course.getStartTime(),
                 course.getEndTime(),
                 course.getLocation(),

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -19,7 +18,6 @@ public record CreateCourseDto(
         @Size(max = 4000) String description,
         @NotNull LocalDate startDate,
         @NotNull RecurrenceType recurrenceType,
-        @NotNull DayOfWeek dayOfWeek,
         @Min(1) int numberOfSessions,
         @NotNull LocalTime startTime,
         @NotNull LocalTime endTime,

--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -71,7 +70,7 @@ public class DevDataSeeder implements ApplicationRunner {
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
                     "Salsa, Merengue, Bachata Solo", DanceStyle.SALSA, CourseLevel.BEGINNER,
                     CourseType.SOLO, "Learn the basics of Salsa, Merengue, and Bachata in solo style.",
-                    LocalDate.of(2026, 4, 10), RecurrenceType.WEEKLY, DayOfWeek.FRIDAY,
+                    LocalDate.of(2026, 4, 10), RecurrenceType.WEEKLY,
                     6, LocalTime.of(19, 30), LocalTime.of(20, 45),
                     "Studio A", "Maria", 12, false, false, null, null,
                     PriceModel.FIXED_COURSE, new BigDecimal("166.50"), CourseStatus.ACTIVE, null), 8);
@@ -79,7 +78,7 @@ public class DevDataSeeder implements ApplicationRunner {
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
                     "Bachata Intermediate", DanceStyle.BACHATA, CourseLevel.INTERMEDIATE,
                     CourseType.PARTNER, "Take your Bachata to the next level with partner work and musicality.",
-                    LocalDate.of(2026, 4, 7), RecurrenceType.WEEKLY, DayOfWeek.TUESDAY,
+                    LocalDate.of(2026, 4, 7), RecurrenceType.WEEKLY,
                     8, LocalTime.of(19, 0), LocalTime.of(20, 0),
                     "Studio B", "Carlos", 15, false, false, null, null,
                     PriceModel.FIXED_COURSE, new BigDecimal("220.00"), CourseStatus.ACTIVE, null), 12);
@@ -87,7 +86,7 @@ public class DevDataSeeder implements ApplicationRunner {
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
                     "Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED,
                     CourseType.PARTNER, "Advanced Salsa patterns, styling, and performance preparation.",
-                    LocalDate.of(2026, 4, 8), RecurrenceType.WEEKLY, DayOfWeek.WEDNESDAY,
+                    LocalDate.of(2026, 4, 8), RecurrenceType.WEEKLY,
                     10, LocalTime.of(20, 0), LocalTime.of(21, 15),
                     "Studio A", "Maria, Carlos", 10, false, false, null, null,
                     PriceModel.FIXED_COURSE, new BigDecimal("310.00"), CourseStatus.FULL, null), 10);
@@ -95,7 +94,7 @@ public class DevDataSeeder implements ApplicationRunner {
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
                     "Bachata Beginners", DanceStyle.BACHATA, CourseLevel.BEGINNER,
                     CourseType.PARTNER, "Start your Bachata journey with the fundamentals of partner dancing.",
-                    LocalDate.of(2026, 4, 6), RecurrenceType.WEEKLY, DayOfWeek.MONDAY,
+                    LocalDate.of(2026, 4, 6), RecurrenceType.WEEKLY,
                     6, LocalTime.of(18, 30), LocalTime.of(19, 45),
                     "Studio B", "Carlos", 16, false, false, null, null,
                     PriceModel.FIXED_COURSE, new BigDecimal("166.50"), CourseStatus.ACTIVE, null), 14);
@@ -105,7 +104,7 @@ public class DevDataSeeder implements ApplicationRunner {
             courseService.seedCourse(owner2.getId(), new CreateCourseDto(
                     "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
                     CourseType.PARTNER, "Introduction to Salsa for complete beginners.",
-                    LocalDate.of(2026, 4, 9), RecurrenceType.WEEKLY, DayOfWeek.THURSDAY,
+                    LocalDate.of(2026, 4, 9), RecurrenceType.WEEKLY,
                     8, LocalTime.of(18, 0), LocalTime.of(19, 0),
                     "Main Hall", "Ana", 20, false, false, null, null,
                     PriceModel.FIXED_COURSE, new BigDecimal("180.00"), CourseStatus.ACTIVE, null), 5);
@@ -113,7 +112,7 @@ public class DevDataSeeder implements ApplicationRunner {
             courseService.seedCourse(owner2.getId(), new CreateCourseDto(
                     "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
                     CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
-                    LocalDate.of(2026, 4, 11), RecurrenceType.WEEKLY, DayOfWeek.SATURDAY,
+                    LocalDate.of(2026, 4, 11), RecurrenceType.WEEKLY,
                     6, LocalTime.of(14, 0), LocalTime.of(15, 30),
                     "Main Hall", "Ana, Luis", 12, false, false, null, null,
                     PriceModel.FIXED_COURSE, new BigDecimal("200.00"), CourseStatus.ACTIVE, null), 8);

--- a/backend/src/main/resources/db/changelog/011-add-course-end-date.yaml
+++ b/backend/src/main/resources/db/changelog/011-add-course-end-date.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 011-add-course-end-date
+      author: claude
+      changes:
+        - addColumn:
+            tableName: course
+            columns:
+              - column:
+                  name: end_date
+                  type: DATE

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -19,3 +19,5 @@ databaseChangeLog:
       file: db/changelog/009-create-course.yaml
   - include:
       file: db/changelog/010-drop-enrollment-dates.yaml
+  - include:
+      file: db/changelog/011-add-course-end-date.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
@@ -140,16 +140,18 @@ class CourseControllerIntegrationTest {
     private void createCourse(School s, String title, DanceStyle danceStyle, CourseLevel level,
                               DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime,
                               int sessions, int enrolled, int max, BigDecimal price, CourseStatus status) {
+        LocalDate startDate = LocalDate.of(2026, 4, 7);
         Course course = new Course();
         course.setSchool(s);
         course.setTitle(title);
         course.setDanceStyle(danceStyle);
         course.setLevel(level);
         course.setCourseType(CourseType.PARTNER);
-        course.setStartDate(LocalDate.of(2026, 4, 7));
+        course.setStartDate(startDate);
         course.setRecurrenceType(RecurrenceType.WEEKLY);
         course.setDayOfWeek(dayOfWeek);
         course.setNumberOfSessions(sessions);
+        course.setEndDate(startDate.plusWeeks(sessions - 1));
         course.setStartTime(startTime);
         course.setEndTime(endTime);
         course.setLocation("Studio A");

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
@@ -72,7 +72,6 @@ class CourseCrudIntegrationTest {
                   "description": "Learn the basics of Salsa",
                   "startDate": "%s",
                   "recurrenceType": "WEEKLY",
-                  "dayOfWeek": "MONDAY",
                   "numberOfSessions": 8,
                   "startTime": "19:00",
                   "endTime": "20:00",
@@ -186,8 +185,9 @@ class CourseCrudIntegrationTest {
                     .andExpect(jsonPath("$.courseType").value("PARTNER"))
                     .andExpect(jsonPath("$.startDate").exists())
                     .andExpect(jsonPath("$.recurrenceType").value("WEEKLY"))
-                    .andExpect(jsonPath("$.dayOfWeek").value("WEDNESDAY"))
+                    .andExpect(jsonPath("$.dayOfWeek").exists())
                     .andExpect(jsonPath("$.numberOfSessions").value(10))
+                    .andExpect(jsonPath("$.endDate").exists())
                     .andExpect(jsonPath("$.startTime").value("20:00:00"))
                     .andExpect(jsonPath("$.endTime").value("21:15:00"))
                     .andExpect(jsonPath("$.location").value("Studio A"))
@@ -376,16 +376,18 @@ class CourseCrudIntegrationTest {
     }
 
     private Course createCourse(School school, String title) {
+        LocalDate startDate = LocalDate.now().plusDays(30);
         Course course = new Course();
         course.setSchool(school);
         course.setTitle(title);
         course.setDanceStyle(DanceStyle.BACHATA);
         course.setLevel(CourseLevel.ADVANCED);
         course.setCourseType(CourseType.PARTNER);
-        course.setStartDate(LocalDate.now().plusDays(30));
+        course.setStartDate(startDate);
         course.setRecurrenceType(RecurrenceType.WEEKLY);
-        course.setDayOfWeek(DayOfWeek.WEDNESDAY);
+        course.setDayOfWeek(startDate.getDayOfWeek());
         course.setNumberOfSessions(10);
+        course.setEndDate(startDate.plusWeeks(9));
         course.setStartTime(LocalTime.of(20, 0));
         course.setEndTime(LocalTime.of(21, 15));
         course.setLocation("Studio A");

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
@@ -124,16 +124,18 @@ class CourseTenantIsolationTest {
     }
 
     private void createCourse(School school, String title) {
+        LocalDate startDate = LocalDate.of(2026, 4, 7);
         Course course = new Course();
         course.setSchool(school);
         course.setTitle(title);
         course.setDanceStyle(DanceStyle.SALSA);
         course.setLevel(CourseLevel.BEGINNER);
         course.setCourseType(CourseType.PARTNER);
-        course.setStartDate(LocalDate.of(2026, 4, 7));
+        course.setStartDate(startDate);
         course.setRecurrenceType(RecurrenceType.WEEKLY);
         course.setDayOfWeek(DayOfWeek.MONDAY);
         course.setNumberOfSessions(8);
+        course.setEndDate(startDate.plusWeeks(7));
         course.setStartTime(LocalTime.of(19, 0));
         course.setEndTime(LocalTime.of(20, 0));
         course.setLocation("Studio A");

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -13,6 +13,7 @@ export interface CourseListItem {
   startTime: string;
   endTime: string;
   numberOfSessions: number;
+  endDate: string;
   enrolledStudents: number;
   maxParticipants: number;
   price: number;

--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -119,25 +119,31 @@
 
           <div class="form-row">
             <mat-form-field class="half-width" appearance="outline">
-              <mat-label>Day of Week</mat-label>
-              <mat-select formControlName="dayOfWeek">
-                @for (day of daysOfWeek; track day.value) {
-                  <mat-option [value]="day.value">{{ day.label }}</mat-option>
-                }
-              </mat-select>
-              @if (scheduleGroup.controls.dayOfWeek.hasError('required')) {
-                <mat-error>Day of week is required</mat-error>
-              }
-            </mat-form-field>
-
-            <mat-form-field class="half-width" appearance="outline">
               <mat-label>Number of Sessions</mat-label>
               <input matInput type="number" formControlName="numberOfSessions" min="1" />
               @if (scheduleGroup.controls.numberOfSessions.hasError('required')) {
                 <mat-error>Number of sessions is required</mat-error>
               }
             </mat-form-field>
+            <div class="half-width"></div>
           </div>
+
+          @if (derivedDayOfWeek || derivedEndDate) {
+            <div class="derived-fields">
+              @if (derivedDayOfWeek) {
+                <div class="derived-field">
+                  <span class="derived-label">Day of Week</span>
+                  <span class="derived-value">{{ derivedDayOfWeek }}</span>
+                </div>
+              }
+              @if (derivedEndDate) {
+                <div class="derived-field">
+                  <span class="derived-label">End Date</span>
+                  <span class="derived-value">{{ derivedEndDate }}</span>
+                </div>
+              }
+            </div>
+          }
 
           <div class="form-row">
             <mat-form-field class="half-width" appearance="outline">
@@ -299,12 +305,18 @@
               </div>
               <div class="review-field">
                 <span class="review-label">Day of Week</span>
-                <span class="review-value">{{ label(daysOfWeek, scheduleGroup.controls.dayOfWeek.value) }}</span>
+                <span class="review-value">{{ derivedDayOfWeek }}</span>
               </div>
               <div class="review-field">
                 <span class="review-label">Sessions</span>
                 <span class="review-value">{{ scheduleGroup.controls.numberOfSessions.value }}</span>
               </div>
+              @if (derivedEndDate) {
+                <div class="review-field">
+                  <span class="review-label">End Date</span>
+                  <span class="review-value">{{ derivedEndDate }}</span>
+                </div>
+              }
               <div class="review-field">
                 <span class="review-label">Time</span>
                 <span class="review-value">{{ scheduleGroup.controls.startTime.value }} – {{ scheduleGroup.controls.endTime.value }}</span>

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -147,6 +147,36 @@
   gap: var(--ds-spacing-5);
 }
 
+// Derived fields (read-only computed values shown in schedule step)
+.derived-fields {
+  display: flex;
+  gap: var(--ds-spacing-8);
+  padding: var(--ds-spacing-4) var(--ds-spacing-5);
+  background: var(--mat-sys-surface-variant);
+  border-radius: var(--ds-radius-md);
+
+  @include ds.bp-down(sm) {
+    flex-direction: column;
+    gap: var(--ds-spacing-3);
+  }
+}
+
+.derived-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-1);
+}
+
+.derived-label {
+  font: var(--mat-sys-label-medium);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.derived-value {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-on-surface);
+}
+
 // Registration step
 .registration-step {
   display: flex;

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -64,15 +64,7 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
   protected roleBalancingModes = ROLE_BALANCING_MODES;
   protected priceModels = PRICE_MODELS;
   protected courseStatuses = COURSE_STATUSES.filter(s => s.value === 'DRAFT' || s.value === 'ACTIVE');
-  protected daysOfWeek = [
-    { value: 'MONDAY', label: 'Monday' },
-    { value: 'TUESDAY', label: 'Tuesday' },
-    { value: 'WEDNESDAY', label: 'Wednesday' },
-    { value: 'THURSDAY', label: 'Thursday' },
-    { value: 'FRIDAY', label: 'Friday' },
-    { value: 'SATURDAY', label: 'Saturday' },
-    { value: 'SUNDAY', label: 'Sunday' },
-  ];
+  private static readonly DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
   protected get detailsGroup() {
     return this.formService.form.controls.details;
@@ -96,6 +88,24 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
 
   protected get isDraft(): boolean {
     return this.pricingGroup.controls.status.value === 'DRAFT';
+  }
+
+  protected get derivedDayOfWeek(): string {
+    const startDate = this.scheduleGroup.controls.startDate.value;
+    if (!startDate) return '';
+    const date = new Date(startDate + 'T00:00:00');
+    return CourseCreateComponent.DAY_NAMES[date.getDay()];
+  }
+
+  protected get derivedEndDate(): string {
+    const startDate = this.scheduleGroup.controls.startDate.value;
+    const sessions = this.scheduleGroup.controls.numberOfSessions.value;
+    const recurrence = this.scheduleGroup.controls.recurrenceType.value;
+    if (!startDate || !sessions || sessions < 1) return '';
+    const date = new Date(startDate + 'T00:00:00');
+    const intervalWeeks = recurrence === 'WEEKLY' ? 1 : 1;
+    date.setDate(date.getDate() + (sessions - 1) * 7 * intervalWeeks);
+    return date.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
   }
 
   ngOnInit(): void {

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -14,7 +14,6 @@ export class CourseFormService {
     schedule: new FormGroup({
       startDate: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
       recurrenceType: new FormControl('WEEKLY', { nonNullable: true, validators: [Validators.required] }),
-      dayOfWeek: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
       numberOfSessions: new FormControl<number | null>(null, { validators: [Validators.required, Validators.min(1)] }),
       startTime: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
       endTime: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -69,7 +68,6 @@ export class CourseFormService {
       schedule: {
         startDate: data['startDate'] as string,
         recurrenceType: data['recurrenceType'] as string,
-        dayOfWeek: data['dayOfWeek'] as string,
         numberOfSessions: data['numberOfSessions'] as number,
         startTime: data['startTime'] as string,
         endTime: data['endTime'] as string,


### PR DESCRIPTION
## Summary
- Remove redundant Day of Week dropdown from course creation — now derived automatically from the start date
- Add calculated End Date display (startDate + (sessions - 1) × recurrence interval) so owners see when a course ends
- Backend: remove `dayOfWeek` from `CreateCourseDto`, derive it in `CourseService`; add `endDate` field to entity and DTOs with Liquibase migration
- Frontend: replace dropdown with derived label, show End Date in a styled info section on the schedule step and review step

## Test plan
- [x] Backend compiles and all 71 tests pass
- [x] Frontend builds and all tests pass
- [x] Visual verification: create course form shows derived Day of Week ("Wednesday") and End Date ("Wednesday, June 17, 2026") correctly for April 15 start with 10 weekly sessions
- [x] Courses list still displays day of week correctly from API response

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)