### PR TITLE
Add course levels and fix schedule layout (#186)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseLevel.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseLevel.java
@@ -1,7 +1,9 @@
 package ch.ruppen.danceschool.course;
 
 public enum CourseLevel {
+    STARTER,
     BEGINNER,
     INTERMEDIATE,
-    ADVANCED
+    ADVANCED,
+    MASTERCLASS
 }

--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -117,33 +117,27 @@
             </mat-form-field>
           </div>
 
-          <div class="form-row">
-            <mat-form-field class="half-width" appearance="outline">
+          <div class="form-row sessions-row">
+            <mat-form-field class="third-width" appearance="outline">
               <mat-label>Number of Sessions</mat-label>
               <input matInput type="number" formControlName="numberOfSessions" min="1" />
               @if (scheduleGroup.controls.numberOfSessions.hasError('required')) {
                 <mat-error>Number of sessions is required</mat-error>
               }
             </mat-form-field>
-            <div class="half-width"></div>
+            @if (derivedDayOfWeek) {
+              <div class="derived-field third-width">
+                <span class="derived-label">Day of Week</span>
+                <span class="derived-value">{{ derivedDayOfWeek }}</span>
+              </div>
+            }
+            @if (derivedEndDate) {
+              <div class="derived-field third-width">
+                <span class="derived-label">End Date</span>
+                <span class="derived-value">{{ derivedEndDate }}</span>
+              </div>
+            }
           </div>
-
-          @if (derivedDayOfWeek || derivedEndDate) {
-            <div class="derived-fields">
-              @if (derivedDayOfWeek) {
-                <div class="derived-field">
-                  <span class="derived-label">Day of Week</span>
-                  <span class="derived-value">{{ derivedDayOfWeek }}</span>
-                </div>
-              }
-              @if (derivedEndDate) {
-                <div class="derived-field">
-                  <span class="derived-label">End Date</span>
-                  <span class="derived-value">{{ derivedEndDate }}</span>
-                </div>
-              }
-            </div>
-          }
 
           <div class="form-row">
             <mat-form-field class="half-width" appearance="outline">

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -147,24 +147,23 @@
   gap: var(--ds-spacing-5);
 }
 
-// Derived fields (read-only computed values shown in schedule step)
-.derived-fields {
-  display: flex;
-  gap: var(--ds-spacing-8);
-  padding: var(--ds-spacing-4) var(--ds-spacing-5);
-  background: var(--mat-sys-surface-variant);
-  border-radius: var(--ds-radius-md);
+// Sessions row with inline derived fields
+.sessions-row {
+  align-items: center;
+}
 
-  @include ds.bp-down(sm) {
-    flex-direction: column;
-    gap: var(--ds-spacing-3);
-  }
+.third-width {
+  flex: 1;
+  min-width: 0;
 }
 
 .derived-field {
   display: flex;
   flex-direction: column;
   gap: var(--ds-spacing-1);
+  padding: var(--ds-spacing-3) var(--ds-spacing-4);
+  background: var(--mat-sys-surface-variant);
+  border-radius: var(--ds-radius-md);
 }
 
 .derived-label {

--- a/frontend/src/app/shared/course-constants.ts
+++ b/frontend/src/app/shared/course-constants.ts
@@ -1,5 +1,5 @@
 export type DanceStyle = 'SALSA' | 'BACHATA' | 'MERENGUE' | 'KIZOMBA' | 'ZOUK' | 'AFRO' | 'OTHER';
-export type CourseLevel = 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+export type CourseLevel = 'STARTER' | 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED' | 'MASTERCLASS';
 export type CourseType = 'PARTNER' | 'SOLO';
 export type CourseStatus = 'DRAFT' | 'ACTIVE' | 'FULL' | 'INACTIVE';
 export type RecurrenceType = 'WEEKLY';
@@ -15,9 +15,11 @@ export const DANCE_STYLES: { value: DanceStyle; label: string }[] = [
 ];
 
 export const COURSE_LEVELS: { value: CourseLevel; label: string }[] = [
+  { value: 'STARTER', label: 'Starter' },
   { value: 'BEGINNER', label: 'Beginner' },
   { value: 'INTERMEDIATE', label: 'Intermediate' },
   { value: 'ADVANCED', label: 'Advanced' },
+  { value: 'MASTERCLASS', label: 'Masterclass' },
 ];
 
 export const COURSE_TYPES: { value: CourseType; label: string }[] = [


### PR DESCRIPTION
## Summary
- Add `STARTER` and `MASTERCLASS` to `CourseLevel` enum (backend + frontend constants)
- Move derived fields (Day of Week, End Date) onto the same row as Number of Sessions in the Schedule step
- Item 3 (waitlist toggle alignment) is obsolete per #186 comment — removed in #188

Closes #186

## Test plan
- [x] Backend tests pass (76/76)
- [x] Frontend tests pass (10/10)
- [x] Frontend builds successfully
- [x] Visual verification: Level dropdown shows all 5 levels (Starter → Masterclass)
- [x] Visual verification: Schedule step shows Number of Sessions, Day of Week, End Date in a single row

🤖 Generated with [Claude Code](https://claude.com/claude-code)