### PR TITLE
Course Overview Page with shared summary component

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -37,6 +37,10 @@ export const routes: Routes = [
         loadComponent: () => import('./courses/create/course-create').then(m => m.CourseCreateComponent),
         canDeactivate: [unsavedChangesGuard],
       },
+      {
+        path: 'courses/:id',
+        loadComponent: () => import('./courses/overview/course-overview').then(m => m.CourseOverviewComponent),
+      },
       { path: 'courses', loadComponent: () => import('./courses/courses').then(m => m.CoursesComponent) },
       { path: 'payments', loadComponent: () => import('./payments/payments').then(m => m.PaymentsComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -20,6 +20,32 @@ export interface CourseListItem {
   status: CourseStatus;
 }
 
+export interface CourseDetail {
+  id: number;
+  title: string;
+  danceStyle: DanceStyle;
+  level: CourseLevel;
+  courseType: string;
+  description: string | null;
+  startDate: string;
+  dayOfWeek: string;
+  recurrenceType: string;
+  numberOfSessions: number;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+  location: string;
+  teachers: string | null;
+  maxParticipants: number;
+  roleBalancingEnabled: boolean;
+  roleBalanceThreshold: number | null;
+  priceModel: string;
+  price: number;
+  status: CourseStatus;
+  publishDate: string | null;
+  enrolledStudents: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class CourseService {
   private http = inject(HttpClient);
@@ -28,8 +54,8 @@ export class CourseService {
     return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`);
   }
 
-  getCourse(id: number): Observable<Record<string, unknown>> {
-    return this.http.get<Record<string, unknown>>(`${environment.apiUrl}/api/courses/${id}`);
+  getCourse(id: number): Observable<CourseDetail> {
+    return this.http.get<CourseDetail>(`${environment.apiUrl}/api/courses/${id}`);
   }
 
   createCourse(dto: Record<string, unknown>): Observable<{ id: number }> {

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -11,6 +11,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { CourseListItem, CourseService } from './course.service';
+import { formatDayShort, formatTime as stripSeconds } from './shared/format-utils';
 import { DANCE_STYLES, COURSE_LEVELS } from '../shared/course-constants';
 
 interface CourseFilter {
@@ -128,15 +129,11 @@ export class CoursesComponent implements OnInit {
   }
 
   protected formatDay(dayOfWeek: string): string {
-    const days: Record<string, string> = {
-      MONDAY: 'Mon', TUESDAY: 'Tue', WEDNESDAY: 'Wed',
-      THURSDAY: 'Thu', FRIDAY: 'Fri', SATURDAY: 'Sat', SUNDAY: 'Sun',
-    };
-    return days[dayOfWeek] ?? dayOfWeek;
+    return formatDayShort(dayOfWeek);
   }
 
   protected formatTime(time: string): string {
-    return time.substring(0, 5);
+    return stripSeconds(time);
   }
 
   protected sessionDuration(startTime: string, endTime: string): number {

--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -244,128 +244,6 @@
       @case (4) {
         <!-- Review Step -->
         <div class="review-step">
-          <!-- Details Card -->
-          <div class="review-card">
-            <div class="review-card-header">
-              <h3 class="review-card-title">Details</h3>
-              <button mat-button class="edit-link" (click)="goToStep(0)" type="button">Edit</button>
-            </div>
-            <div class="review-card-content review-card-content--grid">
-              <div class="review-field review-field--full">
-                <span class="review-label">Course Title</span>
-                <span class="review-value">{{ detailsGroup.controls.title.value }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Dance Style</span>
-                <span class="review-value">{{ label(danceStyles, detailsGroup.controls.danceStyle.value) }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Level</span>
-                <span class="review-value">{{ label(levels, detailsGroup.controls.level.value) }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Course Type</span>
-                <span class="review-value">{{ label(courseTypes, detailsGroup.controls.courseType.value) }}</span>
-              </div>
-              @if (detailsGroup.controls.description.value) {
-                <div class="review-field review-field--full">
-                  <span class="review-label">Description</span>
-                  <span class="review-value">{{ detailsGroup.controls.description.value }}</span>
-                </div>
-              }
-            </div>
-          </div>
-
-          <!-- Schedule Card -->
-          <div class="review-card">
-            <div class="review-card-header">
-              <h3 class="review-card-title">Schedule</h3>
-              <button mat-button class="edit-link" (click)="goToStep(1)" type="button">Edit</button>
-            </div>
-            <div class="review-card-content review-card-content--grid">
-              <div class="review-field">
-                <span class="review-label">Start Date</span>
-                <span class="review-value">{{ scheduleGroup.controls.startDate.value }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Day of Week</span>
-                <span class="review-value">{{ derivedDayOfWeek }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Recurrence</span>
-                <span class="review-value">{{ label(recurrenceTypes, scheduleGroup.controls.recurrenceType.value) }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Sessions</span>
-                <span class="review-value">{{ scheduleGroup.controls.numberOfSessions.value }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Time</span>
-                <span class="review-value">{{ scheduleGroup.controls.startTime.value }} – {{ scheduleGroup.controls.endTime.value }}</span>
-              </div>
-              @if (derivedEndDate) {
-                <div class="review-field">
-                  <span class="review-label">End Date</span>
-                  <span class="review-value">{{ derivedEndDate }}</span>
-                </div>
-              }
-              <div class="review-field review-field--full">
-                <span class="review-label">Location</span>
-                <span class="review-value">{{ scheduleGroup.controls.location.value }}</span>
-              </div>
-              @if (scheduleGroup.controls.teachers.value) {
-                <div class="review-field review-field--full">
-                  <span class="review-label">Teachers</span>
-                  <span class="review-value">{{ scheduleGroup.controls.teachers.value }}</span>
-                </div>
-              }
-            </div>
-          </div>
-
-          <!-- Registration Card -->
-          <div class="review-card">
-            <div class="review-card-header">
-              <h3 class="review-card-title">Registration</h3>
-              <button mat-button class="edit-link" (click)="goToStep(2)" type="button">Edit</button>
-            </div>
-            <div class="review-card-content review-card-content--grid">
-              <div class="review-field">
-                <span class="review-label">Max Participants</span>
-                <span class="review-value">{{ registrationGroup.controls.maxParticipants.value }}</span>
-              </div>
-              @if (isPartnerCourse) {
-                <div class="review-field">
-                  <span class="review-label">Role Balancing</span>
-                  <span class="review-value">{{ registrationGroup.controls.roleBalancingEnabled.value ? 'Enabled' : 'Disabled' }}</span>
-                </div>
-                @if (registrationGroup.controls.roleBalancingEnabled.value && registrationGroup.controls.roleBalanceThreshold.value) {
-                  <div class="review-field">
-                    <span class="review-label">Max Imbalance</span>
-                    <span class="review-value">{{ registrationGroup.controls.roleBalanceThreshold.value }}</span>
-                  </div>
-                }
-              }
-            </div>
-          </div>
-
-          <!-- Pricing Card -->
-          <div class="review-card">
-            <div class="review-card-header">
-              <h3 class="review-card-title">Pricing</h3>
-              <button mat-button class="edit-link" (click)="goToStep(3)" type="button">Edit</button>
-            </div>
-            <div class="review-card-content review-card-content--grid">
-              <div class="review-field">
-                <span class="review-label">Price Model</span>
-                <span class="review-value">{{ label(priceModels, pricingGroup.controls.priceModel.value) }}</span>
-              </div>
-              <div class="review-field">
-                <span class="review-label">Price</span>
-                <span class="review-value">CHF {{ pricingGroup.controls.price.value }}</span>
-              </div>
-            </div>
-          </div>
-
           <!-- Publishing Settings -->
           <div class="publishing-settings" [formGroup]="pricingGroup">
             <h3 class="section-title">Publishing Settings</h3>
@@ -386,6 +264,9 @@
               </mat-form-field>
             </div>
           </div>
+
+          <!-- Course Summary -->
+          <app-course-summary [data]="reviewData" (edit)="goToStep($event)" />
         </div>
       }
     }

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -201,6 +201,12 @@
   margin: 0;
 }
 
+.section-hint {
+  font: var(--mat-sys-body-small);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}
+
 .field-hint {
   font: var(--mat-sys-body-small);
   color: var(--mat-sys-on-surface-variant);
@@ -241,65 +247,6 @@
   display: flex;
   flex-direction: column;
   gap: var(--ds-spacing-5);
-}
-
-.review-card {
-  border: 1px solid var(--mat-sys-outline-variant);
-  border-radius: var(--ds-radius-md);
-  padding: var(--ds-spacing-6);
-}
-
-.review-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: var(--ds-spacing-4);
-}
-
-.review-card-title {
-  font: var(--mat-sys-title-medium);
-  color: var(--mat-sys-on-surface);
-  margin: 0;
-}
-
-.edit-link {
-  color: var(--mat-sys-primary);
-}
-
-.review-card-content {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-spacing-3);
-
-  &--grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--ds-spacing-3) var(--ds-spacing-8);
-
-    @include ds.bp-down(sm) {
-      grid-template-columns: 1fr;
-    }
-  }
-}
-
-.review-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-spacing-1);
-
-  &--full {
-    grid-column: 1 / -1;
-  }
-}
-
-.review-label {
-  font: var(--mat-sys-label-medium);
-  color: var(--mat-sys-on-surface-variant);
-}
-
-.review-value {
-  font: var(--mat-sys-body-large);
-  color: var(--mat-sys-on-surface);
 }
 
 .publishing-settings {

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -14,6 +14,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { CourseFormService } from './course-form.service';
 import { extractErrorMessage } from '../../shared/error-utils';
 import { CourseService } from '../course.service';
+import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summary';
 import { deriveDayOfWeek, deriveEndDate } from './schedule-utils';
 import {
   DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES,
@@ -31,6 +32,7 @@ interface StepDef {
     ReactiveFormsModule, RouterLink,
     MatFormFieldModule, MatInputModule, MatSelectModule,
     MatButtonModule, MatIconModule, MatSlideToggleModule, MatTooltipModule,
+    CourseSummaryComponent,
   ],
   providers: [CourseFormService],
   templateUrl: './course-create.html',
@@ -93,6 +95,31 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
     return this.pricingGroup.controls.status.value === 'DRAFT';
   }
 
+  protected get reviewData(): CourseSummaryData {
+    return {
+      title: this.detailsGroup.controls.title.value,
+      danceStyle: this.detailsGroup.controls.danceStyle.value,
+      level: this.detailsGroup.controls.level.value,
+      courseType: this.detailsGroup.controls.courseType.value,
+      description: this.detailsGroup.controls.description.value || null,
+      startDate: this.scheduleGroup.controls.startDate.value,
+      dayOfWeek: this.derivedDayOfWeek,
+      recurrenceType: this.scheduleGroup.controls.recurrenceType.value,
+      numberOfSessions: this.scheduleGroup.controls.numberOfSessions.value ?? 0,
+      endDate: this.derivedEndDate || null,
+      startTime: this.scheduleGroup.controls.startTime.value,
+      endTime: this.scheduleGroup.controls.endTime.value,
+      location: this.scheduleGroup.controls.location.value,
+      teachers: this.scheduleGroup.controls.teachers.value || null,
+      maxParticipants: this.registrationGroup.controls.maxParticipants.value ?? 0,
+      roleBalancingEnabled: this.registrationGroup.controls.roleBalancingEnabled.value,
+      roleBalanceThreshold: this.registrationGroup.controls.roleBalanceThreshold.value,
+      priceModel: this.pricingGroup.controls.priceModel.value,
+      price: this.pricingGroup.controls.price.value ?? 0,
+      isPartnerCourse: this.isPartnerCourse,
+    };
+  }
+
   protected get derivedDayOfWeek(): string {
     return deriveDayOfWeek(this.scheduleGroup.controls.startDate.value);
   }
@@ -113,8 +140,10 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
       this.formService.clearFutureDateValidator();
       this.courseService.getCourse(+id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
         next: (data) => {
-          this.formService.populate(data);
-          this.currentStep.set(4); // Start on Review step
+          this.formService.populate(data as unknown as Record<string, unknown>);
+          const stepParam = this.route.snapshot.queryParamMap.get('step');
+          const step = stepParam !== null ? +stepParam : 4;
+          this.currentStep.set(step >= 0 && step < this.steps.length ? step : 4);
           this.loading.set(false);
         },
         error: (err: HttpErrorResponse) => {
@@ -147,7 +176,7 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
     const errorMsg = id ? 'Failed to update course' : 'Failed to create course';
     const onSuccess = () => {
       this.snackBar.open(successMsg, 'Close', { duration: 3000, panelClass: 'snackbar-success' });
-      this.router.navigate(['/app/courses']);
+      this.router.navigate(id ? ['/app/courses', id] : ['/app/courses']);
     };
     const onError = (err: HttpErrorResponse) => {
       this.saving.set(false);

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -1,0 +1,25 @@
+@if (!loading()) {
+  @let c = course();
+  @if (c && summaryData) {
+    <!-- Header -->
+    <div class="overview-header">
+      <a class="back-link" routerLink="/app/courses">← Back to Courses</a>
+      <div class="title-row">
+        <h1 class="overview-title">{{ c.title }}</h1>
+        <span class="ds-chip" [ngClass]="statusChipClass(c.status)">
+          {{ c.status | titlecase }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Content Card -->
+    <div class="content-card">
+      <h2 class="content-card-title">Course Summary</h2>
+      <app-course-summary [data]="summaryData" (edit)="onEdit($event)" />
+    </div>
+  }
+} @else {
+  <div class="loading">
+    <p>Loading course...</p>
+  </div>
+}

--- a/frontend/src/app/courses/overview/course-overview.scss
+++ b/frontend/src/app/courses/overview/course-overview.scss
@@ -1,0 +1,59 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-6);
+}
+
+.overview-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+}
+
+.back-link {
+  font: var(--mat-sys-label-large);
+  color: var(--mat-sys-primary);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-4);
+}
+
+.overview-title {
+  font: var(--mat-sys-headline-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.content-card {
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+  padding: var(--ds-spacing-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-6);
+}
+
+.content-card-title {
+  font: var(--mat-sys-title-large);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--ds-spacing-24);
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-body-large);
+}

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -1,0 +1,110 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { CourseOverviewComponent } from './course-overview';
+import { ActivatedRoute } from '@angular/router';
+import { CourseDetail } from '../course.service';
+
+function makeCourseDetail(overrides: Partial<CourseDetail> = {}): CourseDetail {
+  return {
+    id: 1,
+    title: 'Bachata Fundamentals',
+    danceStyle: 'BACHATA',
+    level: 'BEGINNER',
+    courseType: 'PARTNER',
+    description: null,
+    startDate: '2026-04-11',
+    dayOfWeek: 'FRIDAY',
+    recurrenceType: 'WEEKLY',
+    numberOfSessions: 8,
+    endDate: '2026-05-30',
+    startTime: '19:30',
+    endTime: '20:45',
+    location: 'Studio A',
+    teachers: null,
+    maxParticipants: 20,
+    roleBalancingEnabled: true,
+    roleBalanceThreshold: 2,
+    priceModel: 'FIXED_COURSE',
+    price: 166.5,
+    status: 'ACTIVE',
+    publishDate: null,
+    enrolledStudents: 12,
+    ...overrides,
+  };
+}
+
+describe('CourseOverviewComponent', () => {
+  let fixture: ComponentFixture<CourseOverviewComponent>;
+  let httpTesting: HttpTestingController;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CourseOverviewComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => '1' }, queryParamMap: { get: () => null } } },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(CourseOverviewComponent);
+    httpTesting = TestBed.inject(HttpTestingController);
+    el = fixture.nativeElement;
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('should display loading state initially', () => {
+    fixture.detectChanges();
+    expect(el.querySelector('.loading')).toBeTruthy();
+
+    // Flush the pending request
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    fixture.detectChanges();
+    expect(el.querySelector('.loading')).toBeFalsy();
+  });
+
+  it('should display course title and status chip after loading', () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail({ title: 'Salsa Nights', status: 'ACTIVE' }));
+    fixture.detectChanges();
+
+    expect(el.querySelector('.overview-title')?.textContent?.trim()).toBe('Salsa Nights');
+    expect(el.querySelector('.ds-chip')?.textContent?.trim()).toBe('Active');
+  });
+
+  it('should display the back link', () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    fixture.detectChanges();
+
+    const backLink = el.querySelector('.back-link') as HTMLAnchorElement;
+    expect(backLink).toBeTruthy();
+    expect(backLink.textContent?.trim()).toContain('Back to Courses');
+  });
+
+  it('should render the course summary component', () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    fixture.detectChanges();
+
+    expect(el.querySelector('app-course-summary')).toBeTruthy();
+  });
+
+  it('should display "Course Summary" heading inside the content card', () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    fixture.detectChanges();
+
+    expect(el.querySelector('.content-card-title')?.textContent?.trim()).toBe('Course Summary');
+  });
+});

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { NgClass, TitleCasePipe } from '@angular/common';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { HttpErrorResponse } from '@angular/common/http';
+import { CourseDetail, CourseService } from '../course.service';
+import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summary';
+import { formatDayFull, formatTime } from '../shared/format-utils';
+import { extractErrorMessage } from '../../shared/error-utils';
+
+@Component({
+  selector: 'app-course-overview',
+  imports: [RouterLink, NgClass, TitleCasePipe, CourseSummaryComponent],
+  templateUrl: './course-overview.html',
+  styleUrl: './course-overview.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CourseOverviewComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
+  private destroyRef = inject(DestroyRef);
+  private courseService = inject(CourseService);
+
+  protected course = signal<CourseDetail | null>(null);
+  protected loading = signal(true);
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (!id) {
+      this.router.navigate(['/app/courses']);
+      return;
+    }
+
+    this.courseService.getCourse(+id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (data) => {
+        this.course.set(data);
+        this.loading.set(false);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.snackBar.open(extractErrorMessage(err, 'Failed to load course'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+        this.router.navigate(['/app/courses']);
+      },
+    });
+  }
+
+  protected get summaryData(): CourseSummaryData | null {
+    const c = this.course();
+    if (!c) return null;
+    return {
+      title: c.title,
+      danceStyle: c.danceStyle,
+      level: c.level,
+      courseType: c.courseType,
+      description: c.description,
+      startDate: c.startDate,
+      dayOfWeek: formatDayFull(c.dayOfWeek),
+      recurrenceType: c.recurrenceType,
+      numberOfSessions: c.numberOfSessions,
+      endDate: c.endDate,
+      startTime: formatTime(c.startTime),
+      endTime: formatTime(c.endTime),
+      location: c.location,
+      teachers: c.teachers,
+      maxParticipants: c.maxParticipants,
+      roleBalancingEnabled: c.roleBalancingEnabled,
+      roleBalanceThreshold: c.roleBalanceThreshold,
+      priceModel: c.priceModel,
+      price: c.price,
+      isPartnerCourse: c.courseType === 'PARTNER',
+    };
+  }
+
+  protected statusChipClass(status: string): string {
+    switch (status) {
+      case 'ACTIVE': return 'ds-chip-success';
+      default: return 'ds-chip-default';
+    }
+  }
+
+  protected onEdit(sectionIndex: number): void {
+    const id = this.course()?.id;
+    if (id) {
+      this.router.navigate(['/app/courses', id, 'edit'], { queryParams: { step: sectionIndex } });
+    }
+  }
+}

--- a/frontend/src/app/courses/shared/course-summary.html
+++ b/frontend/src/app/courses/shared/course-summary.html
@@ -1,0 +1,123 @@
+@let d = data();
+
+<!-- Details Card -->
+<div class="summary-card">
+  <div class="summary-card-header">
+    <h3 class="summary-card-title">Details</h3>
+    <button mat-button class="edit-link" (click)="edit.emit(0)" type="button">Edit</button>
+  </div>
+  <div class="summary-card-fields">
+    <div class="summary-field">
+      <span class="summary-label">Title</span>
+      <span class="summary-value">{{ d.title }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Dance Style</span>
+      <span class="summary-value">{{ label(danceStyles, d.danceStyle) }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Level</span>
+      <span class="summary-value">{{ label(levels, d.level) }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Course Type</span>
+      <span class="summary-value">{{ label(courseTypes, d.courseType) }}</span>
+    </div>
+    @if (d.description) {
+      <div class="summary-field summary-field--full">
+        <span class="summary-label">Description</span>
+        <span class="summary-value">{{ d.description }}</span>
+      </div>
+    }
+  </div>
+</div>
+
+<!-- Schedule Card -->
+<div class="summary-card">
+  <div class="summary-card-header">
+    <h3 class="summary-card-title">Schedule</h3>
+    <button mat-button class="edit-link" (click)="edit.emit(1)" type="button">Edit</button>
+  </div>
+  <div class="summary-card-fields">
+    <div class="summary-field">
+      <span class="summary-label">Start Date</span>
+      <span class="summary-value">{{ d.startDate }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Recurrence</span>
+      <span class="summary-value">{{ label(recurrenceTypes, d.recurrenceType) }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Day of Week</span>
+      <span class="summary-value">{{ d.dayOfWeek }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Sessions</span>
+      <span class="summary-value">{{ d.numberOfSessions }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Time</span>
+      <span class="summary-value">{{ d.startTime }} – {{ d.endTime }}</span>
+    </div>
+    @if (d.endDate) {
+      <div class="summary-field">
+        <span class="summary-label">End Date</span>
+        <span class="summary-value">{{ d.endDate }}</span>
+      </div>
+    }
+    <div class="summary-field summary-field--full">
+      <span class="summary-label">Location</span>
+      <span class="summary-value">{{ d.location }}</span>
+    </div>
+    @if (d.teachers) {
+      <div class="summary-field summary-field--full">
+        <span class="summary-label">Teachers</span>
+        <span class="summary-value">{{ d.teachers }}</span>
+      </div>
+    }
+  </div>
+</div>
+
+<!-- Registration Card -->
+<div class="summary-card">
+  <div class="summary-card-header">
+    <h3 class="summary-card-title">Registration</h3>
+    <button mat-button class="edit-link" (click)="edit.emit(2)" type="button">Edit</button>
+  </div>
+  <div class="summary-card-fields">
+    <div class="summary-field">
+      <span class="summary-label">Max Participants</span>
+      <span class="summary-value">{{ d.maxParticipants }}</span>
+    </div>
+    @if (d.isPartnerCourse) {
+      <div class="summary-field">
+        <span class="summary-label">Role Balancing</span>
+        <span class="summary-value">{{ d.roleBalancingEnabled ? 'Enabled' : 'Disabled' }}</span>
+      </div>
+      @if (d.roleBalancingEnabled && d.roleBalanceThreshold) {
+        <div class="summary-field">
+          <span class="summary-label">Max Imbalance</span>
+          <span class="summary-value">{{ d.roleBalanceThreshold }}</span>
+        </div>
+      }
+    }
+  </div>
+</div>
+
+<!-- Pricing Card -->
+<div class="summary-card">
+  <div class="summary-card-header">
+    <h3 class="summary-card-title">Pricing</h3>
+    <button mat-button class="edit-link" (click)="edit.emit(3)" type="button">Edit</button>
+  </div>
+  <div class="summary-card-fields">
+    <div class="summary-field">
+      <span class="summary-label">Price Model</span>
+      <span class="summary-value">{{ label(priceModels, d.priceModel) }}</span>
+    </div>
+    <div class="summary-field">
+      <span class="summary-label">Price</span>
+      <span class="summary-value">CHF {{ d.price }}</span>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/courses/shared/course-summary.scss
+++ b/frontend/src/app/courses/shared/course-summary.scss
@@ -1,0 +1,61 @@
+@use 'styles/mixins' as ds;
+
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-6);
+}
+
+.summary-card {
+  background: var(--mat-sys-surface-variant);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+  padding: var(--ds-spacing-5) var(--ds-spacing-6);
+}
+
+.summary-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--ds-spacing-4);
+}
+
+.summary-card-title {
+  font: var(--mat-sys-title-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.edit-link {
+  color: var(--mat-sys-primary);
+}
+
+.summary-card-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--ds-spacing-3) var(--ds-spacing-5);
+
+  @include ds.bp-down(sm) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.summary-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-half);
+
+  &--full {
+    grid-column: 1 / -1;
+  }
+}
+
+.summary-label {
+  font: var(--mat-sys-label-medium);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.summary-value {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-on-surface);
+}

--- a/frontend/src/app/courses/shared/course-summary.spec.ts
+++ b/frontend/src/app/courses/shared/course-summary.spec.ts
@@ -1,0 +1,130 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CourseSummaryComponent, CourseSummaryData } from './course-summary';
+
+function makeSummaryData(overrides: Partial<CourseSummaryData> = {}): CourseSummaryData {
+  return {
+    title: 'Bachata Fundamentals',
+    danceStyle: 'BACHATA',
+    level: 'BEGINNER',
+    courseType: 'PARTNER',
+    description: null,
+    startDate: '2026-04-11',
+    dayOfWeek: 'Friday',
+    recurrenceType: 'WEEKLY',
+    numberOfSessions: 8,
+    endDate: 'May 30, 2026',
+    startTime: '19:30',
+    endTime: '20:45',
+    location: 'Studio A',
+    teachers: null,
+    maxParticipants: 20,
+    roleBalancingEnabled: true,
+    roleBalanceThreshold: 2,
+    priceModel: 'FIXED_COURSE',
+    price: 166.5,
+    isPartnerCourse: true,
+    ...overrides,
+  };
+}
+
+describe('CourseSummaryComponent', () => {
+  let fixture: ComponentFixture<CourseSummaryComponent>;
+  let el: HTMLElement;
+
+  function setup(data: CourseSummaryData): void {
+    TestBed.configureTestingModule({ imports: [CourseSummaryComponent] });
+    fixture = TestBed.createComponent(CourseSummaryComponent);
+    fixture.componentRef.setInput('data', data);
+    fixture.detectChanges();
+    el = fixture.nativeElement;
+  }
+
+  it('should render all 4 section titles', () => {
+    setup(makeSummaryData());
+    const titles = Array.from(el.querySelectorAll('.summary-card-title')).map(e => e.textContent?.trim());
+    expect(titles).toEqual(['Details', 'Schedule', 'Registration', 'Pricing']);
+  });
+
+  it('should display course details fields with labels', () => {
+    setup(makeSummaryData());
+    const labels = Array.from(el.querySelectorAll('.summary-card:first-child .summary-label')).map(e => e.textContent?.trim());
+    expect(labels).toContain('Title');
+    expect(labels).toContain('Dance Style');
+    expect(labels).toContain('Level');
+    expect(labels).toContain('Course Type');
+  });
+
+  it('should display field values correctly', () => {
+    setup(makeSummaryData());
+    const values = Array.from(el.querySelectorAll('.summary-value')).map(e => e.textContent?.trim());
+    expect(values).toContain('Bachata Fundamentals');
+    expect(values).toContain('Bachata');
+    expect(values).toContain('Beginner');
+    expect(values).toContain('Partner');
+  });
+
+  it('should show description when provided', () => {
+    setup(makeSummaryData({ description: 'A great course' }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).toContain('Description');
+  });
+
+  it('should hide description when null', () => {
+    setup(makeSummaryData({ description: null }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).not.toContain('Description');
+  });
+
+  it('should show role balancing fields for partner courses', () => {
+    setup(makeSummaryData({ isPartnerCourse: true, roleBalancingEnabled: true, roleBalanceThreshold: 3 }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).toContain('Role Balancing');
+    expect(labels).toContain('Max Imbalance');
+  });
+
+  it('should hide role balancing fields for solo courses', () => {
+    setup(makeSummaryData({ isPartnerCourse: false, courseType: 'SOLO' }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).not.toContain('Role Balancing');
+    expect(labels).not.toContain('Max Imbalance');
+  });
+
+  it('should show teachers when provided', () => {
+    setup(makeSummaryData({ teachers: 'Maria, Carlos' }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).toContain('Teachers');
+  });
+
+  it('should hide teachers when null', () => {
+    setup(makeSummaryData({ teachers: null }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).not.toContain('Teachers');
+  });
+
+  it('should display price formatted as CHF', () => {
+    setup(makeSummaryData({ price: 166.5 }));
+    const values = Array.from(el.querySelectorAll('.summary-value')).map(e => e.textContent?.trim());
+    expect(values).toContain('CHF 166.5');
+  });
+
+  it('should emit edit event with correct section index when Edit is clicked', () => {
+    setup(makeSummaryData());
+    const editSpy = vi.fn();
+    fixture.componentInstance.edit.subscribe(editSpy);
+
+    const editButtons = el.querySelectorAll('.edit-link');
+    expect(editButtons.length).toBe(4);
+
+    (editButtons[0] as HTMLButtonElement).click();
+    expect(editSpy).toHaveBeenCalledWith(0);
+
+    (editButtons[1] as HTMLButtonElement).click();
+    expect(editSpy).toHaveBeenCalledWith(1);
+
+    (editButtons[2] as HTMLButtonElement).click();
+    expect(editSpy).toHaveBeenCalledWith(2);
+
+    (editButtons[3] as HTMLButtonElement).click();
+    expect(editSpy).toHaveBeenCalledWith(3);
+  });
+});

--- a/frontend/src/app/courses/shared/course-summary.ts
+++ b/frontend/src/app/courses/shared/course-summary.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES, PRICE_MODELS, labelOf,
+} from '../../shared/course-constants';
+
+export interface CourseSummaryData {
+  title: string;
+  danceStyle: string;
+  level: string;
+  courseType: string;
+  description?: string | null;
+  startDate: string;
+  dayOfWeek: string;
+  recurrenceType: string;
+  numberOfSessions: number;
+  endDate?: string | null;
+  startTime: string;
+  endTime: string;
+  location: string;
+  teachers?: string | null;
+  maxParticipants: number;
+  roleBalancingEnabled: boolean;
+  roleBalanceThreshold?: number | null;
+  priceModel: string;
+  price: number;
+  isPartnerCourse: boolean;
+}
+
+@Component({
+  selector: 'app-course-summary',
+  imports: [MatButtonModule],
+  templateUrl: './course-summary.html',
+  styleUrl: './course-summary.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CourseSummaryComponent {
+  data = input.required<CourseSummaryData>();
+  edit = output<number>();
+
+  protected label(items: { value: string; label: string }[], value: string): string {
+    return labelOf(items, value);
+  }
+
+  protected readonly danceStyles = DANCE_STYLES;
+  protected readonly levels = COURSE_LEVELS;
+  protected readonly courseTypes = COURSE_TYPES;
+  protected readonly recurrenceTypes = RECURRENCE_TYPES;
+  protected readonly priceModels = PRICE_MODELS;
+}

--- a/frontend/src/app/courses/shared/format-utils.ts
+++ b/frontend/src/app/courses/shared/format-utils.ts
@@ -1,0 +1,19 @@
+const DAY_ABBREVIATIONS: Record<string, string> = {
+  MONDAY: 'Mon', TUESDAY: 'Tue', WEDNESDAY: 'Wed',
+  THURSDAY: 'Thu', FRIDAY: 'Fri', SATURDAY: 'Sat', SUNDAY: 'Sun',
+};
+
+/** Abbreviate a backend DayOfWeek enum value (e.g. "FRIDAY" → "Fri"). */
+export function formatDayShort(dayOfWeek: string): string {
+  return DAY_ABBREVIATIONS[dayOfWeek] ?? dayOfWeek;
+}
+
+/** Title-case a backend DayOfWeek enum value (e.g. "FRIDAY" → "Friday"). */
+export function formatDayFull(dayOfWeek: string): string {
+  return dayOfWeek.charAt(0).toUpperCase() + dayOfWeek.slice(1).toLowerCase();
+}
+
+/** Strip seconds from a backend time string (e.g. "19:30:00" → "19:30"). */
+export function formatTime(time: string): string {
+  return time.substring(0, 5);
+}

--- a/frontend/src/app/shared/course-constants.ts
+++ b/frontend/src/app/shared/course-constants.ts
@@ -42,3 +42,7 @@ export const PRICE_MODELS: { value: PriceModel; label: string }[] = [
   { value: 'FIXED_COURSE', label: 'Fixed Course' },
 ];
 
+export function labelOf(items: { value: string; label: string }[], value: string): string {
+  return items.find(i => i.value === value)?.label ?? value;
+}
+


### PR DESCRIPTION
## Summary

- Extract the wizard Review step's 4 summary cards (Details, Schedule, Registration, Pricing) into a reusable `CourseSummaryComponent` shared between the wizard and the new Course Overview page
- Add read-only Course Overview page at `courses/:id` showing course title, status chip, and the shared summary with per-section Edit links
- Add wizard step deep-linking via `?step=N` query param — Edit links on the overview navigate directly to the correct wizard step
- After saving in edit mode, navigate to the course overview instead of the course list
- Move Publishing Settings above the summary cards in the Review step
- Extract shared `format-utils.ts` for day/time formatting, replacing inline duplicates

Closes #199

## Test plan

- [x] `ng build` passes
- [x] All 32 unit tests pass (`ng test`)
- [x] Visual verification: Course Overview page renders all 4 summary sections with correct data
- [x] Visual verification: Edit button on overview navigates to wizard at correct step (`?step=1` → Schedule)
- [x] Visual verification: Wizard Review step renders shared summary component with Publishing Settings above
- [x] Day of week displays as "Friday" (not "FRIDAY"), time as "19:30" (not "19:30:00")

🤖 Generated with [Claude Code](https://claude.com/claude-code)