### PR TITLE
Architecture cleanup: Course Overview & Edit Flow (#201)

### DIFF
--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -1,0 +1,191 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { CoursesComponent } from './courses';
+import { CourseListItem } from './course.service';
+
+function makeCourse(overrides: Partial<CourseListItem> = {}): CourseListItem {
+  return {
+    id: 1,
+    title: 'Bachata Fundamentals',
+    danceStyle: 'BACHATA',
+    level: 'BEGINNER',
+    dayOfWeek: 'FRIDAY',
+    startTime: '19:30:00',
+    endTime: '20:45:00',
+    numberOfSessions: 8,
+    endDate: '2026-05-30',
+    enrolledStudents: 12,
+    maxParticipants: 20,
+    price: 166.5,
+    status: 'ACTIVE',
+    ...overrides,
+  };
+}
+
+describe('CoursesComponent', () => {
+  let fixture: ComponentFixture<CoursesComponent>;
+  let httpTesting: HttpTestingController;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CoursesComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    fixture = TestBed.createComponent(CoursesComponent);
+    httpTesting = TestBed.inject(HttpTestingController);
+    el = fixture.nativeElement;
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  function flushCourses(courses: CourseListItem[]): void {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.includes('/api/courses/me')).flush(courses);
+    fixture.detectChanges();
+  }
+
+  it('should display loading state initially', () => {
+    fixture.detectChanges();
+    expect(el.querySelector('.loading')).toBeTruthy();
+
+    httpTesting.expectOne(req => req.url.includes('/api/courses/me')).flush([]);
+    fixture.detectChanges();
+    expect(el.querySelector('.loading')).toBeFalsy();
+  });
+
+  it('should display empty state when no courses', () => {
+    flushCourses([]);
+    expect(el.querySelector('.empty-state')).toBeTruthy();
+    expect(el.querySelector('.empty-state-title')?.textContent?.trim()).toBe('No courses yet');
+  });
+
+  it('should display all table columns without Actions column', () => {
+    flushCourses([makeCourse()]);
+    const headers = Array.from(el.querySelectorAll('th')).map(th => th.textContent?.trim());
+    expect(headers).toContain('Course Name');
+    expect(headers).toContain('Type');
+    expect(headers).toContain('Level');
+    expect(headers).toContain('Schedule');
+    expect(headers).toContain('Enrollment');
+    expect(headers).toContain('Price');
+    expect(headers).toContain('Status');
+    expect(headers).not.toContain('Actions');
+  });
+
+  it('should display course data in table rows', () => {
+    flushCourses([makeCourse({ title: 'Salsa Nights', enrolledStudents: 5, maxParticipants: 15 })]);
+    const cells = Array.from(el.querySelectorAll('td')).map(td => td.textContent?.trim());
+    expect(cells).toContain('Salsa Nights');
+    expect(cells.some(c => c?.includes('5 / 15'))).toBe(true);
+  });
+
+  it('should show correct count in table footer', () => {
+    flushCourses([makeCourse(), makeCourse({ id: 2, title: 'Salsa' })]);
+    const footer = el.querySelector('.ds-table-footer')?.textContent?.trim();
+    expect(footer).toContain('2 of 2');
+  });
+
+  it('should display error state', () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.includes('/api/courses/me')).error(new ProgressEvent('error'));
+    fixture.detectChanges();
+    expect(el.querySelector('.error-text')).toBeTruthy();
+  });
+
+  describe('filter predicate', () => {
+    it('should filter by free-text search across title', () => {
+      flushCourses([
+        makeCourse({ id: 1, title: 'Bachata Fundamentals' }),
+        makeCourse({ id: 2, title: 'Salsa Nights' }),
+      ]);
+
+      const component = fixture.componentInstance as any;
+      component.searchText = 'salsa';
+      component.applyFilter();
+      fixture.detectChanges();
+
+      const rows = el.querySelectorAll('tr.clickable-row');
+      expect(rows.length).toBe(1);
+    });
+
+    it('should filter by dance style', () => {
+      flushCourses([
+        makeCourse({ id: 1, danceStyle: 'BACHATA' }),
+        makeCourse({ id: 2, danceStyle: 'SALSA' }),
+      ]);
+
+      const component = fixture.componentInstance as any;
+      component.selectedDanceStyle = 'BACHATA';
+      component.applyFilter();
+      fixture.detectChanges();
+
+      const rows = el.querySelectorAll('tr.clickable-row');
+      expect(rows.length).toBe(1);
+    });
+
+    it('should filter by level', () => {
+      flushCourses([
+        makeCourse({ id: 1, level: 'BEGINNER' }),
+        makeCourse({ id: 2, level: 'INTERMEDIATE' }),
+      ]);
+
+      const component = fixture.componentInstance as any;
+      component.selectedLevel = 'BEGINNER';
+      component.applyFilter();
+      fixture.detectChanges();
+
+      const rows = el.querySelectorAll('tr.clickable-row');
+      expect(rows.length).toBe(1);
+    });
+
+    it('should combine filters', () => {
+      flushCourses([
+        makeCourse({ id: 1, title: 'Bachata Beginner', danceStyle: 'BACHATA', level: 'BEGINNER' }),
+        makeCourse({ id: 2, title: 'Bachata Advanced', danceStyle: 'BACHATA', level: 'ADVANCED' }),
+        makeCourse({ id: 3, title: 'Salsa Beginner', danceStyle: 'SALSA', level: 'BEGINNER' }),
+      ]);
+
+      const component = fixture.componentInstance as any;
+      component.selectedDanceStyle = 'BACHATA';
+      component.selectedLevel = 'BEGINNER';
+      component.applyFilter();
+      fixture.detectChanges();
+
+      const rows = el.querySelectorAll('tr.clickable-row');
+      expect(rows.length).toBe(1);
+    });
+  });
+
+  describe('helper methods', () => {
+    it('should return correct status chip class', () => {
+      const component = fixture.componentInstance as any;
+      expect(component.statusChipClass('ACTIVE')).toBe('ds-chip-success');
+      expect(component.statusChipClass('DRAFT')).toBe('ds-chip-default');
+      expect(component.statusChipClass('INACTIVE')).toBe('ds-chip-default');
+    });
+
+    it('should return correct dance style chip class', () => {
+      const component = fixture.componentInstance as any;
+      expect(component.danceStyleChipClass('BACHATA')).toBe('ds-chip-primary');
+      expect(component.danceStyleChipClass('SALSA')).toBe('ds-chip-info');
+      expect(component.danceStyleChipClass('MERENGUE')).toBe('ds-chip-success');
+      expect(component.danceStyleChipClass('OTHER')).toBe('ds-chip-default');
+    });
+
+    it('should calculate session duration in minutes', () => {
+      const component = fixture.componentInstance as any;
+      expect(component.sessionDuration('19:30:00', '20:45:00')).toBe(75);
+      expect(component.sessionDuration('18:00:00', '19:00:00')).toBe(60);
+    });
+  });
+});

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -225,8 +225,8 @@
 .warning-icon {
   color: var(--mat-sys-error);
   font-size: var(--mat-sys-body-large-size);
-  width: 20px;
-  height: 20px;
+  width: var(--ds-spacing-5);
+  height: var(--ds-spacing-5);
   flex-shrink: 0;
 }
 

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -9,7 +9,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { MatTooltipModule } from '@angular/material/tooltip';
+
 import { HttpErrorResponse } from '@angular/common/http';
 import { CourseFormService } from './course-form.service';
 import { extractErrorMessage } from '../../shared/error-utils';
