### PR TITLE
Fix currency display from EUR to CHF (#179)

### DIFF
--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -82,7 +82,7 @@
         <!-- Price -->
         <ng-container matColumnDef="price">
           <th mat-header-cell *matHeaderCellDef mat-sort-header>Price</th>
-          <td mat-cell *matCellDef="let course">{{ course.price | currency:'EUR' }}</td>
+          <td mat-cell *matCellDef="let course">{{ course.price | currency:'CHF' }}</td>
         </ng-container>
 
         <!-- Status -->


### PR DESCRIPTION
## Summary
- Changed currency formatting in the courses table from EUR to CHF

Closes #179

## Test plan
- [x] Build passes (`ng build`)
- [x] Visually verified courses table shows CHF prices via Playwright screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)