### PR TITLE
Remove Readiness column from Draft courses table (#227)

### DIFF
--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -99,14 +99,6 @@
           <td mat-cell *matCellDef="let course">{{ course.price | currency:'CHF' }}</td>
         </ng-container>
 
-        <!-- Readiness (Draft tab) -->
-        <ng-container matColumnDef="readiness">
-          <th mat-header-cell *matHeaderCellDef>Readiness</th>
-          <td mat-cell *matCellDef="let course">
-            <span class="readiness-ready">Ready</span>
-          </td>
-        </ng-container>
-
         <!-- Enrollment (Open tab) -->
         <ng-container matColumnDef="enrollment">
           <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Enrollment</th>

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -101,13 +101,6 @@
   }
 }
 
-// Readiness column
-.readiness-ready {
-  color: var(--ds-color-success);
-  font: var(--mat-sys-label-large);
-  font-weight: 500;
-}
-
 // Clickable table rows
 .clickable-row {
   cursor: pointer;

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -28,7 +28,7 @@ interface TabConfig {
 }
 
 const TAB_CONFIGS: TabConfig[] = [
-  { status: 'DRAFT', label: 'Draft', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'price', 'readiness'] },
+  { status: 'DRAFT', label: 'Draft', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'price'] },
   { status: 'OPEN', label: 'Open', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'startsIn'] },
   { status: 'RUNNING', label: 'Running', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'progress', 'participants'] },
   { status: 'FINISHED', label: 'Finished', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'participants'] },


### PR DESCRIPTION
## Summary
- Removes the static "Readiness" column from the Draft courses tab — it was hardcoded to always render "Ready".
- Course creation already enforces every field the publish-readiness check validates, so the column carried no information.
- Reintroduce when genuinely optional-at-creation fields appear (photo, description, etc.).

Closes #227

## Test plan
- [x] `ng build` passes
- [x] Visual check: Draft tab renders Status, Course Name, Type, Level, Schedule, Price — no Readiness column
- [x] Other tabs (Open, Running, Finished) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)