@@ -31,7 +31,7 @@ interface StepDef {
   imports: [
     ReactiveFormsModule, RouterLink,
     MatFormFieldModule, MatInputModule, MatSelectModule,
-    MatButtonModule, MatIconModule, MatSlideToggleModule, MatTooltipModule,
+    MatButtonModule, MatIconModule, MatSlideToggleModule,
     CourseSummaryComponent,
   ],
   providers: [CourseFormService],
@@ -116,7 +116,6 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
       roleBalanceThreshold: this.registrationGroup.controls.roleBalanceThreshold.value,
       priceModel: this.pricingGroup.controls.priceModel.value,
       price: this.pricingGroup.controls.price.value ?? 0,
-      isPartnerCourse: this.isPartnerCourse,
     };
   }
 

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -68,7 +68,6 @@ export class CourseOverviewComponent implements OnInit {
       roleBalanceThreshold: c.roleBalanceThreshold,
       priceModel: c.priceModel,
       price: c.price,
-      isPartnerCourse: c.courseType === 'PARTNER',
     };
   }
 

--- a/frontend/src/app/courses/shared/course-summary.html
+++ b/frontend/src/app/courses/shared/course-summary.html
@@ -89,7 +89,7 @@
       <span class="summary-label">Max Participants</span>
       <span class="summary-value">{{ d.maxParticipants }}</span>
     </div>
