### PR TITLE
Arch review cleanup: dedupe statusChipClass, drop unused endpoint (#211)

### DIFF
--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -53,10 +53,6 @@ export interface CourseDetail {
 export class CourseService {
   private http = inject(HttpClient);
 
-  getCourses(): Observable<CourseListItem[]> {
-    return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`);
-  }
-
   getCoursesByStatus(status: string): Observable<CourseListItem[]> {
     return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`, {
       params: { status },
@@ -71,8 +67,8 @@ export class CourseService {
     return this.http.post<{ id: number }>(`${environment.apiUrl}/api/courses`, dto);
   }
 
-  updateCourse(id: number, dto: Record<string, unknown>): Observable<void> {
-    return this.http.put<void>(`${environment.apiUrl}/api/courses/${id}`, dto);
+  updateCourse(id: number, dto: Record<string, unknown>): Observable<CourseDetail> {
+    return this.http.put<CourseDetail>(`${environment.apiUrl}/api/courses/${id}`, dto);
   }
 
   publishCourse(id: number): Observable<CourseDetail> {

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -12,7 +12,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { forkJoin } from 'rxjs';
 import { CourseListItem, CourseService } from './course.service';
-import { formatDayShort, formatTime as stripSeconds } from './shared/format-utils';
+import { formatDayShort, formatTime as stripSeconds, statusChipClass } from './shared/format-utils';
 import { DANCE_STYLES, COURSE_LEVELS } from '../shared/course-constants';
 
 interface CourseFilter {
@@ -162,15 +162,7 @@ export class CoursesComponent implements OnInit {
     return `${days} days`;
   }
 
-  protected statusChipClass(status: string): string {
-    switch (status) {
-      case 'OPEN': return 'ds-chip-success';
-      case 'RUNNING': return 'ds-chip-primary';
-      case 'DRAFT': return 'ds-chip-default';
-      case 'FINISHED': return 'ds-chip-default';
-      default: return 'ds-chip-default';
-    }
-  }
+  protected statusChipClass = statusChipClass;
 
   protected statusEmoji(status: string): string {
     switch (status) {

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -7,7 +7,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpErrorResponse } from '@angular/common/http';
 import { CourseDetail, CourseService } from '../course.service';
 import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summary';
-import { formatDate, formatDayFull, formatTime } from '../shared/format-utils';
+import { formatDate, formatDayFull, formatTime, statusChipClass } from '../shared/format-utils';
 import { extractErrorMessage } from '../../shared/error-utils';
 
 @Component({
@@ -66,15 +66,7 @@ export class CourseOverviewComponent implements OnInit {
     };
   }
 
-  protected statusChipClass(status: string): string {
-    switch (status) {
-      case 'OPEN': return 'ds-chip-success';
-      case 'RUNNING': return 'ds-chip-primary';
-      case 'DRAFT': return 'ds-chip-default';
-      case 'FINISHED': return 'ds-chip-default';
-      default: return 'ds-chip-default';
-    }
-  }
+  protected statusChipClass = statusChipClass;
 
   protected onPublish(): void {
     const c = this.course();

--- a/frontend/src/app/courses/shared/format-utils.ts
+++ b/frontend/src/app/courses/shared/format-utils.ts
@@ -24,3 +24,14 @@ export function formatDate(isoDate: string): string {
   const [year, month, day] = isoDate.split('-');
   return `${day}.${month}.${year}`;
 }
+
+/** Map a course lifecycle status to its chip class. */
+export function statusChipClass(status: string): string {
+  switch (status) {
+    case 'OPEN': return 'ds-chip-success';
+    case 'RUNNING': return 'ds-chip-primary';
+    case 'DRAFT': return 'ds-chip-default';
+    case 'FINISHED': return 'ds-chip-default';
+    default: return 'ds-chip-default';
+  }
+}


### PR DESCRIPTION
## Summary
Post-implementation arch review for PRD #206. Small cleanups, no behavior change.

- Removed unused `CourseService.getCourses()` — all callers use `getCoursesByStatus`
- Extracted duplicated `statusChipClass()` switch (identical in list + overview) into `format-utils.ts`
- Fixed `updateCourse` return type to `Observable<CourseDetail>` — backend already returns `CourseDetailDto`, frontend was typed as `void`. Consistent with `publishCourse` and ready for inline edits.

Skipped for now: hardcoded "Ready" readiness column in Draft tab (placeholder, discuss separately).

Closes #211

## Test plan
- [x] `npx ng build` passes
- [x] `npx ng test` — 58/58 pass
- [x] Visual: courses list (Running & Draft tabs), course overview with Publish button — all chips render correctly