### PR TITLE
Quiet pass on courses list + /create-design-proposals command

### DIFF
--- a/.claude/commands/create-design-proposals.md
+++ b/.claude/commands/create-design-proposals.md
@@ -1,0 +1,61 @@
+Produce N visual design proposals for a single frontend page, screenshot each one, and save them where the user can review side-by-side.
+
+## Input
+
+The user provides the page to redesign and (optionally) a reference image:
+- `/create-design-proposals courses` → 3 proposals for the courses list page
+- `/create-design-proposals courses 4` → 4 proposals
+- `/create-design-proposals course-detail --ref "C:\Users\leon_\Pictures\...\ref.png"` → proposals informed by a reference
+
+Defaults: **3 proposals**, no reference.
+
+## Phase 1 — Understand the page
+
+1. Locate the component (template + scss + ts). Read them.
+2. If a reference image was provided, view it and list what makes it distinct (layout, typography, color, density, chip/pill style, card vs flat, etc.).
+3. Ask the user for a 1–2 sentence design goal if it isn't obvious ("calmer", "more density", "match Figma", ...). Skip if the goal is clear from the reference or the invoking message.
+
+## Phase 2 — Propose N directions
+
+Generate N meaningfully different proposals, not minor variations. Pick axes that matter for this page. Examples:
+- **Surface**: card-wrapped vs flat on page bg vs elevated
+- **Chrome density**: outlined form fields vs filled vs ghost
+- **Tab placement**: in the card vs above it vs hidden behind a toggle
+- **Status indicator**: emoji vs colored dot vs pill fill
+- **Typography scale**: Material per-region default vs unified 2-scale (chrome/content)
+
+Write a one-paragraph brief for each proposal before touching code so the user can see the plan.
+
+## Phase 3 — Set up infrastructure (once)
+
+Follow the setup + visual-testing steps from `.claude/commands/start-issue.md` (Phase 1 worktree + deps, Phase 4 servers + Playwright login). The same rules apply: run in a worktree, install frontend deps, start backend on a random port, start the Angular dev server via Angular MCP, log in via Playwright at 1440×900, and navigate to the target page.
+
+Before starting the per-proposal loop:
+- Create a **fresh output directory** for this run so previous variants aren't overwritten: `/mnt/c/Users/<user>/Pictures/Dance School/<page>-<YYYYMMDD-HHMM>/` (e.g. `courses-20260412-1430/`). Use `mkdir -p`.
+- Take a **v0-baseline.png** screenshot of the current page into that directory.
+
+## Phase 4 — For each proposal, repeat
+
+1. Apply the minimal edits for this proposal (usually just the component's html + scss, occasionally `_table.scss` / `_tokens.scss`). Commit nothing.
+2. Wait for devserver rebuild (Angular MCP `devserver.wait_for_build`).
+3. Refresh the Playwright page if needed and take a viewport screenshot named `v<N>-<short-name>.png`.
+4. Copy the screenshot from the Playwright output directory into the Pictures output dir.
+5. **Revert the edits** with `git checkout -- <files>` so the next proposal starts from a clean `main`.
+
+Never commit the proposals. This command produces screenshots, not PRs.
+
+## Phase 5 — Report
+
+Present the user with:
+- The absolute path to the output directory
+- A table listing each file + the one-line description of what that proposal does
+- A short ask: "Which direction do you want me to build for real? Or a mix — e.g. 'V2 with V1's subtitle'."
+
+## Rules
+
+- **Never skip the revert step** between proposals. Mixing leaves the working tree dirty and compounds changes.
+- **Always screenshot at 1440×900** (per project feedback memory).
+- **Don't invent features** — keep each proposal a visual-only rework. If a proposal needs a new column or new data, flag it as out-of-scope and move on.
+- **Respect design tokens** (see `frontend/CLAUDE.md` — no hardcoded spacing/colors/typography). If a proposal needs a new token, add it to `_tokens.scss` in the same cycle.
+- **Login is session-based in dev** — click Sign in rather than navigating directly to the app route, since the session cookie must be established first.
+- **Playwright output path** is bound to where the session started. If screenshots land in a worktree directory, `cp` them to the Pictures output dir before reverting.

--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -57,7 +57,8 @@
             <th mat-header-cell *matHeaderCellDef>Status</th>
             <td mat-cell *matCellDef="let course">
               <span class="ds-chip" [ngClass]="statusChipClass(course.status)">
-                {{ statusEmoji(course.status) }} {{ course.status | titlecase }}
+                <span class="ds-chip__dot"></span>
+                {{ course.status | titlecase }}
               </span>
             </td>
           </ng-container>

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -25,13 +25,14 @@
   gap: var(--ds-spacing-3);
   margin-top: var(--ds-spacing-4);
 
-  // Compact form fields; input text matches the table body scale so controls
-  // and content read at the same size.
+  // Compact, quiet form fields; outline softened so filters read as supporting
+  // chrome rather than competing with the table.
   .mat-mdc-form-field {
     --mat-form-field-container-height: 40px;
     --mat-form-field-container-vertical-padding: 8px;
     --mdc-outlined-text-field-input-text-size: var(--mat-sys-body-medium-size);
     --mdc-outlined-text-field-label-text-size: var(--mat-sys-body-medium-size);
+    --mdc-outlined-text-field-outline-color: var(--mat-sys-outline-variant);
   }
 }
 

