### PR TITLE
Extract schedule utils with tests, update frontend testing policy

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -89,7 +89,7 @@ Custom design tokens (`--ds-*`) extend Material's system tokens (`--mat-sys-*`).
 
 ## Testing
 
-No unit test convention for now. Components are thin Material wrappers. Visual verification via Playwright covers rendering regressions. Revisit when complexity in frontend grows.
+Write unit tests for business logic (calculations, derived values, data transformations). Pure UI/layout components are covered by visual verification via Playwright.
 
 ## Angular Rules
 

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -12,9 +12,11 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { CourseFormService } from './course-form.service';
 import { CourseService } from '../course.service';
+import { deriveDayOfWeek, deriveEndDate } from './schedule-utils';
 import {
   DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES,
   ROLE_BALANCING_MODES, PRICE_MODELS, COURSE_STATUSES,
+  RecurrenceType,
 } from '../../shared/course-constants';
 import { FieldHelpComponent } from '../../shared/field-help/field-help';
 
@@ -67,7 +69,6 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
   protected roleBalancingModes = ROLE_BALANCING_MODES;
   protected priceModels = PRICE_MODELS;
   protected courseStatuses = COURSE_STATUSES.filter(s => s.value === 'DRAFT' || s.value === 'ACTIVE');
-  private static readonly DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
   protected get detailsGroup() {
     return this.formService.form.controls.details;
@@ -94,21 +95,15 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
   }
 
   protected get derivedDayOfWeek(): string {
-    const startDate = this.scheduleGroup.controls.startDate.value;
-    if (!startDate) return '';
-    const date = new Date(startDate + 'T00:00:00');
-    return CourseCreateComponent.DAY_NAMES[date.getDay()];
+    return deriveDayOfWeek(this.scheduleGroup.controls.startDate.value);
   }
 
   protected get derivedEndDate(): string {
-    const startDate = this.scheduleGroup.controls.startDate.value;
-    const sessions = this.scheduleGroup.controls.numberOfSessions.value;
-    const recurrence = this.scheduleGroup.controls.recurrenceType.value;
-    if (!startDate || !sessions || sessions < 1) return '';
-    const date = new Date(startDate + 'T00:00:00');
-    const intervalWeeks = recurrence === 'WEEKLY' ? 1 : 1;
-    date.setDate(date.getDate() + (sessions - 1) * 7 * intervalWeeks);
-    return date.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+    return deriveEndDate(
+      this.scheduleGroup.controls.startDate.value,
+      this.scheduleGroup.controls.numberOfSessions.value,
+      this.scheduleGroup.controls.recurrenceType.value as RecurrenceType,
+    );
   }
 
   ngOnInit(): void {

--- a/frontend/src/app/courses/create/schedule-utils.spec.ts
+++ b/frontend/src/app/courses/create/schedule-utils.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { deriveDayOfWeek, deriveEndDate } from './schedule-utils';
+
+describe('deriveDayOfWeek', () => {
+  it('returns the correct day name for a Wednesday', () => {
+    expect(deriveDayOfWeek('2026-04-15')).toBe('Wednesday');
+  });
+
+  it('returns the correct day name for a Monday', () => {
+    expect(deriveDayOfWeek('2026-04-06')).toBe('Monday');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(deriveDayOfWeek('')).toBe('');
+  });
+});
+
+describe('deriveEndDate', () => {
+  it('calculates end date for 10 weekly sessions starting April 15', () => {
+    const result = deriveEndDate('2026-04-15', 10, 'WEEKLY');
+    expect(result).toContain('June 17, 2026');
+    expect(result).toContain('Wednesday');
+  });
+
+  it('returns the start date itself for 1 session', () => {
+    const result = deriveEndDate('2026-04-15', 1, 'WEEKLY');
+    expect(result).toContain('April 15, 2026');
+  });
+
+  it('returns empty string when startDate is missing', () => {
+    expect(deriveEndDate('', 10, 'WEEKLY')).toBe('');
+  });
+
+  it('returns empty string when sessions is null', () => {
+    expect(deriveEndDate('2026-04-15', null, 'WEEKLY')).toBe('');
+  });
+
+  it('returns empty string when sessions is 0', () => {
+    expect(deriveEndDate('2026-04-15', 0, 'WEEKLY')).toBe('');
+  });
+});

--- a/frontend/src/app/courses/create/schedule-utils.ts
+++ b/frontend/src/app/courses/create/schedule-utils.ts
@@ -1,0 +1,17 @@
+import { RecurrenceType } from '../../shared/course-constants';
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+export function deriveDayOfWeek(startDate: string): string {
+  if (!startDate) return '';
+  const date = new Date(startDate + 'T00:00:00');
+  return DAY_NAMES[date.getDay()];
+}
+
+export function deriveEndDate(startDate: string, numberOfSessions: number | null, recurrenceType: RecurrenceType): string {
+  if (!startDate || !numberOfSessions || numberOfSessions < 1) return '';
+  const date = new Date(startDate + 'T00:00:00');
+  const intervalWeeks = recurrenceType === 'WEEKLY' ? 1 : 1;
+  date.setDate(date.getDate() + (numberOfSessions - 1) * 7 * intervalWeeks);
+  return date.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+}


### PR DESCRIPTION
## Summary
- Extract `deriveDayOfWeek` and `deriveEndDate` into `schedule-utils.ts` — pure functions, easy to test
- Add unit tests covering day derivation, end date calculation, and edge cases (empty input, null sessions, single session)
- Simplify frontend `CLAUDE.md` testing section to one line

Follow-up to #175.

## Test plan
- [x] Frontend builds clean
- [x] All 10 tests pass (2 existing + 8 new schedule-utils tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)