### PR TITLE
Add edit button to courses table

### DIFF
--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -95,6 +95,16 @@
           </td>
         </ng-container>
 
+        <!-- Actions -->
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let course">
+            <a mat-icon-button [routerLink]="['/app/courses', course.id, 'edit']" aria-label="Edit course">
+              <mat-icon>edit</mat-icon>
+            </a>
+          </td>
+        </ng-container>
+
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
       </table>

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -75,6 +75,12 @@
   max-width: var(--ds-max-width-narrow);
 }
 
+// Actions column
+.mat-column-actions {
+  width: var(--ds-spacing-12);
+  text-align: center;
+}
+
 // Loading / error states
 .loading {
   display: flex;

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -54,7 +54,7 @@ export class CoursesComponent implements OnInit {
   protected filteredCount = computed(() => this.dataSource.filteredData.length);
 
   protected displayedColumns = [
-    'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'price', 'status',
+    'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'price', 'status', 'actions',
   ];
 
   @ViewChild(MatSort) set sort(sort: MatSort) {


### PR DESCRIPTION
## Summary
- Adds an actions column with an edit (pencil) icon button to each row in the courses table
- Clicking the button navigates to `/courses/:id/edit`, which loads the existing edit form pre-filled with course data
- The edit form, route, and backend PUT endpoint already existed — this PR just adds the missing UI entry point

Closes #178

## Test plan
- [x] Build passes (`ng build`)
- [x] All 10 unit tests pass (`ng test`)
- [x] Visual verification: edit icons display correctly in the courses table
- [x] Clicking edit navigates to the edit form with correct course data pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)