### PR TITLE
Redesign courses list: Material tabs, quieter filter bar, unified typography

### DIFF
--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -2,10 +2,16 @@
   <!-- Page Header -->
   <div class="page-header">
     <h1 class="page-title">Courses</h1>
+    @if (hasAnyCourses()) {
+      <button mat-flat-button routerLink="/app/courses/create">
+        <mat-icon>add</mat-icon>
+        Add Course
+      </button>
+    }
   </div>
 
   @if (hasAnyCourses()) {
-    <!-- Filter Bar -->
+    <!-- Filter Bar (on page background, above the card) -->
     <div class="filter-bar">
       <mat-form-field class="filter-search" appearance="outline" subscriptSizing="dynamic">
         <mat-icon matPrefix>search</mat-icon>
@@ -29,107 +35,102 @@
           }
         </mat-select>
       </mat-form-field>
-
-      <button mat-flat-button routerLink="/app/courses/create">
-        <mat-icon>add</mat-icon>
-        Add Course
-      </button>
     </div>
 
-    <!-- Tab Bar -->
-    <div class="tab-bar">
-      @for (tab of tabs; track tab.status; let i = $index) {
-        <button
-          class="tab"
-          [class.active]="activeTabIndex() === i"
-          (click)="selectTab(i)"
-        >
-          {{ tab.label }} ({{ tabCounts()[i] }})
-        </button>
-      }
-    </div>
-
-    <!-- Table Card -->
+    <!-- Table Card (tabs + table) -->
     <div class="ds-table-card">
-      <table mat-table [dataSource]="activeDataSource()" matSort>
-        <!-- Status -->
-        <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>Status</th>
-          <td mat-cell *matCellDef="let course">
-            <span class="ds-chip" [ngClass]="statusChipClass(course.status)">
-              {{ statusEmoji(course.status) }} {{ course.status | titlecase }}
-            </span>
-          </td>
-        </ng-container>
+      <nav mat-tab-nav-bar [tabPanel]="coursesTabPanel" mat-align-tabs="start" class="ds-table-card__tabs">
+        @for (tab of tabs; track tab.status; let i = $index) {
+          <a
+            mat-tab-link
+            (click)="selectTab(i)"
+            [active]="activeTabIndex() === i"
+          >
+            {{ tab.label }} ({{ tabCounts()[i] }})
+          </a>
+        }
+      </nav>
+      <mat-tab-nav-panel #coursesTabPanel>
+        <table mat-table [dataSource]="activeDataSource()" matSort>
+          <!-- Status -->
+          <ng-container matColumnDef="status">
+            <th mat-header-cell *matHeaderCellDef>Status</th>
+            <td mat-cell *matCellDef="let course">
+              <span class="ds-chip" [ngClass]="statusChipClass(course.status)">
+                {{ statusEmoji(course.status) }} {{ course.status | titlecase }}
+              </span>
+            </td>
+          </ng-container>
 
-        <!-- Course Name -->
-        <ng-container matColumnDef="title">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Course Name</th>
-          <td mat-cell *matCellDef="let course">{{ course.title }}</td>
-        </ng-container>
+          <!-- Course Name -->
+          <ng-container matColumnDef="title">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Course Name</th>
+            <td mat-cell *matCellDef="let course">{{ course.title }}</td>
+          </ng-container>
 
-        <!-- Type (Dance Style) -->
-        <ng-container matColumnDef="danceStyle">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Type</th>
-          <td mat-cell *matCellDef="let course">
-            <span class="ds-chip" [ngClass]="danceStyleChipClass(course.danceStyle)">
-              {{ course.danceStyle | titlecase }}
-            </span>
-          </td>
-        </ng-container>
+          <!-- Type (Dance Style) -->
+          <ng-container matColumnDef="danceStyle">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Type</th>
+            <td mat-cell *matCellDef="let course">
+              <span class="ds-chip" [ngClass]="danceStyleChipClass(course.danceStyle)">
+                {{ course.danceStyle | titlecase }}
+              </span>
+            </td>
+          </ng-container>
 
