### PR TITLE
Fix course edit time display and polish Registration step

### DIFF
--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -182,13 +182,11 @@
             @if (registrationGroup.controls.maxParticipants.hasError('required')) {
               <mat-error>Max participants is required</mat-error>
             }
-            <mat-hint>When this limit is reached, new students are placed on a waiting list.</mat-hint>
+            <mat-hint>Extra students go on the waiting list.</mat-hint>
           </mat-form-field>
 
           @if (isPartnerCourse) {
             <div class="role-balancing-section">
-              <h3 class="section-title">Partner Course Settings</h3>
-
               <div class="toggle-field">
                 <mat-slide-toggle formControlName="roleBalancingEnabled">
                   Require Role Balancing
@@ -197,19 +195,18 @@
 
               @if (registrationGroup.controls.roleBalancingEnabled.value) {
                 <p class="field-hint">
-                  Ensures an even split between leaders and followers. When the imbalance exceeds the threshold, new students of the over-represented role are placed on the waiting list.
+                  Keeps leaders and followers roughly balanced — extras of the bigger role go on the waiting list.
                 </p>
 
                 <mat-form-field appearance="outline">
                   <mat-label>Max Imbalance</mat-label>
                   <input matInput type="number" formControlName="roleBalanceThreshold" min="0" />
-                  <mat-hint>Maximum allowed difference between leaders and followers before the waiting list activates for the over-represented role.</mat-hint>
+                  <mat-hint>Allowed difference before balancing kicks in.</mat-hint>
                 </mat-form-field>
               } @else {
-                <div class="balancing-warning">
-                  <mat-icon class="warning-icon">error</mat-icon>
-                  <span class="warning-text">Without role balancing, all spots could be filled by one role — e.g., 20 followers and 0 leaders.</span>
-                </div>
+                <p class="field-hint">
+                  Without balancing, all spots may be filled by one role.
+                </p>
               }
             </div>
           }

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -195,44 +195,11 @@
   gap: var(--ds-spacing-4);
 }
 
-.section-title {
-  font: var(--mat-sys-title-medium);
-  color: var(--mat-sys-on-surface);
-  margin: 0;
-}
-
-.section-hint {
-  font: var(--mat-sys-body-small);
-  color: var(--mat-sys-on-surface-variant);
-  margin: 0;
-}
-
 .field-hint {
   font: var(--mat-sys-body-small);
   color: var(--mat-sys-on-surface-variant);
   margin: 0;
-}
-
-.balancing-warning {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--ds-spacing-2);
-  padding: var(--ds-spacing-3);
-  border-radius: var(--ds-radius-md);
-  background: var(--mat-sys-error-container);
-}
-
-.warning-icon {
-  color: var(--mat-sys-error);
-  font-size: var(--mat-sys-body-large-size);
-  width: var(--ds-spacing-5);
-  height: var(--ds-spacing-5);
-  flex-shrink: 0;
-}
-
-.warning-text {
-  font: var(--mat-sys-body-small);
-  color: var(--mat-sys-on-error-container);
+  padding: 0 var(--ds-spacing-4);
 }
 
 // Pricing step

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -6,7 +6,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -32,7 +31,7 @@ interface StepDef {
   imports: [
     ReactiveFormsModule, RouterLink,
     MatFormFieldModule, MatInputModule, MatSelectModule,
-    MatButtonModule, MatIconModule, MatSlideToggleModule,
+    MatButtonModule, MatSlideToggleModule,
     CourseSummaryComponent,
   ],
   providers: [CourseFormService],

--- a/frontend/src/app/courses/create/course-form.service.spec.ts
+++ b/frontend/src/app/courses/create/course-form.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { CourseFormService, toHHMM } from './course-form.service';
+
+describe('toHHMM', () => {
+  it('strips seconds from HH:MM:SS', () => {
+    expect(toHHMM('19:30:00')).toBe('19:30');
+  });
+
+  it('passes through already-short HH:MM', () => {
+    expect(toHHMM('19:30')).toBe('19:30');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(toHHMM(undefined)).toBe('');
+  });
+});
+
+describe('CourseFormService.populate', () => {
+  let service: CourseFormService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [CourseFormService] });
+    service = TestBed.inject(CourseFormService);
+  });
+
+  it('strips seconds from backend time fields before patching', () => {
+    service.populate({
+      title: 'T',
+      danceStyle: 'BACHATA',
+      level: 'BEGINNER',
+      courseType: 'PARTNER',
+      description: '',
+      startDate: '2030-01-01',
+      recurrenceType: 'WEEKLY',
+      numberOfSessions: 8,
+      startTime: '19:30:00',
+      endTime: '21:00:00',
+      location: 'Studio A',
+      teachers: '',
+      maxParticipants: 20,
+      roleBalancingEnabled: false,
+      roleBalanceThreshold: null,
+      priceModel: 'FIXED_COURSE',
+      price: 100,
+    });
+
+    expect(service.form.controls.schedule.controls.startTime.value).toBe('19:30');
+    expect(service.form.controls.schedule.controls.endTime.value).toBe('21:00');
+  });
+});

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -65,8 +65,8 @@ export class CourseFormService {
         startDate: data['startDate'] as string,
         recurrenceType: data['recurrenceType'] as string,
         numberOfSessions: data['numberOfSessions'] as number,
-        startTime: data['startTime'] as string,
-        endTime: data['endTime'] as string,
+        startTime: toHHMM(data['startTime'] as string | undefined),
+        endTime: toHHMM(data['endTime'] as string | undefined),
         location: data['location'] as string,
         teachers: (data['teachers'] as string) ?? '',
       },
@@ -108,6 +108,10 @@ export class CourseFormService {
   reset(): void {
     this.form.reset();
   }
+}
+
+export function toHHMM(value: string | undefined): string {
+  return value ? value.slice(0, 5) : '';
 }
 
 export function futureDateValidator(control: AbstractControl): ValidationErrors | null {


### PR DESCRIPTION
## Summary

- **#231** – `CourseFormService.populate()` now trims backend `HH:MM:SS` times to `HH:MM` via a new `toHHMM` helper, so the time input renders without seconds on the edit view.
- **#230** – Registration step helper text unified: all three hints (Max Participants, Role Balancing explanation, Max Imbalance) now use the same `body-small` / `--mat-sys-on-surface-variant` style with a consistent 16 px left inset. Copy shortened to one clause each, warning collapsed to a `field-hint`, and the redundant "Partner Course Settings" H3 removed.
- Added `course-form.service.spec.ts` covering `toHHMM` and `populate()` stripping seconds.

Closes #230, closes #231.

## Test plan

- [x] `npx ng test --browsers chromium --no-watch` — 62 passed (9 spec files)
- [x] Visual check at 1440×900: Registration step on create wizard (balancing on & off) — hints aligned, consistent typography
- [x] Visual check at 1440×900: edit an existing course → Schedule step shows `HH:MM` times, not `HH:MM:SS`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)