### PR TITLE
Clean up docs: consolidate dev workflow, expand testing rules

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -19,16 +19,15 @@ Assess whether the issue is trivial or non-trivial:
 
 ## Phase 3 — Implementation
 
-Implement the changes according to the plan (or directly for trivial issues). Follow all project conventions in CLAUDE.md files. Run builds and tests as you go:
-- **Frontend:** `npx ng build`, `npx ng test --browsers chromium --no-watch`
-- **Backend:** `cd backend && ./mvnw test`
+Implement the changes according to the plan (or directly for trivial issues). Follow all project conventions in CLAUDE.md files. Run builds and tests as you go — see each CLAUDE.md for the exact commands.
 
-## Phase 4 — Visual Verification
+## Phase 4 — Visual Verification End to End
 
 **Always run this for frontend changes.** Skip only if the issue is purely backend with no UI impact.
 
 1. **Start backend:** `cd backend && ./mvnw spring-boot:run` (background)
-2. **Start frontend:** Angular MCP `devserver.start` (workspace: `frontend/`)
+2. **Start frontend:** Angular MCP `devserver.start` (workspace: `frontend/`), then `devserver.wait_for_build`
+   - **After code changes:** call `devserver.wait_for_build` again to confirm it compiled. If it returns the same stale error after a fix, run `npx ng build` directly — the MCP devserver can cache stale errors.
 3. **Wait for both** to be ready
 4. **Login:** Use Playwright MCP `browser_navigate` to the login page and click the Owner quick-login button (`owner@test.com` / `password`)
 5. **Navigate and screenshot:** Visit all pages affected by the change. Take screenshots to verify visual correctness.

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -60,6 +60,7 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 
 ### 8. Logging
 - AOP aspects in `shared/logging/` handle general logging (controllers, services), expand if necessary
+- Annotate service methods that represent domain events (create, update, delete) with `@BusinessOperation(event = "EventName")` — the `BusinessLoggingAspect` logs these automatically
 
 ## Security
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -10,6 +10,7 @@ DDD-style glossary. Canonical naming for code, APIs, and conversation.
 | **Teacher**    | A member role (future). Can manage classes but not school settings.                                  |
 | **Class**      | A dance class offered by a school (e.g., "Salsa Beginners, Monday 19:00"). Created by Owner/Teacher.|
 | **Student**    | An end user of the student-facing apps (future). Browses schools, views classes, enrolls.           |
+| **PricingPlan** | A subscription product template defined by a school. Has a lifecycle: DRAFT → ACTIVE → ARCHIVED. Students purchase plans to get access to classes. |
 | **Enrollment** | A student signing up for a class (future).                                                          |
 
 ## Bounded Contexts

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -4,25 +4,12 @@
 
 - **Install:** `npm install`
 - **Build:** `ng build`
-- **Test:** `ng test --browsers chromium --no-watch` (or use Angular MCP `test`)
+- **Test:** `npx ng test --browsers chromium --no-watch` (or use Angular MCP `test`)
   - Requires `@vitest/browser-playwright` + `playwright` (already installed)
   - Browser binary: `npx playwright install chromium` (already done)
 - **Lint:** `ng lint`
 
-All commands run from the `frontend/` directory. For the dev server, see the workflow below.
-
-## Frontend Development Workflow
-
-Use MCP tools for the develop → verify loop:
-
-1. **Install dependencies:** Run `npm install` if in a fresh worktree or after pulling new changes
-2. **Verify build first:** Run `npx ng build` to confirm compilation before starting the dev server. This catches errors faster than the MCP devserver.
-3. **Start dev server:** Angular MCP `devserver.start` (workspace: `frontend/`)
-4. **Wait for build:** Angular MCP `devserver.wait_for_build` — also call this after every code change to confirm it compiled
-   - **Fallback:** If `wait_for_build` returns the same error after you've fixed the code, don't cycle stop/restart — run `npx ng build` directly to get the real build status. The MCP devserver can cache stale errors.
-5. **Stop server:** Angular MCP `devserver.stop` when done
-
-Visual verification (Playwright screenshots) is handled by `/start-issue` Phase 4 — see `.claude/commands/start-issue.md` for the full procedure and Playwright rules.
+All commands run from the `frontend/` directory.
 
 ## Architecture
 
@@ -85,7 +72,9 @@ Custom design tokens (`--ds-*`) extend Material's system tokens (`--mat-sys-*`).
 
 ## Testing
 
-Write unit tests for business logic (calculations, derived values, data transformations). Pure UI/layout components are covered by visual verification via Playwright.
+1. **Business logic** — calculations, data transformations, derived values, formatting. Pure unit tests.
+2. **Data-display correctness** — components that render dynamic data (tables, summaries, detail views). Render with mock data, assert all expected fields/columns are present in the output.
+3. **Conditional rendering** — things that show/hide based on state. Render with different inputs, assert presence/absence of elements.
 
 ## Angular Rules
 


### PR DESCRIPTION
## Summary

- Remove redundant Frontend Development Workflow section (covered by start-issue.md)
- Move `wait_for_build` fallback tip into start-issue.md Phase 4
- Expand frontend testing rules: business logic, data-display correctness, conditional rendering
- Add `@BusinessOperation` annotation rule to backend logging docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)