### PR TITLE
Remove status dropdown from create wizard (#210)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -192,7 +192,6 @@ public class CourseService {
         course.setRoleBalanceThreshold(dto.roleBalanceThreshold());
         course.setPriceModel(dto.priceModel());
         course.setPrice(dto.price());
-        // status and publishDate from DTO are ignored — publishedAt is managed via publish endpoint
     }
 
     private LocalDate calculateEndDate(LocalDate startDate, RecurrenceType recurrenceType, int numberOfSessions) {

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
@@ -27,8 +27,6 @@ public record CreateCourseDto(
         boolean roleBalancingEnabled,
         Integer roleBalanceThreshold,
         @NotNull PriceModel priceModel,
-        @NotNull @DecimalMin("0") BigDecimal price,
-        String status,
-        LocalDate publishDate
+        @NotNull @DecimalMin("0") BigDecimal price
 ) {
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -75,7 +75,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.minusWeeks(1), RecurrenceType.WEEKLY,
                     6, LocalTime.of(19, 30), LocalTime.of(20, 45),
                     "Studio A", "Maria", 12, false, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("166.50"), null, null), 8, today.minusWeeks(2));
+                    PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 8, today.minusWeeks(2));
 
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
                     "Bachata Intermediate", DanceStyle.BACHATA, CourseLevel.INTERMEDIATE,
@@ -83,7 +83,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.minusWeeks(2), RecurrenceType.WEEKLY,
                     8, LocalTime.of(19, 0), LocalTime.of(20, 0),
                     "Studio B", "Carlos", 15, true, 3,
-                    PriceModel.FIXED_COURSE, new BigDecimal("220.00"), null, null), 12, today.minusWeeks(3));
+                    PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 12, today.minusWeeks(3));
 
             // --- OPEN courses (published, start in the future) ---
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -92,7 +92,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.plusWeeks(4), RecurrenceType.WEEKLY,
                     10, LocalTime.of(20, 0), LocalTime.of(21, 15),
                     "Studio A", "Maria, Carlos", 10, true, 2,
-                    PriceModel.FIXED_COURSE, new BigDecimal("310.00"), null, null), 7, today.minusDays(5));
+                    PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 7, today.minusDays(5));
 
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
                     "Bachata Beginners", DanceStyle.BACHATA, CourseLevel.BEGINNER,
@@ -100,7 +100,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.plusWeeks(5), RecurrenceType.WEEKLY,
                     6, LocalTime.of(18, 30), LocalTime.of(19, 45),
                     "Studio B", "Carlos", 16, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("166.50"), null, null), 5, today.minusDays(3));
+                    PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 5, today.minusDays(3));
 
             // --- DRAFT courses (not published) ---
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -109,7 +109,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.plusWeeks(8), RecurrenceType.WEEKLY,
                     8, LocalTime.of(19, 0), LocalTime.of(20, 0),
                     "Studio A", "Maria", 20, false, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("220.00"), null, null), 0, null);
+                    PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 0, null);
 
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
                     "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
@@ -117,7 +117,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.plusWeeks(10), RecurrenceType.WEEKLY,
                     6, LocalTime.of(14, 0), LocalTime.of(15, 30),
                     "Studio B", "Carlos, Ana", 12, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("310.00"), null, null), 0, null);
+                    PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, null);
 
             // --- FINISHED course (end date in the past) ---
             courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -126,7 +126,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.minusWeeks(12), RecurrenceType.WEEKLY,
                     8, LocalTime.of(20, 0), LocalTime.of(21, 0),
                     "Studio A", "Luis", 14, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("180.00"), null, null), 11, today.minusWeeks(14));
+                    PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 11, today.minusWeeks(14));
         }
 
         if (!courseService.hasCoursesForMember(owner2.getId())) {
@@ -136,7 +136,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.minusWeeks(1), RecurrenceType.WEEKLY,
                     8, LocalTime.of(18, 0), LocalTime.of(19, 0),
                     "Main Hall", "Ana", 20, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("180.00"), null, null), 5, today.minusWeeks(2));
