### PR TITLE
Add business event logging for domain operations

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
+import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class CourseService {
     }
 
     @Transactional
+    @BusinessOperation(event = "CourseCreated")
     public Long createCourse(Long userId, CreateCourseDto dto) {
         validateDomainRules(dto, true);
         School school = schoolService.findSchoolByMember(userId);
@@ -41,6 +43,7 @@ public class CourseService {
     }
 
     @Transactional
+    @BusinessOperation(event = "CourseUpdated")
     public CourseDetailDto updateCourse(Long userId, Long courseId, CreateCourseDto dto) {
         validateDomainRules(dto, false);
         School school = schoolService.findSchoolByMember(userId);

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.schoolmember.MemberRole;
 import ch.ruppen.danceschool.schoolmember.SchoolMember;
 import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
+import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import ch.ruppen.danceschool.shared.storage.ImageStorageService;
 import ch.ruppen.danceschool.user.AppUser;
 import ch.ruppen.danceschool.user.UserService;
@@ -29,6 +30,7 @@ public class SchoolService {
     private final UserService userService;
 
     @Transactional
+    @BusinessOperation(event = "SchoolCreated")
     public SchoolDetailDto createSchool(SchoolUpdateDto dto, Long userId) {
         AppUser user = userService.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", userId));
@@ -54,6 +56,7 @@ public class SchoolService {
         return toDetailDto(findSchoolByMember(userId));
     }
 
+    @BusinessOperation(event = "SchoolUpdated")
     public SchoolDetailDto updateSchool(Long userId, SchoolUpdateDto dto) {
         School school = findSchoolByMember(userId);
         deleteReplacedImages(school, dto);

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.schoolmember;
 
+import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,7 @@ public class SchoolMemberService {
                 .toList();
     }
 
+    @BusinessOperation(event = "MembershipCreated")
     public SchoolMember createMembership(SchoolMember member) {
         return schoolMemberRepository.save(member);
     }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspect.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspect.java
@@ -1,0 +1,115 @@
+package ch.ruppen.danceschool.shared.logging;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+class BusinessLoggingAspect {
+
+    @AfterReturning(pointcut = "@annotation(op)", returning = "result")
+    void logBusinessEvent(JoinPoint joinPoint, BusinessOperation op, Object result) {
+        Map<String, Object> details = new LinkedHashMap<>();
+        extractArgumentDetails(joinPoint, details);
+        extractResultDetails(result, details);
+
+        StringJoiner joiner = new StringJoiner(" ");
+        details.forEach((key, value) ->
+                joiner.add(value instanceof String
+                        ? key + "=\"" + value + "\""
+                        : key + "=" + value));
+
+        log.info("BUSINESS | {} | {}", op.event(), joiner);
+    }
+
+    private void extractArgumentDetails(JoinPoint joinPoint, Map<String, Object> details) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < args.length; i++) {
+            Object arg = args[i];
+            String name = paramNames[i];
+            if (arg == null) {
+                continue;
+            }
+            if (arg instanceof Long) {
+                details.put(name, arg);
+            } else if (arg instanceof String) {
+                details.put(name, arg);
+            } else {
+                extractAccessor(arg, "name", details);
+                extractAccessor(arg, "title", details);
+                extractAccessor(arg, "role", details);
+                extractNestedId(arg, "school", "schoolId", details);
+                extractNestedId(arg, "user", "userId", details);
+            }
+        }
+    }
+
+    private void extractResultDetails(Object result, Map<String, Object> details) {
+        if (result == null) {
+            return;
+        }
+        if (result instanceof Long id) {
+            details.put("resultId", id);
+            return;
+        }
+        extractAccessor(result, "id", details);
+        extractAccessor(result, "name", details);
+        extractAccessor(result, "title", details);
+        extractAccessor(result, "role", details);
+        extractNestedId(result, "school", "schoolId", details);
+        extractNestedId(result, "user", "userId", details);
+    }
+
+    private void extractAccessor(Object obj, String field, Map<String, Object> details) {
+        if (details.containsKey(field)) {
+            return;
+        }
+        Object value = invokeAccessor(obj, field);
+        if (value != null) {
+            details.put(field, value);
+        }
+    }
+
+    private void extractNestedId(Object obj, String nestedField, String targetKey,
+                                  Map<String, Object> details) {
+        if (details.containsKey(targetKey)) {
+            return;
+        }
+        Object nested = invokeAccessor(obj, nestedField);
+        if (nested != null) {
+            Object id = invokeAccessor(nested, "id");
+            if (id != null) {
+                details.put(targetKey, id);
+            }
+        }
+    }
+
+    private Object invokeAccessor(Object obj, String field) {
+        // Try record-style accessor first (field()), then getter (getField())
+        try {
+            Method method = obj.getClass().getMethod(field);
+            return method.invoke(obj);
+        } catch (Exception ignored) {
+        }
+        try {
+            String getter = "get" + Character.toUpperCase(field.charAt(0)) + field.substring(1);
+            Method method = obj.getClass().getMethod(getter);
+            return method.invoke(obj);
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/logging/BusinessOperation.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/logging/BusinessOperation.java
@@ -1,0 +1,12 @@
+package ch.ruppen.danceschool.shared.logging;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BusinessOperation {
+    String event();
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/user/UserService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/user/UserService.java
@@ -4,12 +4,14 @@ import ch.ruppen.danceschool.schoolmember.MembershipDto;
 import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -29,7 +31,9 @@ public class UserService {
                     user.setFirebaseUid(firebaseUid);
                     user.setEmail(email);
                     user.setName(name);
-                    return userRepository.save(user);
+                    AppUser saved = userRepository.save(user);
+                    log.info("BUSINESS | UserOnboarded | userId={} email=\"{}\"", saved.getId(), email);
+                    return saved;
                 });
     }
 

--- a/backend/src/test/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspectTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspectTest.java
@@ -1,0 +1,183 @@
+package ch.ruppen.danceschool.shared.logging;
+
+import java.util.List;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BusinessLoggingAspectTest {
+
+    private final BusinessLoggingAspect aspect = new BusinessLoggingAspect();
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void setUp() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        Logger logger = (Logger) LoggerFactory.getLogger(BusinessLoggingAspect.class);
+        logger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Logger logger = (Logger) LoggerFactory.getLogger(BusinessLoggingAspect.class);
+        logger.detachAppender(logAppender);
+    }
+
+    @Test
+    void logsEventWithLongAndStringArgs() {
+        JoinPoint joinPoint = mockJoinPoint(
+                new String[]{"userId", "email"},
+                new Object[]{3L, "leon@test.com"});
+        BusinessOperation op = mockOperation("UserOnboarded");
+
+        aspect.logBusinessEvent(joinPoint, op, null);
+
+        assertLogContains("BUSINESS | UserOnboarded | userId=3 email=\"leon@test.com\"");
+    }
+
+    @Test
+    void logsEventWithRecordDtoArg() {
+        JoinPoint joinPoint = mockJoinPoint(
+                new String[]{"userId", "dto"},
+                new Object[]{3L, new SampleDto("Bachata Beginners")});
+        BusinessOperation op = mockOperation("CourseCreated");
+
+        aspect.logBusinessEvent(joinPoint, op, 12L);
+
+        assertLogContains("BUSINESS | CourseCreated | userId=3 title=\"Bachata Beginners\" resultId=12");
+    }
+
+    @Test
+    void logsEventWithReturnValueFields() {
+        JoinPoint joinPoint = mockJoinPoint(
+                new String[]{"userId"},
+                new Object[]{3L});
+        BusinessOperation op = mockOperation("SchoolCreated");
+
+        aspect.logBusinessEvent(joinPoint, op, new SampleResult(5L, "Tanzwerk"));
+
+        assertLogContains("BUSINESS | SchoolCreated | userId=3 id=5 name=\"Tanzwerk\"");
+    }
+
+    @Test
+    void logsEventWithNestedIds() {
+        SampleParent school = new SampleParent(5L);
+        SampleParent user = new SampleParent(7L);
+        SampleMember member = new SampleMember(school, user, "OWNER");
+
+        JoinPoint joinPoint = mockJoinPoint(
+                new String[]{"member"},
+                new Object[]{member});
+        BusinessOperation op = mockOperation("MembershipCreated");
+
+        SampleMember result = new SampleMember(school, user, "OWNER");
+        result.setId(1L);
+
+        aspect.logBusinessEvent(joinPoint, op, result);
+
+        String logLine = lastLogMessage();
+        assertThat(logLine).contains("BUSINESS | MembershipCreated");
+        assertThat(logLine).contains("role=\"OWNER\"");
+        assertThat(logLine).contains("schoolId=5");
+        assertThat(logLine).contains("userId=7");
+        assertThat(logLine).contains("id=1");
+    }
+
+    @Test
+    void doesNotDuplicateKeysFromArgsAndResult() {
+        JoinPoint joinPoint = mockJoinPoint(
+                new String[]{"userId", "dto"},
+                new Object[]{3L, new SampleDto("Salsa")});
+        BusinessOperation op = mockOperation("CourseUpdated");
+
+        aspect.logBusinessEvent(joinPoint, op, new SampleDetailResult(12L, "Salsa"));
+
+        String logLine = lastLogMessage();
+        // "title" should appear only once (from arg dto, not duplicated from result)
+        assertThat(logLine.indexOf("title=")).isEqualTo(logLine.lastIndexOf("title="));
+    }
+
+    @Test
+    void handlesNullArgs() {
+        JoinPoint joinPoint = mockJoinPoint(
+                new String[]{"userId", "name"},
+                new Object[]{3L, null});
+        BusinessOperation op = mockOperation("TestEvent");
+
+        aspect.logBusinessEvent(joinPoint, op, null);
+
+        assertLogContains("BUSINESS | TestEvent | userId=3");
+    }
+
+    // --- helpers ---
+
+    private JoinPoint mockJoinPoint(String[] paramNames, Object[] args) {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        MethodSignature signature = mock(MethodSignature.class);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getParameterNames()).thenReturn(paramNames);
+        when(joinPoint.getArgs()).thenReturn(args);
+        return joinPoint;
+    }
+
+    private BusinessOperation mockOperation(String event) {
+        BusinessOperation op = mock(BusinessOperation.class);
+        when(op.event()).thenReturn(event);
+        return op;
+    }
+
+    private void assertLogContains(String expected) {
+        assertThat(lastLogMessage()).isEqualTo(expected);
+    }
+
+    private String lastLogMessage() {
+        List<ILoggingEvent> events = logAppender.list;
+        assertThat(events).isNotEmpty();
+        return events.getLast().getFormattedMessage();
+    }
+
+    // --- test doubles ---
+
+    record SampleDto(String title) {}
+
+    record SampleResult(Long id, String name) {}
+
+    record SampleDetailResult(Long id, String title) {}
+
+    static class SampleParent {
+        private final Long id;
+        SampleParent(Long id) { this.id = id; }
+        public Long getId() { return id; }
+    }
+
+    static class SampleMember {
+        private Long id;
+        private final SampleParent school;
+        private final SampleParent user;
+        private final String role;
+
+        SampleMember(SampleParent school, SampleParent user, String role) {
+            this.school = school;
+            this.user = user;
+            this.role = role;
+        }
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+        public SampleParent getSchool() { return school; }
+        public SampleParent getUser() { return user; }
+        public String getRole() { return role; }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #173

- Add `@BusinessOperation` annotation and `BusinessLoggingAspect` AOP aspect that logs structured business events (`BUSINESS | EventName | key=value`) on successful service method completion
- Annotate 5 service methods: `SchoolService.createSchool/updateSchool`, `CourseService.createCourse/updateCourse`, `SchoolMemberService.createMembership`
- `UserService.findOrCreateByFirebaseUid` uses manual logging inside the creation path (method runs on every auth, annotation would be too noisy)
- Aspect auto-extracts key identifiers from method args and return values via reflection (Long/String params, record accessors, getter methods, nested school/user IDs)

## Test plan

- [x] 6 unit tests for BusinessLoggingAspect covering: Long/String args, record DTO extraction, return value fields, nested ID extraction, key deduplication, null arg handling
- [x] All 71 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)