### PR TITLE
Fix course form layout and add field help tooltips (#176)

### DIFF
--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -180,7 +180,7 @@
       @case (2) {
         <!-- Registration Step -->
         <div class="registration-step" [formGroup]="registrationGroup">
-          <div class="form-row">
+          <div class="form-row form-row--align-toggle">
             <mat-form-field class="half-width" appearance="outline">
               <mat-label>Max Participants</mat-label>
               <input matInput type="number" formControlName="maxParticipants" min="1" />
@@ -189,7 +189,10 @@
               }
             </mat-form-field>
             <div class="half-width toggle-field">
-              <mat-slide-toggle formControlName="waitingListEnabled">Enable Waiting List</mat-slide-toggle>
+              <mat-slide-toggle formControlName="waitingListEnabled">
+                Enable Waiting List
+              </mat-slide-toggle>
+              <app-field-help text="When enabled, students beyond the max participant limit are placed on a waiting list and automatically promoted when a spot opens." />
             </div>
           </div>
 
@@ -210,7 +213,10 @@
 
             <div class="form-row">
               <mat-form-field class="half-width" appearance="outline">
-                <mat-label>Role Balancing Mode</mat-label>
+                <mat-label>
+                  Partner Balancing
+                  <app-field-help text="Controls how leader/follower roles are balanced in partner dance courses." />
+                </mat-label>
                 <mat-select formControlName="roleBalancingMode" [disabled]="!isPartnerCourse">
                   @for (mode of roleBalancingModes; track mode.value) {
                     <mat-option [value]="mode.value">{{ mode.label }}</mat-option>
@@ -219,7 +225,10 @@
               </mat-form-field>
 
               <mat-form-field class="half-width" appearance="outline">
-                <mat-label>Role Balance Threshold</mat-label>
+                <mat-label>
+                  Max Imbalance
+                  <app-field-help text="The maximum allowed imbalance between leaders and followers before new sign-ups are waitlisted." />
+                </mat-label>
                 <input matInput type="number" formControlName="roleBalanceThreshold"
                        [readonly]="!isPartnerCourse" min="0" />
               </mat-form-field>
@@ -356,13 +365,13 @@
                 </div>
                 @if (registrationGroup.controls.roleBalancingMode.value) {
                   <div class="review-field">
-                    <span class="review-label">Role Balancing Mode</span>
+                    <span class="review-label">Partner Balancing</span>
                     <span class="review-value">{{ label(roleBalancingModes, registrationGroup.controls.roleBalancingMode.value) }}</span>
                   </div>
                 }
                 @if (registrationGroup.controls.roleBalanceThreshold.value) {
                   <div class="review-field">
-                    <span class="review-label">Role Balance Threshold</span>
+                    <span class="review-label">Max Imbalance</span>
                     <span class="review-value">{{ registrationGroup.controls.roleBalanceThreshold.value }}</span>
                   </div>
                 }

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -184,10 +184,16 @@
   gap: var(--ds-spacing-5);
 }
 
+.form-row--align-toggle {
+  align-items: flex-start;
+}
+
 .toggle-field {
   display: flex;
   align-items: center;
-  padding-top: var(--ds-spacing-2);
+  gap: var(--ds-spacing-1);
+  // Vertically center with mat-form-field input area (label + top padding)
+  margin-top: var(--ds-spacing-5);
 }
 
 .partner-settings {

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -9,12 +9,14 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { CourseFormService } from './course-form.service';
 import { CourseService } from '../course.service';
 import {
   DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES,
   ROLE_BALANCING_MODES, PRICE_MODELS, COURSE_STATUSES,
 } from '../../shared/course-constants';
+import { FieldHelpComponent } from '../../shared/field-help/field-help';
 
 interface StepDef {
   label: string;
@@ -25,7 +27,8 @@ interface StepDef {
   imports: [
     ReactiveFormsModule, RouterLink,
     MatFormFieldModule, MatInputModule, MatSelectModule,
-    MatButtonModule, MatIconModule, MatSlideToggleModule,
+    MatButtonModule, MatIconModule, MatSlideToggleModule, MatTooltipModule,
+    FieldHelpComponent,
   ],
   providers: [CourseFormService],
   templateUrl: './course-create.html',

--- a/frontend/src/app/shared/field-help/field-help.ts
+++ b/frontend/src/app/shared/field-help/field-help.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+@Component({
+  selector: 'app-field-help',
+  imports: [MatIconModule, MatTooltipModule],
+  template: `
+    <mat-icon
+      class="help-icon"
+      [matTooltip]="text()"
+      matTooltipPosition="above"
+      matTooltipClass="field-help-tooltip"
+    >help_outline</mat-icon>
+  `,
+  styles: `
+    .help-icon {
+      font-size: var(--ds-spacing-5);
+      width: var(--ds-spacing-5);
+      height: var(--ds-spacing-5);
+      color: var(--mat-sys-on-surface-variant);
+      cursor: help;
+      vertical-align: middle;
+      margin-left: var(--ds-spacing-1);
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FieldHelpComponent {
+  text = input.required<string>();
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -39,3 +39,8 @@ body {
   height: 100%;
 }
 /* You can add global styles to this file, and also import other style files */
+
+// Field help tooltip — wider than default for readable help text
+.field-help-tooltip .mdc-tooltip__surface {
+  max-width: 280px;
+}


### PR DESCRIPTION
## Summary
- Fix alignment between Max Participants input and Enable Waiting List toggle on the Registration step
- Add reusable `FieldHelpComponent` (shared) — a "?" icon with Material tooltip for contextual field help
- Apply help tooltips to Waiting List, Partner Balancing, and Max Imbalance fields
- Rename technical labels: "Role Balancing Mode" → "Partner Balancing", "Role Balance Threshold" → "Max Imbalance"

## Test plan
- [x] Build passes (`ng build`)
- [x] Visual verification: Registration step layout alignment verified via Playwright screenshot
- [x] Tooltip hover tested — displays correct help text
- [x] Review step labels updated to match renamed fields

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)