-        <!-- Level -->
-        <ng-container matColumnDef="level">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Level</th>
-          <td mat-cell *matCellDef="let course">{{ course.level | titlecase }}</td>
-        </ng-container>
+          <!-- Level -->
+          <ng-container matColumnDef="level">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Level</th>
+            <td mat-cell *matCellDef="let course">{{ course.level | titlecase }}</td>
+          </ng-container>
 
-        <!-- Schedule -->
-        <ng-container matColumnDef="schedule">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Schedule</th>
-          <td mat-cell *matCellDef="let course">
-            <div class="ds-cell-primary">{{ formatDay(course.dayOfWeek) }}, {{ formatTime(course.startTime) }} – {{ formatTime(course.endTime) }}</div>
-            <div class="ds-cell-secondary">{{ course.numberOfSessions }} sessions × {{ sessionDuration(course.startTime, course.endTime) }} min</div>
-          </td>
-        </ng-container>
+          <!-- Schedule -->
+          <ng-container matColumnDef="schedule">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Schedule</th>
+            <td mat-cell *matCellDef="let course">
+              <div class="ds-cell-primary">{{ formatDay(course.dayOfWeek) }}, {{ formatTime(course.startTime) }} – {{ formatTime(course.endTime) }}</div>
+              <div class="ds-cell-secondary">{{ course.numberOfSessions }} sessions × {{ sessionDuration(course.startTime, course.endTime) }} min</div>
+            </td>
+          </ng-container>
 
-        <!-- Price (Draft tab) -->
-        <ng-container matColumnDef="price">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Price</th>
-          <td mat-cell *matCellDef="let course">{{ course.price | currency:'CHF' }}</td>
-        </ng-container>
+          <!-- Price (Draft tab) -->
+          <ng-container matColumnDef="price">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Price</th>
+            <td mat-cell *matCellDef="let course">{{ course.price | currency:'CHF' }}</td>
+          </ng-container>
 
-        <!-- Enrollment (Open tab) -->
-        <ng-container matColumnDef="enrollment">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Enrollment</th>
-          <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }} / {{ course.maxParticipants }}</td>
-        </ng-container>
+          <!-- Enrollment (Open tab) -->
+          <ng-container matColumnDef="enrollment">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Enrollment</th>
+            <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }} / {{ course.maxParticipants }}</td>
+          </ng-container>
 
-        <!-- Starts In (Open tab) -->
-        <ng-container matColumnDef="startsIn">
-          <th mat-header-cell *matHeaderCellDef>Starts In</th>
-          <td mat-cell *matCellDef="let course">{{ startsIn(course.startDate) }}</td>
-        </ng-container>
+          <!-- Starts In (Open tab) -->
+          <ng-container matColumnDef="startsIn">
+            <th mat-header-cell *matHeaderCellDef>Starts In</th>
+            <td mat-cell *matCellDef="let course">{{ startsIn(course.startDate) }}</td>
+          </ng-container>
 
-        <!-- Progress (Running tab) -->
-        <ng-container matColumnDef="progress">
-          <th mat-header-cell *matHeaderCellDef>Progress</th>
-          <td mat-cell *matCellDef="let course">Session {{ course.completedSessions }}/{{ course.numberOfSessions }}</td>
-        </ng-container>
+          <!-- Progress (Running tab) -->
+          <ng-container matColumnDef="progress">
+            <th mat-header-cell *matHeaderCellDef>Progress</th>
+            <td mat-cell *matCellDef="let course">Session {{ course.completedSessions }}/{{ course.numberOfSessions }}</td>
+          </ng-container>
 