--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -120,11 +120,11 @@ describe('CoursesComponent', () => {
     expect(cells.some(c => c?.includes('Session 3/8'))).toBe(true);
   });
 
-  it('should display status chip with emoji', () => {
+  it('should display status chip with dot indicator', () => {
     flushAllTabs({ running: [makeCourse()] });
 
     const chip = el.querySelector('.ds-chip');
-    expect(chip?.textContent?.trim()).toContain('🔵');
+    expect(chip?.querySelector('.ds-chip__dot')).toBeTruthy();
     expect(chip?.textContent?.trim()).toContain('Running');
   });
 
@@ -153,14 +153,6 @@ describe('CoursesComponent', () => {
       expect(component.statusChipClass('RUNNING')).toBe('ds-chip-primary');
       expect(component.statusChipClass('DRAFT')).toBe('ds-chip-default');
       expect(component.statusChipClass('FINISHED')).toBe('ds-chip-default');
-    });
-
-    it('should return correct status emoji', () => {
-      const component = fixture.componentInstance as any;
-      expect(component.statusEmoji('DRAFT')).toBe('🟡');
-      expect(component.statusEmoji('OPEN')).toBe('🟢');
-      expect(component.statusEmoji('RUNNING')).toBe('🔵');
-      expect(component.statusEmoji('FINISHED')).toBe('⚫');
     });
 
     it('should calculate starts in days', () => {

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -165,16 +165,6 @@ export class CoursesComponent implements OnInit {
 
   protected statusChipClass = statusChipClass;
 
-  protected statusEmoji(status: string): string {
-    switch (status) {
-      case 'DRAFT': return '🟡';
-      case 'OPEN': return '🟢';
-      case 'RUNNING': return '🔵';
-      case 'FINISHED': return '⚫';
-      default: return '';
-    }
-  }
-
   protected danceStyleChipClass(style: string): string {
     switch (style) {
       case 'BACHATA': return 'ds-chip-primary';

--- a/frontend/src/styles/_table.scss
+++ b/frontend/src/styles/_table.scss
@@ -34,6 +34,8 @@
     min-width: 0;
     padding: 0 var(--ds-spacing-4);
     font: var(--mat-sys-label-large);
+    text-transform: uppercase;
+    letter-spacing: var(--ds-letter-spacing-wide);
   }
 }
 
@@ -43,6 +45,7 @@
   .mat-mdc-header-row {
     height: 44px;
     border-bottom-color: var(--mat-sys-outline-variant);
+    background: var(--mat-sys-surface-container-low);
   }
 
   .mat-mdc-header-cell {
@@ -84,13 +87,24 @@
 }
 
 // ── Chip styles ──
-// Semantic colored chips for status, dance style, etc.
+// Semantic colored chips for status, dance style, etc. Status chips use an
+// optional `.ds-chip__dot` child to render a small leading dot in the chip's
+// own color; dance-style chips and plain chips omit it.
 .ds-chip {
   display: inline-flex;
   align-items: center;
   padding: var(--ds-spacing-1) var(--ds-spacing-3);
   border-radius: var(--ds-radius-md);
   font: var(--mat-sys-label-medium);
+}
+
+.ds-chip__dot {
+  width: var(--ds-spacing-2);
+  height: var(--ds-spacing-2);
+  border-radius: var(--ds-radius-full);
+  background: currentColor;
+  margin-right: var(--ds-spacing-2);
+  display: inline-block;
 }
 
 .ds-chip-success {

--- a/frontend/src/styles/_tokens.scss
+++ b/frontend/src/styles/_tokens.scss
@@ -80,6 +80,9 @@
   --ds-landing-feature-analytics: #e37100;
   --ds-landing-screenshot-shadow: 0 20px 60px -8px rgba(0, 0, 0, 0.12), 0 4px 24px -4px rgba(0, 0, 0, 0.08);
 
+  // ── Typography extras ──
+  --ds-letter-spacing-wide: 0.06em;
+
   // ── Motion ──
   --ds-duration-fast: 150ms;
   --ds-duration-normal: 250ms;


### PR DESCRIPTION
## Summary
- V2 "minimal card" pass from the design review: tinted table header, colored-dot status chip, uppercase tab labels, softer filter outlines
- Drop unused \`statusEmoji\` method + spec
- Add \`/create-design-proposals\` slash command that generalises the screenshot-driven design-review workflow (delegates setup to \`/start-issue\`)

## Test plan
- [x] 61/61 unit tests pass
- [ ] Hard refresh \`/app/courses\`; confirm tabs read as uppercase, header row has subtle grey tint, status shows as dot + word (no emoji)

🤖 Generated with [Claude Code](https://claude.com/claude-code)