### PR TITLE
Consolidate visual testing docs into start-issue.md

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -30,9 +30,15 @@ Implement the changes according to the plan (or directly for trivial issues). Fo
 1. **Start backend:** `cd backend && ./mvnw spring-boot:run` (background)
 2. **Start frontend:** Angular MCP `devserver.start` (workspace: `frontend/`)
 3. **Wait for both** to be ready
-4. **Login:** Use Playwright MCP to navigate to the app and log in with `owner@test.com` / `password` (click the Owner quick-login button)
+4. **Login:** Use Playwright MCP `browser_navigate` to the login page and click the Owner quick-login button (`owner@test.com` / `password`)
 5. **Navigate and screenshot:** Visit all pages affected by the change. Take screenshots to verify visual correctness.
 6. **Stop servers:** Stop the frontend devserver (Angular MCP `devserver.stop`) and kill the backend process
+
+### Playwright rules
+- Use `browser_snapshot` over `browser_take_screenshot` when you need to interact with elements (click, fill, etc.)
+- Use `browser_take_screenshot` to visually verify layout and styling
+- **Never use `browser_navigate` / `page.goto()` after the initial login** — direct URL navigation reloads the page and loses the Angular auth session. Always navigate via sidebar links and in-app buttons instead. The only `browser_navigate` call should be to the login page.
+- **Always take a final screenshot before committing** style or layout changes
 
 ## Phase 5 — Ship
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Use `/start-issue <number>` to work on a GitHub issue. This runs the full automa
 **Setup** → load issue, create worktree + branch, install deps
 **Plan** → enter plan mode for non-trivial issues (use judgment to skip for trivial fixes)
 **Implement** → code, build, test
-**Visual E2E** → start both servers, login via Playwright, screenshot affected pages
+**Visual Testing Workflow** → start both servers, login via Playwright, screenshot affected pages
 **Ship** → commit, rebase, push, PR, watch CI, squash merge
 
 **Do not stop between phases** unless genuinely blocked. Auto-merge after CI passes — no manual review needed.
@@ -61,34 +61,13 @@ See `.claude/commands/start-issue.md` for the full step-by-step.
 
 ## Visual Testing Workflow
 
-Required for all frontend changes. Skip only for purely backend issues with no UI impact.
+Required for all frontend changes. Skip only for purely backend issues with no UI impact. The full procedure (start servers, login, screenshot, stop) is in `.claude/commands/start-issue.md` Phase 4.
 
-### 1. Start both servers
-
+**Key details for reference:**
 - **Backend:** `cd backend && ./mvnw spring-boot:run` (runs on `http://localhost:8080`)
 - **Frontend:** Angular MCP `devserver.start` (workspace: `frontend/`) — uses `proxy.conf.json` to forward `/api` requests to the backend
-- Wait for both to be ready before proceeding
-
-### 2. Log in
-
 - **Dev credentials:** `owner@test.com` / `password` (School 1) or `owner2@test.com` / `password` (School 2)
-- The login page shows a simple email/password form with quick-login buttons for each owner
-- Use Playwright MCP to click a quick-login button
-
-### 3. Handle fresh database state
-
-The backend uses H2 in-memory, so every restart is a clean slate. However, `DevDataSeeder` automatically seeds two dev users with separate schools on startup, so login lands directly in the app shell — no onboarding step needed.
-
-### 4. Navigate and screenshot
-
-- Use Playwright `browser_navigate` to the relevant page
-- Use `browser_take_screenshot` to visually verify layout and styling
-- **Always take a final screenshot before committing** style or layout changes
-
-### 5. Stop servers
-
-- Stop the frontend devserver: Angular MCP `devserver.stop`
-- Kill the backend process
+- **Database:** H2 in-memory — every restart is a clean slate, but `DevDataSeeder` seeds two owners with separate schools automatically
 
 ## Working Rules
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,13 +20,9 @@ Use MCP tools for the develop → verify loop:
 3. **Start dev server:** Angular MCP `devserver.start` (workspace: `frontend/`)
 4. **Wait for build:** Angular MCP `devserver.wait_for_build` — also call this after every code change to confirm it compiled
    - **Fallback:** If `wait_for_build` returns the same error after you've fixed the code, don't cycle stop/restart — run `npx ng build` directly to get the real build status. The MCP devserver can cache stale errors.
-5. **Visual verify:** Follow the end-to-end Visual Testing Workflow in the root `CLAUDE.md` — start backend, log in, navigate, and screenshot affected pages.
-6. **Stop server:** Angular MCP `devserver.stop` when done
+5. **Stop server:** Angular MCP `devserver.stop` when done
 
-### Playwright MCP tips
-- Use `browser_snapshot` over `browser_take_screenshot` when you need to interact with elements (click, fill, etc.)
-- Use `browser_take_screenshot` to visually verify layout and styling
-- **Never use `browser_navigate` / `page.goto()` after the initial login** — direct URL navigation reloads the page and loses the Angular auth session. Always navigate via sidebar links and in-app buttons instead. The only `browser_navigate` call should be to the login page.
+Visual verification (Playwright screenshots) is handled by `/start-issue` Phase 4 — see `.claude/commands/start-issue.md` for the full procedure and Playwright rules.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Make `start-issue.md` Phase 4 the single source of truth for visual verification
- Add Playwright rules (snapshot vs screenshot, never goto after login) to `start-issue.md`
- Slim down root `CLAUDE.md` — keep reference info, point to start-issue for procedure
- Slim down `frontend/CLAUDE.md` — remove duplicated workflow, point to start-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)