+                    PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 5, today.minusWeeks(2));
 
             courseService.seedCourse(owner2.getId(), new CreateCourseDto(
                     "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
@@ -144,7 +144,7 @@ public class DevDataSeeder implements ApplicationRunner {
                     today.plusWeeks(3), RecurrenceType.WEEKLY,
                     6, LocalTime.of(14, 0), LocalTime.of(15, 30),
                     "Main Hall", "Ana, Luis", 12, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("200.00"), null, null), 8, today.minusDays(2));
+                    PriceModel.FIXED_COURSE, new BigDecimal("200.00")), 8, today.minusDays(2));
         }
     }
 }

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
-import { CourseLevel, CourseStatus, DanceStyle } from '../shared/course-constants';
+import { CourseLevel, DanceStyle } from '../shared/course-constants';
 
 export interface CourseListItem {
   id: number;
@@ -18,7 +18,7 @@ export interface CourseListItem {
   enrolledStudents: number;
   maxParticipants: number;
   price: number;
-  status: CourseStatus;
+  status: string;
   completedSessions: number;
 }
 
@@ -43,7 +43,7 @@ export interface CourseDetail {
   roleBalanceThreshold: number | null;
   priceModel: string;
   price: number;
-  status: CourseStatus;
+  status: string;
   publishedAt: string | null;
   enrolledStudents: number;
   completedSessions: number;
@@ -57,7 +57,7 @@ export class CourseService {
     return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`);
   }
 
-  getCoursesByStatus(status: CourseStatus): Observable<CourseListItem[]> {
+  getCoursesByStatus(status: string): Observable<CourseListItem[]> {
     return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`, {
       params: { status },
     });

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -13,7 +13,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { forkJoin } from 'rxjs';
 import { CourseListItem, CourseService } from './course.service';
 import { formatDayShort, formatTime as stripSeconds } from './shared/format-utils';
-import { CourseStatus, DANCE_STYLES, COURSE_LEVELS } from '../shared/course-constants';
+import { DANCE_STYLES, COURSE_LEVELS } from '../shared/course-constants';
 
 interface CourseFilter {
   text: string;
@@ -22,7 +22,7 @@ interface CourseFilter {
 }
 
 interface TabConfig {
-  status: CourseStatus;
+  status: string;
   label: string;
   columns: string[];
 }

--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -244,27 +244,6 @@
       @case (4) {
         <!-- Review Step -->
         <div class="review-step">
-          <!-- Publishing Settings -->
-          <div class="publishing-settings" [formGroup]="pricingGroup">
-            <h3 class="section-title">Publishing Settings</h3>
-            <p class="section-hint">Controls whether this course is visible to students. Draft courses are only visible to you.</p>
-            <div class="form-row">
-              <mat-form-field class="half-width" appearance="outline">
-                <mat-label>Status</mat-label>
-                <mat-select formControlName="status">
-                  @for (status of courseStatuses; track status.value) {
-                    <mat-option [value]="status.value">{{ status.label }}</mat-option>
-                  }
-                </mat-select>
-              </mat-form-field>
-
-              <mat-form-field class="half-width" appearance="outline">
-                <mat-label>Publish Date</mat-label>
-                <input matInput type="date" formControlName="publishDate" />
-              </mat-form-field>
-            </div>
-          </div>
-
           <!-- Course Summary -->
           <app-course-summary [data]="reviewData" (edit)="goToStep($event)" />
         </div>
@@ -288,7 +267,7 @@
         @if (isEditMode) {
           Save Changes
         } @else {
-          {{ isDraft ? 'Save as Draft' : 'Publish Now' }}
+          Save as Draft
         }
       </button>
     }

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -249,15 +249,6 @@
   gap: var(--ds-spacing-5);
 }
 
-.publishing-settings {
-  border: 1px solid var(--mat-sys-outline-variant);
-  border-radius: var(--ds-radius-md);
-  padding: var(--ds-spacing-6);
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-spacing-5);
-}
-
 .placeholder-step {
   display: flex;
   align-items: center;

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -18,7 +18,7 @@ import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summ
 import { deriveDayOfWeek, deriveEndDate } from './schedule-utils';
 import {
   DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES,
-  PRICE_MODELS, COURSE_STATUSES,
+  PRICE_MODELS,
   RecurrenceType,
 } from '../../shared/course-constants';
 
@@ -69,7 +69,6 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
   protected courseTypes = COURSE_TYPES;
   protected recurrenceTypes = RECURRENCE_TYPES;
   protected priceModels = PRICE_MODELS;
-  protected courseStatuses = COURSE_STATUSES.filter(s => s.value === 'DRAFT' || s.value === 'OPEN');
 
   protected get detailsGroup() {
     return this.formService.form.controls.details;
@@ -89,10 +88,6 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
 
   protected get isPartnerCourse(): boolean {
     return this.formService.form.controls.details.controls.courseType.value === 'PARTNER';
-  }
-
-  protected get isDraft(): boolean {
-    return this.pricingGroup.controls.status.value === 'DRAFT';
   }
 
   protected get reviewData(): CourseSummaryData {

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -28,8 +28,6 @@ export class CourseFormService {
     pricing: new FormGroup({
       priceModel: new FormControl('FIXED_COURSE', { nonNullable: true, validators: [Validators.required] }),
       price: new FormControl<number | null>(null, { validators: [Validators.required, Validators.min(0)] }),
-      status: new FormControl('DRAFT', { nonNullable: true, validators: [Validators.required] }),
-      publishDate: new FormControl('', { nonNullable: true }),
     }),
   });
 
@@ -80,8 +78,6 @@ export class CourseFormService {
       pricing: {
         priceModel: data['priceModel'] as string,
         price: data['price'] as number,
-        status: (data['status'] as string) ?? 'DRAFT',
-        publishDate: (data['publishedAt'] as string) ?? '',
       },
     });
     // Mark as pristine after loading — form is not "dirty" until user edits
@@ -97,8 +93,6 @@ export class CourseFormService {
       roleBalanceThreshold: v.registration.roleBalancingEnabled ? v.registration.roleBalanceThreshold : null,
       priceModel: v.pricing.priceModel,
       price: v.pricing.price,
-      status: v.pricing.status,
-      publishDate: v.pricing.publishDate || null,
     };
   }
 

--- a/frontend/src/app/courses/shared/course-summary.ts
+++ b/frontend/src/app/courses/shared/course-summary.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import {
-  DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES, PRICE_MODELS, labelOf, CourseStatus,
+  DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES, PRICE_MODELS, labelOf,
 } from '../../shared/course-constants';
 
 export interface CourseSummaryData {
@@ -15,7 +15,7 @@ export interface CourseSummaryData {
   recurrenceType: string;
   numberOfSessions: number;
   completedSessions?: number;
-  status?: CourseStatus;
+  status?: string;
   endDate?: string | null;
   startTime: string;
   endTime: string;

--- a/frontend/src/app/shared/course-constants.ts
+++ b/frontend/src/app/shared/course-constants.ts
@@ -1,7 +1,6 @@
 export type DanceStyle = 'SALSA' | 'BACHATA' | 'MERENGUE' | 'KIZOMBA' | 'ZOUK' | 'AFRO' | 'OTHER';
 export type CourseLevel = 'STARTER' | 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED' | 'MASTERCLASS';
 export type CourseType = 'PARTNER' | 'SOLO';
-export type CourseStatus = 'DRAFT' | 'OPEN' | 'RUNNING' | 'FINISHED';
 export type RecurrenceType = 'WEEKLY';
 export type PriceModel = 'FIXED_COURSE';
 export const DANCE_STYLES: { value: DanceStyle; label: string }[] = [
@@ -25,13 +24,6 @@ export const COURSE_LEVELS: { value: CourseLevel; label: string }[] = [
 export const COURSE_TYPES: { value: CourseType; label: string }[] = [
   { value: 'PARTNER', label: 'Partner' },
   { value: 'SOLO', label: 'Solo' },
-];
-
-export const COURSE_STATUSES: { value: CourseStatus; label: string }[] = [
-  { value: 'DRAFT', label: 'Draft' },
-  { value: 'OPEN', label: 'Open' },
-  { value: 'RUNNING', label: 'Running' },
-  { value: 'FINISHED', label: 'Finished' },
 ];
 
 export const RECURRENCE_TYPES: { value: RecurrenceType; label: string }[] = [


### PR DESCRIPTION
## Summary
- Remove `status` and `publishDate` fields from `CreateCourseDto` (backend) and frontend form model
- Remove "Publishing Settings" section (status dropdown + publish date) from the create wizard review step
- Remove `CourseStatus` type and `COURSE_STATUSES` constant from frontend code
- Save button always reads "Save as Draft" in create mode (courses start as drafts, published from detail page)

Closes #210

## Test plan
- [x] Backend: 97 tests pass
- [x] Frontend: 51 tests pass, build succeeds
- [x] Visual: create wizard review step verified — no status dropdown, button says "Save as Draft"
- [x] Courses list page loads correctly with tabbed layout


🤖 Generated with [Claude Code](https://claude.com/claude-code)