-        <!-- Participants (Running/Finished tabs) -->
-        <ng-container matColumnDef="participants">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Participants</th>
-          <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }} students</td>
-        </ng-container>
+          <!-- Participants (Running/Finished tabs) -->
+          <ng-container matColumnDef="participants">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Participants</th>
+            <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }} students</td>
+          </ng-container>
 
-        <tr mat-header-row *matHeaderRowDef="activeTab().columns"></tr>
-        <tr mat-row *matRowDef="let row; columns: activeTab().columns;" [routerLink]="['/app/courses', row.id]" class="clickable-row"></tr>
-      </table>
+          <tr mat-header-row *matHeaderRowDef="activeTab().columns"></tr>
+          <tr mat-row *matRowDef="let row; columns: activeTab().columns;" [routerLink]="['/app/courses', row.id]" class="clickable-row"></tr>
+        </table>
 
-      <div class="ds-table-footer">
-        Showing {{ activeDataSource().filteredData.length }} of {{ tabCounts()[activeTabIndex()] }} courses
-      </div>
+        <div class="ds-table-footer">
+          Showing {{ activeDataSource().filteredData.length }} of {{ tabCounts()[activeTabIndex()] }} courses
+        </div>
+      </mat-tab-nav-panel>
     </div>
   } @else {
     <!-- Empty State -->

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -4,25 +4,34 @@
   gap: var(--ds-spacing-4);
 }
 
-// Page header
+// Page header (title + Add Course)
 .page-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
+  gap: var(--ds-spacing-4);
 }
 
-// Filter bar
+.page-title {
+  font: var(--mat-sys-headline-small);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+// Filter bar (on page background, above the card)
 .filter-bar {
   display: flex;
   align-items: center;
   gap: var(--ds-spacing-3);
+  margin-top: var(--ds-spacing-4);
 
-  // Compact form fields — reduce Material's default density and match table font
+  // Compact form fields; input text matches the table body scale so controls
+  // and content read at the same size.
   .mat-mdc-form-field {
     --mat-form-field-container-height: 40px;
     --mat-form-field-container-vertical-padding: 8px;
-    --mdc-outlined-text-field-label-text-size: 14px;
-    --mdc-outlined-text-field-input-text-size: 14px;
+    --mdc-outlined-text-field-input-text-size: var(--mat-sys-body-medium-size);
+    --mdc-outlined-text-field-label-text-size: var(--mat-sys-body-medium-size);
   }
 }
 
@@ -32,12 +41,6 @@
 
 .filter-select {
   width: var(--ds-size-filter-select);
-}
-
-.page-title {
-  font: var(--mat-sys-headline-small);
-  color: var(--mat-sys-on-surface);
-  margin: 0;
 }
 
 // Empty state
@@ -71,35 +74,6 @@
   max-width: var(--ds-max-width-narrow);
 }
 
-// Tab bar (sits between filter bar and table card)
-.tab-bar {
-  display: flex;
-  gap: var(--ds-spacing-6);
-  border-bottom: 1px solid var(--mat-sys-outline-variant);
-}
-
-.tab {
-  padding: var(--ds-spacing-4) var(--ds-spacing-1);
-  border: none;
-  background: none;
-  cursor: pointer;
-  font: var(--mat-sys-title-medium);
-  color: var(--mat-sys-on-surface-variant);
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  transition: color var(--ds-duration-fast) var(--ds-easing-standard),
-              border-color var(--ds-duration-fast) var(--ds-easing-standard);
-
-  &.active {
-    color: var(--mat-sys-on-surface);
-    border-bottom-color: var(--mat-sys-on-surface);
-    font-weight: 600;
-  }
-
-  &:hover:not(.active) {
-    color: var(--mat-sys-on-surface);
-  }
-}
 
 // Clickable table rows
 .clickable-row {

--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -92,7 +92,7 @@ describe('CoursesComponent', () => {
       finished: [makeCourse({ id: 4, status: 'FINISHED' })],
     });
 
-    const tabs = el.querySelectorAll('.tab');
+    const tabs = el.querySelectorAll('a[mat-tab-link]');
     expect(tabs.length).toBe(4);
     // Order: Draft, Open, Running, Finished
     expect(tabs[0].textContent?.trim()).toBe('Draft (0)');

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -10,6 +10,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatTabsModule } from '@angular/material/tabs';
 import { forkJoin } from 'rxjs';
 import { CourseListItem, CourseService } from './course.service';
 import { formatDayShort, formatTime as stripSeconds, statusChipClass } from './shared/format-utils';
