### PR TITLE
Publish endpoint + course detail page updates

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
@@ -45,6 +45,12 @@ public class CourseController {
         return courseService.getCourseDetail(principal.userId(), id);
     }
 
+    @PostMapping("/{id}/publish")
+    public CourseDetailDto publish(@PathVariable Long id,
+                                  @AuthenticationPrincipal AuthenticatedUser principal) {
+        return courseService.publishCourse(principal.userId(), id);
+    }
+
     @PutMapping("/{id}")
     public CourseDetailDto update(@PathVariable Long id,
                                  @Valid @RequestBody CreateCourseDto dto,

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -3,6 +3,7 @@ package ch.ruppen.danceschool.course;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
+import ch.ruppen.danceschool.shared.error.PublishValidationException;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
 import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -62,6 +65,65 @@ public class CourseService {
         Course course = courseRepository.findByIdAndSchoolId(courseId, school.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
         return toDetailDto(course, LocalDate.now(clock));
+    }
+
+    @Transactional
+    @BusinessOperation(event = "CoursePublished")
+    public CourseDetailDto publishCourse(Long userId, Long courseId) {
+        School school = schoolService.findSchoolByMember(userId);
+        Course course = courseRepository.findByIdAndSchoolId(courseId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
+
+        // Idempotent: already published → return current state
+        if (course.getPublishedAt() != null) {
+            return toDetailDto(course, LocalDate.now(clock));
+        }
+
+        validatePublishReadiness(course);
+
+        course.setPublishedAt(LocalDate.now(clock));
+        return toDetailDto(course, LocalDate.now(clock));
+    }
+
+    private void validatePublishReadiness(Course course) {
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        if (course.getTitle() == null || course.getTitle().isBlank()) {
+            errors.put("title", "must not be blank");
+        }
+        if (course.getDanceStyle() == null) {
+            errors.put("danceStyle", "must not be null");
+        }
+        if (course.getLevel() == null) {
+            errors.put("level", "must not be null");
+        }
+        if (course.getCourseType() == null) {
+            errors.put("courseType", "must not be null");
+        }
+        if (course.getStartDate() == null) {
+            errors.put("startDate", "must not be null");
+        } else if (!course.getStartDate().isAfter(LocalDate.now(clock))) {
+            errors.put("startDate", "must be in the future");
+        }
+        if (course.getStartTime() == null) {
+            errors.put("startTime", "must not be null");
+        }
+        if (course.getEndTime() == null) {
+            errors.put("endTime", "must not be null");
+        }
+        if (course.getNumberOfSessions() < 1) {
+            errors.put("numberOfSessions", "must be at least 1");
+        }
+        if (course.getMaxParticipants() < 1) {
+            errors.put("maxParticipants", "must be at least 1");
+        }
+        if (course.getPrice() == null) {
+            errors.put("price", "must not be null");
+        }
+
+        if (!errors.isEmpty()) {
+            throw new PublishValidationException(errors);
+        }
     }
 
     /**

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/error/GlobalExceptionHandler.java
@@ -33,6 +33,14 @@ class GlobalExceptionHandler {
         return problem;
     }
 
+    @ExceptionHandler(PublishValidationException.class)
+    ProblemDetail handlePublishValidation(PublishValidationException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setTitle("Publish Validation Failed");
+        problem.setProperty("fieldErrors", ex.getFieldErrors());
+        return problem;
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/error/PublishValidationException.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/error/PublishValidationException.java
@@ -1,0 +1,17 @@
+package ch.ruppen.danceschool.shared.error;
+
+import java.util.Map;
+
+public class PublishValidationException extends RuntimeException {
+
+    private final Map<String, String> fieldErrors;
+
+    public PublishValidationException(Map<String, String> fieldErrors) {
+        super("Course is not ready to publish");
+        this.fieldErrors = fieldErrors;
+    }
+
+    public Map<String, String> getFieldErrors() {
+        return fieldErrors;
+    }
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CoursePublishTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CoursePublishTest.java
@@ -1,0 +1,175 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class CoursePublishTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser testUser;
+    private School school;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createUser("test@example.com", "Test User", "firebase-test");
+        school = createSchoolWithOwner("Test Dance School", testUser);
+        entityManager.flush();
+    }
+
+    @Test
+    void publish_setsPublishedAtAndReturnsOpenStatus() throws Exception {
+        Course course = createDraftCourse(school, "Salsa Beginners", LocalDate.now().plusDays(30));
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/publish", course.getId())
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(course.getId()))
+                .andExpect(jsonPath("$.title").value("Salsa Beginners"))
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.publishedAt").exists());
+    }
+
+    @Test
+    void publish_isIdempotent_returnsSuccessWhenAlreadyPublished() throws Exception {
+        Course course = createDraftCourse(school, "Salsa Beginners", LocalDate.now().plusDays(30));
+        course.setPublishedAt(LocalDate.now().minusDays(5));
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/publish", course.getId())
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.publishedAt").value(LocalDate.now().minusDays(5).toString()));
+    }
+
+    @Test
+    void publish_returns400_whenStartDateIsInThePast() throws Exception {
+        Course course = createDraftCourse(school, "Past Course", LocalDate.now().minusDays(10));
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/publish", course.getId())
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Publish Validation Failed"))
+                .andExpect(jsonPath("$.fieldErrors.startDate").value("must be in the future"));
+    }
+
+    @Test
+    void publish_returns400_whenStartDateIsToday() throws Exception {
+        Course course = createDraftCourse(school, "Today Course", LocalDate.now());
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/publish", course.getId())
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.startDate").value("must be in the future"));
+    }
+
+    @Test
+    void publish_returns404_forCourseInAnotherSchool() throws Exception {
+        AppUser otherUser = createUser("other@example.com", "Other User", "firebase-other");
+        School otherSchool = createSchoolWithOwner("Other School", otherUser);
+        Course course = createDraftCourse(otherSchool, "Other Course", LocalDate.now().plusDays(30));
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/publish", course.getId())
+                        .with(authentication(authToken(testUser))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void publish_returns401_whenNotAuthenticated() throws Exception {
+        Course course = createDraftCourse(school, "Salsa Beginners", LocalDate.now().plusDays(30));
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/publish", course.getId()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser owner) {
+        School s = new School();
+        s.setName(name);
+        entityManager.persist(s);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(owner);
+        member.setSchool(s);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return s;
+    }
+
+    private Course createDraftCourse(School s, String title, LocalDate startDate) {
+        Course course = new Course();
+        course.setSchool(s);
+        course.setTitle(title);
+        course.setDanceStyle(DanceStyle.SALSA);
+        course.setLevel(CourseLevel.BEGINNER);
+        course.setCourseType(CourseType.PARTNER);
+        course.setStartDate(startDate);
+        course.setRecurrenceType(RecurrenceType.WEEKLY);
+        course.setDayOfWeek(startDate.getDayOfWeek());
+        course.setNumberOfSessions(8);
+        course.setEndDate(startDate.plusWeeks(7));
+        course.setStartTime(LocalTime.of(19, 0));
+        course.setEndTime(LocalTime.of(20, 0));
+        course.setLocation("Studio A");
+        course.setMaxParticipants(15);
+        course.setPriceModel(PriceModel.FIXED_COURSE);
+        course.setPrice(new BigDecimal("180.00"));
+        // publishedAt is null → DRAFT
+        entityManager.persist(course);
+        return course;
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -74,4 +74,8 @@ export class CourseService {
   updateCourse(id: number, dto: Record<string, unknown>): Observable<void> {
     return this.http.put<void>(`${environment.apiUrl}/api/courses/${id}`, dto);
   }
+
+  publishCourse(id: number): Observable<CourseDetail> {
+    return this.http.post<CourseDetail>(`${environment.apiUrl}/api/courses/${id}/publish`, null);
+  }
 }

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -5,10 +5,17 @@
     <div class="overview-header">
       <a class="back-link" routerLink="/app/courses">← Back to Courses</a>
       <div class="title-row">
-        <h1 class="overview-title">{{ c.title }}</h1>
-        <span class="ds-chip" [ngClass]="statusChipClass(c.status)">
-          {{ c.status | titlecase }}
-        </span>
+        <div class="title-row-left">
+          <h1 class="overview-title">{{ c.title }}</h1>
+          <span class="ds-chip" [ngClass]="statusChipClass(c.status)">
+            {{ c.status | titlecase }}
+          </span>
+        </div>
+        @if (c.status === 'DRAFT') {
+          <button mat-flat-button class="publish-button" (click)="onPublish()" [disabled]="publishing()">
+            Publish
+          </button>
+        }
       </div>
     </div>
 

--- a/frontend/src/app/courses/overview/course-overview.scss
+++ b/frontend/src/app/courses/overview/course-overview.scss
@@ -24,6 +24,13 @@
 .title-row {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-spacing-4);
+}
+
+.title-row-left {
+  display: flex;
+  align-items: center;
   gap: var(--ds-spacing-4);
 }
 

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { NgClass, TitleCasePipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpErrorResponse } from '@angular/common/http';
 import { CourseDetail, CourseService } from '../course.service';
@@ -11,7 +12,7 @@ import { extractErrorMessage } from '../../shared/error-utils';
 
 @Component({
   selector: 'app-course-overview',
-  imports: [RouterLink, NgClass, TitleCasePipe, CourseSummaryComponent],
+  imports: [RouterLink, NgClass, TitleCasePipe, MatButtonModule, CourseSummaryComponent],
   templateUrl: './course-overview.html',
   styleUrl: './course-overview.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -25,6 +26,7 @@ export class CourseOverviewComponent implements OnInit {
 
   protected course = signal<CourseDetail | null>(null);
   protected loading = signal(true);
+  protected publishing = signal(false);
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -33,16 +35,7 @@ export class CourseOverviewComponent implements OnInit {
       return;
     }
 
-    this.courseService.getCourse(+id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (data) => {
-        this.course.set(data);
-        this.loading.set(false);
-      },
-      error: (err: HttpErrorResponse) => {
-        this.snackBar.open(extractErrorMessage(err, 'Failed to load course'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
-        this.router.navigate(['/app/courses']);
-      },
-    });
+    this.loadCourse(+id);
   }
 
   protected get summaryData(): CourseSummaryData | null {
@@ -58,6 +51,8 @@ export class CourseOverviewComponent implements OnInit {
       dayOfWeek: formatDayFull(c.dayOfWeek),
       recurrenceType: c.recurrenceType,
       numberOfSessions: c.numberOfSessions,
+      completedSessions: c.completedSessions,
+      status: c.status,
       endDate: c.endDate,
       startTime: formatTime(c.startTime),
       endTime: formatTime(c.endTime),
@@ -81,10 +76,41 @@ export class CourseOverviewComponent implements OnInit {
     }
   }
 
+  protected onPublish(): void {
+    const c = this.course();
+    if (!c) return;
+
+    this.publishing.set(true);
+    this.courseService.publishCourse(c.id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (updated) => {
+        this.course.set(updated);
+        this.publishing.set(false);
+        this.snackBar.open('Course published successfully', 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+      },
+      error: (err: HttpErrorResponse) => {
+        this.publishing.set(false);
+        this.snackBar.open(extractErrorMessage(err, 'Failed to publish course'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+      },
+    });
+  }
+
   protected onEdit(sectionIndex: number): void {
     const id = this.course()?.id;
     if (id) {
       this.router.navigate(['/app/courses', id, 'edit'], { queryParams: { step: sectionIndex } });
     }
+  }
+
+  private loadCourse(id: number): void {
+    this.courseService.getCourse(id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (data) => {
+        this.course.set(data);
+        this.loading.set(false);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.snackBar.open(extractErrorMessage(err, 'Failed to load course'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+        this.router.navigate(['/app/courses']);
+      },
+    });
   }
 }

--- a/frontend/src/app/courses/shared/course-summary.html
+++ b/frontend/src/app/courses/shared/course-summary.html
@@ -53,7 +53,13 @@
     </div>
     <div class="summary-field">
       <span class="summary-label">Sessions</span>
-      <span class="summary-value">{{ d.numberOfSessions }}</span>
+      <span class="summary-value">
+        @if (d.status === 'RUNNING' && d.completedSessions != null) {
+          Session {{ d.completedSessions }}/{{ d.numberOfSessions }}
+        } @else {
+          {{ d.numberOfSessions }}
+        }
+      </span>
     </div>
     <div class="summary-field">
       <span class="summary-label">Time</span>

--- a/frontend/src/app/courses/shared/course-summary.ts
+++ b/frontend/src/app/courses/shared/course-summary.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import {
-  DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES, PRICE_MODELS, labelOf,
+  DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES, PRICE_MODELS, labelOf, CourseStatus,
 } from '../../shared/course-constants';
 
 export interface CourseSummaryData {
@@ -14,6 +14,8 @@ export interface CourseSummaryData {
   dayOfWeek: string;
   recurrenceType: string;
   numberOfSessions: number;
+  completedSessions?: number;
+  status?: CourseStatus;
   endDate?: string | null;
   startTime: string;
   endTime: string;


### PR DESCRIPTION
## Summary
- Add `POST /api/courses/{id}/publish` endpoint with field validation, future start date check, idempotency, and tenant isolation
- Update course detail page with Publish button for DRAFT courses (right-aligned per Figma design)
- Show derived status chip (Draft/Open/Running/Finished) and session progress ("Session 2/6") for RUNNING courses
- Add `PublishValidationException` with structured field errors (400 response)
- Seed draft courses in dev data for testing

Closes #209

## Test plan
- [x] Backend: 6 integration tests (happy path, idempotent, past date, today date, tenant isolation, unauthenticated)
- [x] Frontend: 49 tests pass
- [x] Visual: Draft course shows Publish button, clicking publishes and updates status to Open, running course shows session progress
- [x] Full backend suite: 103 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)