-    @if (d.isPartnerCourse) {
+    @if (d.courseType === 'PARTNER') {
       <div class="summary-field">
         <span class="summary-label">Role Balancing</span>
         <span class="summary-value">{{ d.roleBalancingEnabled ? 'Enabled' : 'Disabled' }}</span>

--- a/frontend/src/app/courses/shared/course-summary.spec.ts
+++ b/frontend/src/app/courses/shared/course-summary.spec.ts
@@ -22,7 +22,6 @@ function makeSummaryData(overrides: Partial<CourseSummaryData> = {}): CourseSumm
     roleBalanceThreshold: 2,
     priceModel: 'FIXED_COURSE',
     price: 166.5,
-    isPartnerCourse: true,
     ...overrides,
   };
 }
@@ -76,14 +75,14 @@ describe('CourseSummaryComponent', () => {
   });
 
   it('should show role balancing fields for partner courses', () => {
-    setup(makeSummaryData({ isPartnerCourse: true, roleBalancingEnabled: true, roleBalanceThreshold: 3 }));
+    setup(makeSummaryData({ courseType: 'PARTNER', roleBalancingEnabled: true, roleBalanceThreshold: 3 }));
     const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
     expect(labels).toContain('Role Balancing');
     expect(labels).toContain('Max Imbalance');
   });
 
   it('should hide role balancing fields for solo courses', () => {
-    setup(makeSummaryData({ isPartnerCourse: false, courseType: 'SOLO' }));
+    setup(makeSummaryData({ courseType: 'SOLO' }));
     const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
     expect(labels).not.toContain('Role Balancing');
     expect(labels).not.toContain('Max Imbalance');

--- a/frontend/src/app/courses/shared/course-summary.ts
+++ b/frontend/src/app/courses/shared/course-summary.ts
@@ -24,7 +24,6 @@ export interface CourseSummaryData {
   roleBalanceThreshold?: number | null;
   priceModel: string;
   price: number;
-  isPartnerCourse: boolean;
 }
 
 @Component({


### PR DESCRIPTION
## Summary
- Fix design token violation: replace hardcoded `20px` with `--ds-spacing-5` on warning icon in course create wizard
- Remove unused `MatTooltipModule` import from course-create component
- Simplify `CourseSummaryData` interface: derive `isPartnerCourse` inside `CourseSummaryComponent` from `courseType` field, removing the derived boolean from the interface and both callers (overview + wizard)
- Add `CoursesComponent` test suite covering filter predicate, chip class methods, and session duration calculation

## Test plan
- [x] `ng build` passes with no errors
- [x] All 49 tests pass (7 test files)
- [x] Visual verification: courses list, course overview with role balancing fields all render correctly
- [x] No visual regression — token change is value-equivalent (20px = --ds-spacing-5)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)