### PR TITLE
Add inline future date validation to course start date (#196)

### DIFF
--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -104,6 +104,8 @@
               <input matInput type="date" formControlName="startDate" />
               @if (scheduleGroup.controls.startDate.hasError('required')) {
                 <mat-error>Start date is required</mat-error>
+              } @else if (scheduleGroup.controls.startDate.hasError('futureDate')) {
+                <mat-error>Start date must be in the future</mat-error>
               }
             </mat-form-field>
 

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -110,6 +110,7 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
     if (id) {
       this.editId.set(+id);
       this.loading.set(true);
+      this.formService.clearFutureDateValidator();
       this.courseService.getCourse(+id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
         next: (data) => {
           this.formService.populate(data);

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
 
 @Injectable()
 export class CourseFormService {
@@ -12,7 +12,7 @@ export class CourseFormService {
       description: new FormControl('', { nonNullable: true }),
     }),
     schedule: new FormGroup({
-      startDate: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+      startDate: new FormControl('', { nonNullable: true, validators: [Validators.required, futureDateValidator] }),
       recurrenceType: new FormControl('WEEKLY', { nonNullable: true, validators: [Validators.required] }),
       numberOfSessions: new FormControl<number | null>(null, { validators: [Validators.required, Validators.min(1)] }),
       startTime: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -106,7 +106,21 @@ export class CourseFormService {
     return this.form.dirty;
   }
 
+  clearFutureDateValidator(): void {
+    this.form.controls.schedule.controls.startDate.removeValidators(futureDateValidator);
+    this.form.controls.schedule.controls.startDate.updateValueAndValidity();
+  }
+
   reset(): void {
     this.form.reset();
   }
+}
+
+export function futureDateValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value;
+  if (!value) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const selected = new Date(value + 'T00:00:00');
+  return selected > today ? null : { futureDate: true };
 }

--- a/frontend/src/app/courses/create/future-date-validator.spec.ts
+++ b/frontend/src/app/courses/create/future-date-validator.spec.ts
@@ -1,0 +1,28 @@
+import { FormControl } from '@angular/forms';
+import { futureDateValidator } from './course-form.service';
+
+describe('futureDateValidator', () => {
+  it('should return null for a future date', () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const value = tomorrow.toISOString().split('T')[0];
+    const control = new FormControl(value);
+    expect(futureDateValidator(control)).toBeNull();
+  });
+
+  it('should return error for today', () => {
+    const today = new Date().toISOString().split('T')[0];
+    const control = new FormControl(today);
+    expect(futureDateValidator(control)).toEqual({ futureDate: true });
+  });
+
+  it('should return error for a past date', () => {
+    const control = new FormControl('2020-01-01');
+    expect(futureDateValidator(control)).toEqual({ futureDate: true });
+  });
+
+  it('should return null for empty value', () => {
+    const control = new FormControl('');
+    expect(futureDateValidator(control)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `futureDateValidator` custom validator on the `startDate` form control that rejects dates not in the future
- Show inline `<mat-error>` "Start date must be in the future" on the schedule step
- Stepper blocks progression past schedule step when date is invalid
- Validator is removed in edit mode so existing courses with past dates can still be edited

## Test plan
- [x] 4 unit tests for `futureDateValidator`: future date (pass), today (fail), past date (fail), empty (pass)
- [x] All 20 tests pass
- [x] Build passes
- [x] Visual verification: entered past date, clicked Next — inline error shown, step blocked

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)