@@ -45,7 +46,7 @@ const DAY_ORDER: Record<string, number> = {
   selector: 'app-courses',
   imports: [
     MatTableModule, MatSortModule, MatIconModule, MatButtonModule,
-    MatFormFieldModule, MatInputModule, MatSelectModule,
+    MatFormFieldModule, MatInputModule, MatSelectModule, MatTabsModule,
     FormsModule, RouterLink, CurrencyPipe, TitleCasePipe, NgClass,
   ],
   templateUrl: './courses.html',

--- a/frontend/src/styles/_table.scss
+++ b/frontend/src/styles/_table.scss
@@ -1,13 +1,40 @@
 // Shared table styles — reusable across all table pages (Courses, Students, Subscriptions, Payments).
 // Import via: @use 'styles' as ds; then apply classes to your template.
+//
+// Typography rule inside .ds-table-card:
+//   - Chrome (tabs, header cells)    -> label-medium / label-large
+//   - Content (table cells)          -> body-medium
+// Filters / search live outside the card (on the page background) and follow
+// the same body-medium input scale for consistency.
 
 // ── Table card wrapper ──
-// White card with border, wraps the mat-table + footer.
+// White card with border. May optionally start with a mat-tab-nav-bar acting as
+// the card header; otherwise it wraps just the mat-table + footer.
 .ds-table-card {
   background: var(--mat-sys-surface);
   border: 1px solid var(--mat-sys-outline-variant);
   border-radius: var(--ds-radius-lg);
   overflow: hidden;
+}
+
+// Optional: mat-tab-nav-bar used as the card header — left-align tabs and let
+// them size to their label instead of stretching.
+// NOTE: mat-tab-nav-bar does NOT support stretchTabs via config or binding
+// (angular/components#27211). When stretchTabs is (default) true, Material adds
+// `.mat-mdc-tab-nav-bar-stretch-tabs` and forces `flex: 1 0 auto` on both the
+// links container and each tab link. We disable that with a matching-specificity
+// override.
+.ds-table-card__tabs.mat-mdc-tab-nav-bar.mat-mdc-tab-nav-bar-stretch-tabs {
+  .mat-mdc-tab-links {
+    flex-grow: 0;
+  }
+
+  .mat-mdc-tab-link.mdc-tab {
+    flex-grow: 0;
+    min-width: 0;
+    padding: 0 var(--ds-spacing-4);
+    font: var(--mat-sys-label-large);
+  }
 }
 
 // ── Mat-table overrides ──


### PR DESCRIPTION
## Summary
- Replace hand-rolled tab strip with `mat-tab-nav-bar` — left-aligned, content-sized, keyboard/a11y for free
- Move **Add Course** into the page header; filter bar stays on the page background with search + Type + Level
- Unify typography inside the card: `label-medium` for chrome (tabs, headers), `body-medium` for content (cells, filter inputs) — two sizes instead of four
- `mat-tab-nav-bar` ignores `stretchTabs` via config/binding ([angular/components#27211](https://github.com/angular/components/issues/27211)); killed the stretch with a matching-specificity CSS override in `_table.scss`

## Test plan
- [x] Unit tests pass (58/58)
- [ ] Hard refresh `/app/courses`; confirm tabs sit at content width, left-aligned
- [ ] Confirm filter bar inputs read at the same size as table cells (no more 16px vs 14px mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)