### PR TITLE
Wire course table rows to overview & remove Actions column

### DIFF
--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -95,18 +95,8 @@
           </td>
         </ng-container>
 
-        <!-- Actions -->
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let course">
-            <a mat-icon-button [routerLink]="['/app/courses', course.id, 'edit']" aria-label="Edit course">
-              <mat-icon>edit</mat-icon>
-            </a>
-          </td>
-        </ng-container>
-
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;" [routerLink]="['/app/courses', row.id]" class="clickable-row"></tr>
       </table>
 
       <div class="ds-table-footer">

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -75,10 +75,9 @@
   max-width: var(--ds-max-width-narrow);
 }
 
-// Actions column
-.mat-column-actions {
-  width: var(--ds-spacing-12);
-  text-align: center;
+// Clickable table rows
+.clickable-row {
+  cursor: pointer;
 }
 
 // Loading / error states

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -55,7 +55,7 @@ export class CoursesComponent implements OnInit {
   protected filteredCount = computed(() => this.dataSource.filteredData.length);
 
   protected displayedColumns = [
-    'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'price', 'status', 'actions',
+    'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'price', 'status',
   ];
 
   @ViewChild(MatSort) set sort(sort: MatSort) {


### PR DESCRIPTION
## Summary

- Make course table rows clickable — row click navigates to `courses/:id` (Course Overview page)
- Remove the Actions column (edit pencil icon) from the courses table
- Add `cursor: pointer` styling to clickable rows

Closes #200

## Test plan

- [x] `ng build` passes
- [x] All 36 unit tests pass (`ng test`)
- [x] Visual: Actions column is removed from the courses table
- [x] Visual: Clicking a course row navigates to the Course Overview page
- [x] Table sorting and filtering still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)