### PR TITLE
Add index on school_member.school_id (#213)

### DIFF
--- a/backend/src/main/resources/db/changelog/013-index-school-member-school-id.yaml
+++ b/backend/src/main/resources/db/changelog/013-index-school-member-school-id.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 013-index-school-member-school-id
+      author: claude
+      changes:
+        - createIndex:
+            indexName: idx_school_member_school_id
+            tableName: school_member
+            columns:
+              - column:
+                  name: school_id

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -23,3 +23,5 @@ databaseChangeLog:
       file: db/changelog/011-add-course-end-date.yaml
   - include:
       file: db/changelog/012-simplify-registration-fields.yaml
+  - include:
+      file: db/changelog/013-index-school-member-school-id.yaml


### PR DESCRIPTION
## Summary
- Adds a Liquibase migration (`013`) creating an index on `school_member.school_id` for Postgres query performance
- `user_id` already covered by the existing unique constraint's composite index — no additional index needed

## Test plan
- [x] Backend builds and all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)