### PR TITLE
Redesign courses list: GitLab-style toolbar + unified columns

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -62,6 +62,7 @@ Custom design tokens (`--ds-*`) extend Material's system tokens (`--mat-sys-*`).
 - `src/styles/_tokens.scss` — spacing scale, border radius, semantic colors, semantic layout, motion
 - `src/styles/_mixins.scss` — responsive breakpoint mixins
 - `src/styles/_index.scss` — barrel file (import via `@use 'styles' as ds;`, enabled by `includePaths` in angular.json)
+- `src/styles/_table.scss` — shared chrome for list/table pages (`.ds-page-toolbar`, `.ds-filter-bar`, `.ds-table-card`, chips, cells). Read its header comment before building a new list page; copy the Courses page skeleton and swap column defs rather than wrapping mat-table.
 
 **Strict rules — always enforced:**
 1. **Spacing/layout:** MUST use `--ds-spacing-*` or semantic layout tokens. Hardcoded `px`, `rem`, or `em` values for margins, padding, and gaps are forbidden. If the scale doesn't have the value you need, add a new token to `_tokens.scss` — do not inline it.

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -47,8 +47,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
-                  "maximumError": "18kB"
+                  "maximumWarning": "1MB",
+                  "maximumError": "2MB"
                 }
               ],
               "outputHashing": "all",

--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -1,20 +1,19 @@
 @if (loaded() && !error()) {
   @if (hasAnyCourses()) {
-    <!-- Top toolbar: tabs left, actions right -->
-    <div class="page-toolbar">
-      <nav mat-tab-nav-bar [tabPanel]="coursesTabPanel" mat-align-tabs="start" class="page-toolbar__tabs">
+    <div class="ds-page-toolbar">
+      <nav mat-tab-nav-bar [tabPanel]="coursesTabPanel" mat-align-tabs="start" class="ds-page-toolbar__tabs">
         @for (tab of tabs; track tab.status; let i = $index) {
           <a
             mat-tab-link
             (click)="selectTab(i)"
             [active]="activeTabIndex() === i"
           >
-            <span class="tab-label">{{ tab.label }}</span>
-            <span class="tab-count">{{ tabCounts()[i] }}</span>
+            <span class="ds-tab-label">{{ tab.label }}</span>
+            <span class="ds-tab-count">{{ tabCounts()[i] }}</span>
           </a>
         }
       </nav>
-      <div class="page-toolbar__actions">
+      <div class="ds-page-toolbar__actions">
         <button mat-flat-button routerLink="/app/courses/create">
           <mat-icon>add</mat-icon>
           Add Course
@@ -22,9 +21,8 @@
       </div>
     </div>
 
-    <!-- Filter row: full-width search -->
-    <div class="filter-bar">
-      <mat-form-field class="filter-search" appearance="outline" subscriptSizing="dynamic">
+    <div class="ds-filter-bar">
+      <mat-form-field class="ds-filter-search" appearance="outline" subscriptSizing="dynamic">
         <mat-icon matPrefix>search</mat-icon>
         <input matInput placeholder="Search or filter courses..." [(ngModel)]="searchText" (ngModelChange)="applyFilter()" />
       </mat-form-field>

--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -1,58 +1,38 @@
 @if (loaded() && !error()) {
-  <!-- Page Header -->
-  <div class="page-header">
-    <h1 class="page-title">Courses</h1>
-    @if (hasAnyCourses()) {
-      <button mat-flat-button routerLink="/app/courses/create">
-        <mat-icon>add</mat-icon>
-        Add Course
-      </button>
-    }
-  </div>
-
   @if (hasAnyCourses()) {
-    <!-- Filter Bar (on page background, above the card) -->
-    <div class="filter-bar">
-      <mat-form-field class="filter-search" appearance="outline" subscriptSizing="dynamic">
-        <mat-icon matPrefix>search</mat-icon>
-        <input matInput placeholder="Search courses..." [(ngModel)]="searchText" (ngModelChange)="applyFilter()" />
-      </mat-form-field>
-
-      <mat-form-field class="filter-select" appearance="outline" subscriptSizing="dynamic">
-        <mat-select placeholder="Dance Type" [(ngModel)]="selectedDanceStyle" (ngModelChange)="applyFilter()">
-          <mat-option value="">All Types</mat-option>
-          @for (style of danceStyles; track style) {
-            <mat-option [value]="style">{{ style | titlecase }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-
-      <mat-form-field class="filter-select" appearance="outline" subscriptSizing="dynamic">
-        <mat-select placeholder="Level" [(ngModel)]="selectedLevel" (ngModelChange)="applyFilter()">
-          <mat-option value="">All Levels</mat-option>
-          @for (level of levels; track level) {
-            <mat-option [value]="level">{{ level | titlecase }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-    </div>
-
-    <!-- Table Card (tabs + table) -->
-    <div class="ds-table-card">
-      <nav mat-tab-nav-bar [tabPanel]="coursesTabPanel" mat-align-tabs="start" class="ds-table-card__tabs">
+    <!-- Top toolbar: tabs left, actions right -->
+    <div class="page-toolbar">
+      <nav mat-tab-nav-bar [tabPanel]="coursesTabPanel" mat-align-tabs="start" class="page-toolbar__tabs">
         @for (tab of tabs; track tab.status; let i = $index) {
           <a
             mat-tab-link
             (click)="selectTab(i)"
             [active]="activeTabIndex() === i"
           >
-            {{ tab.label }} ({{ tabCounts()[i] }})
+            <span class="tab-label">{{ tab.label }}</span>
+            <span class="tab-count">{{ tabCounts()[i] }}</span>
           </a>
         }
       </nav>
-      <mat-tab-nav-panel #coursesTabPanel>
+      <div class="page-toolbar__actions">
+        <button mat-flat-button routerLink="/app/courses/create">
+          <mat-icon>add</mat-icon>
+          Add Course
+        </button>
+      </div>
+    </div>
+
+    <!-- Filter row: full-width search -->
+    <div class="filter-bar">
+      <mat-form-field class="filter-search" appearance="outline" subscriptSizing="dynamic">
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput placeholder="Search or filter courses..." [(ngModel)]="searchText" (ngModelChange)="applyFilter()" />
+      </mat-form-field>
+    </div>
+
+    <mat-tab-nav-panel #coursesTabPanel>
+      <div class="ds-table-card courses-table">
         <table mat-table [dataSource]="activeDataSource()" matSort>
-          <!-- Status -->
           <ng-container matColumnDef="status">
             <th mat-header-cell *matHeaderCellDef>Status</th>
             <td mat-cell *matCellDef="let course">
@@ -63,13 +43,11 @@
             </td>
           </ng-container>
 
-          <!-- Course Name -->
           <ng-container matColumnDef="title">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Course Name</th>
             <td mat-cell *matCellDef="let course">{{ course.title }}</td>
           </ng-container>
 
-          <!-- Type (Dance Style) -->
           <ng-container matColumnDef="danceStyle">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Type</th>
             <td mat-cell *matCellDef="let course">
@@ -79,62 +57,38 @@
             </td>
           </ng-container>
 
-          <!-- Level -->
           <ng-container matColumnDef="level">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Level</th>
             <td mat-cell *matCellDef="let course">{{ course.level | titlecase }}</td>
           </ng-container>
 
-          <!-- Schedule -->
-          <ng-container matColumnDef="schedule">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>Schedule</th>
+          <ng-container matColumnDef="dateRange">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Start / End</th>
             <td mat-cell *matCellDef="let course">
-              <div class="ds-cell-primary">{{ formatDay(course.dayOfWeek) }}, {{ formatTime(course.startTime) }} – {{ formatTime(course.endTime) }}</div>
-              <div class="ds-cell-secondary">{{ course.numberOfSessions }} sessions × {{ sessionDuration(course.startTime, course.endTime) }} min</div>
+              <div class="ds-cell-primary">{{ formatDateRange(course.startDate, course.endDate) }}</div>
+              <div class="ds-cell-secondary">{{ sessionDuration(course.startTime, course.endTime) }} min / session</div>
             </td>
           </ng-container>
 
-          <!-- Price (Draft tab) -->
-          <ng-container matColumnDef="price">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>Price</th>
-            <td mat-cell *matCellDef="let course">{{ course.price | currency:'CHF' }}</td>
-          </ng-container>
-
-          <!-- Enrollment (Open tab) -->
           <ng-container matColumnDef="enrollment">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Enrollment</th>
-            <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }} / {{ course.maxParticipants }}</td>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Enrollment</th>
+            <td mat-cell *matCellDef="let course">
+              @if (course.status !== 'DRAFT') {
+                {{ course.enrolledStudents }} / {{ course.maxParticipants }}
+              }
+            </td>
           </ng-container>
 
-          <!-- Starts In (Open tab) -->
-          <ng-container matColumnDef="startsIn">
-            <th mat-header-cell *matHeaderCellDef>Starts In</th>
-            <td mat-cell *matCellDef="let course">{{ startsIn(course.startDate) }}</td>
-          </ng-container>
-
-          <!-- Progress (Running tab) -->
-          <ng-container matColumnDef="progress">
-            <th mat-header-cell *matHeaderCellDef>Progress</th>
-            <td mat-cell *matCellDef="let course">Session {{ course.completedSessions }}/{{ course.numberOfSessions }}</td>
-          </ng-container>
-
-          <!-- Participants (Running/Finished tabs) -->
-          <ng-container matColumnDef="participants">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="enrolledStudents">Participants</th>
-            <td mat-cell *matCellDef="let course">{{ course.enrolledStudents }} students</td>
-          </ng-container>
-
-          <tr mat-header-row *matHeaderRowDef="activeTab().columns"></tr>
-          <tr mat-row *matRowDef="let row; columns: activeTab().columns;" [routerLink]="['/app/courses', row.id]" class="clickable-row"></tr>
+          <tr mat-header-row *matHeaderRowDef="columns"></tr>
+          <tr mat-row *matRowDef="let row; columns: columns;" [routerLink]="['/app/courses', row.id]" class="clickable-row"></tr>
         </table>
 
         <div class="ds-table-footer">
           Showing {{ activeDataSource().filteredData.length }} of {{ tabCounts()[activeTabIndex()] }} courses
         </div>
-      </mat-tab-nav-panel>
-    </div>
+      </div>
+    </mat-tab-nav-panel>
   } @else {
-    <!-- Empty State -->
     <div class="empty-state">
       <mat-icon class="empty-state-icon">school</mat-icon>
       <h2 class="empty-state-title">No courses yet</h2>

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -4,34 +4,61 @@
   gap: var(--ds-spacing-4);
 }
 
-// Page header (title + Add Course)
-.page-header {
+// ── Top toolbar: tabs left, actions right (GitLab-style) ──
+.page-toolbar {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-between;
   gap: var(--ds-spacing-4);
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
 }
 
-.page-title {
-  font: var(--mat-sys-headline-small);
-  color: var(--mat-sys-on-surface);
-  margin: 0;
+.page-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-2);
+  padding-bottom: var(--ds-spacing-2);
 }
 
-// Filter bar (on page background, above the card)
+.page-toolbar__tabs {
+  ::ng-deep .mat-mdc-tab-link.mdc-tab {
+    font: var(--mat-sys-label-large);
+    text-transform: none;
+    letter-spacing: normal;
+    padding: 0 var(--ds-spacing-4);
+    min-width: 0;
+    flex-grow: 0;
+  }
+
+  ::ng-deep .mat-mdc-tab-links {
+    flex-grow: 0;
+  }
+}
+
+.tab-label {
+  font-weight: 500;
+}
+
+.tab-count {
+  margin-left: var(--ds-spacing-2);
+  padding: 0 var(--ds-spacing-2);
+  border-radius: var(--ds-radius-md);
+  background: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-label-small);
+  font-weight: 600;
+}
+
+// ── Filter row ──
 .filter-bar {
   display: flex;
   align-items: center;
   gap: var(--ds-spacing-3);
-  margin-top: var(--ds-spacing-4);
 
-  // Compact, quiet form fields; outline softened so filters read as supporting
-  // chrome rather than competing with the table.
   .mat-mdc-form-field {
     --mat-form-field-container-height: 40px;
     --mat-form-field-container-vertical-padding: 8px;
     --mdc-outlined-text-field-input-text-size: var(--mat-sys-body-medium-size);
-    --mdc-outlined-text-field-label-text-size: var(--mat-sys-body-medium-size);
     --mdc-outlined-text-field-outline-color: var(--mat-sys-outline-variant);
   }
 }
@@ -40,11 +67,37 @@
   flex: 1;
 }
 
-.filter-select {
-  width: var(--ds-size-filter-select);
+// ── Table: plain white header row, bold dark text (overrides shared grey) ──
+.courses-table {
+  ::ng-deep table {
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  ::ng-deep .mat-mdc-header-row {
+    background: var(--mat-sys-surface);
+  }
+
+  ::ng-deep .mat-mdc-header-cell {
+    font: var(--mat-sys-label-large);
+    font-weight: 500;
+    color: var(--mat-sys-on-surface);
+  }
+
+  // Consistent column widths across all tabs
+  ::ng-deep .mat-column-status      { width: 120px; }
+  ::ng-deep .mat-column-title       { width: auto; }
+  ::ng-deep .mat-column-danceStyle  { width: 120px; }
+  ::ng-deep .mat-column-level       { width: 140px; }
+  ::ng-deep .mat-column-dateRange   { width: 200px; }
+  ::ng-deep .mat-column-enrollment  { width: 120px; }
 }
 
-// Empty state
+.clickable-row {
+  cursor: pointer;
+}
+
+// ── Empty / loading / error ──
 .empty-state {
   display: flex;
   flex-direction: column;
@@ -75,13 +128,6 @@
   max-width: var(--ds-max-width-narrow);
 }
 
-
-// Clickable table rows
-.clickable-row {
-  cursor: pointer;
-}
-
-// Loading / error states
 .loading {
   display: flex;
   justify-content: center;

--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -4,97 +4,14 @@
   gap: var(--ds-spacing-4);
 }
 
-// ── Top toolbar: tabs left, actions right (GitLab-style) ──
-.page-toolbar {
-  display: flex;
-  align-items: stretch;
-  justify-content: space-between;
-  gap: var(--ds-spacing-4);
-  border-bottom: 1px solid var(--mat-sys-outline-variant);
-}
-
-.page-toolbar__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-spacing-2);
-  padding-bottom: var(--ds-spacing-2);
-}
-
-.page-toolbar__tabs {
-  ::ng-deep .mat-mdc-tab-link.mdc-tab {
-    font: var(--mat-sys-label-large);
-    text-transform: none;
-    letter-spacing: normal;
-    padding: 0 var(--ds-spacing-4);
-    min-width: 0;
-    flex-grow: 0;
-  }
-
-  ::ng-deep .mat-mdc-tab-links {
-    flex-grow: 0;
-  }
-}
-
-.tab-label {
-  font-weight: 500;
-}
-
-.tab-count {
-  margin-left: var(--ds-spacing-2);
-  padding: 0 var(--ds-spacing-2);
-  border-radius: var(--ds-radius-md);
-  background: var(--mat-sys-surface-container-high);
-  color: var(--mat-sys-on-surface-variant);
-  font: var(--mat-sys-label-small);
-  font-weight: 600;
-}
-
-// ── Filter row ──
-.filter-bar {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-spacing-3);
-
-  .mat-mdc-form-field {
-    --mat-form-field-container-height: 40px;
-    --mat-form-field-container-vertical-padding: 8px;
-    --mdc-outlined-text-field-input-text-size: var(--mat-sys-body-medium-size);
-    --mdc-outlined-text-field-outline-color: var(--mat-sys-outline-variant);
-  }
-}
-
-.filter-search {
-  flex: 1;
-}
-
-// ── Table: plain white header row, bold dark text (overrides shared grey) ──
+// Column widths specific to the courses table
 .courses-table {
-  ::ng-deep table {
-    table-layout: fixed;
-    width: 100%;
-  }
-
-  ::ng-deep .mat-mdc-header-row {
-    background: var(--mat-sys-surface);
-  }
-
-  ::ng-deep .mat-mdc-header-cell {
-    font: var(--mat-sys-label-large);
-    font-weight: 500;
-    color: var(--mat-sys-on-surface);
-  }
-
-  // Consistent column widths across all tabs
   ::ng-deep .mat-column-status      { width: 120px; }
   ::ng-deep .mat-column-title       { width: auto; }
   ::ng-deep .mat-column-danceStyle  { width: 120px; }
   ::ng-deep .mat-column-level       { width: 140px; }
   ::ng-deep .mat-column-dateRange   { width: 200px; }
   ::ng-deep .mat-column-enrollment  { width: 120px; }
-}
-
-.clickable-row {
-  cursor: pointer;
 }
 
 // ── Empty / loading / error ──

--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -95,8 +95,8 @@ describe('CoursesComponent', () => {
     const tabs = el.querySelectorAll('a[mat-tab-link]');
     expect(tabs.length).toBe(5);
 
-    const labels = Array.from(tabs).map(t => t.querySelector('.tab-label')?.textContent?.trim());
-    const counts = Array.from(tabs).map(t => t.querySelector('.tab-count')?.textContent?.trim());
+    const labels = Array.from(tabs).map(t => t.querySelector('.ds-tab-label')?.textContent?.trim());
+    const counts = Array.from(tabs).map(t => t.querySelector('.ds-tab-count')?.textContent?.trim());
     expect(labels).toEqual(['All', 'Draft', 'Open', 'Running', 'Finished']);
     expect(counts).toEqual(['4', '0', '1', '2', '1']);
   });

--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -142,6 +142,57 @@ describe('CoursesComponent', () => {
     expect(footer).toContain('2 of 2');
   });
 
+  it('should aggregate all statuses into the All tab', () => {
+    flushAllTabs({
+      running: [makeCourse({ id: 1 }), makeCourse({ id: 2 })],
+      open: [makeCourse({ id: 3, status: 'OPEN' })],
+      draft: [makeCourse({ id: 4, status: 'DRAFT' })],
+      finished: [makeCourse({ id: 5, status: 'FINISHED' }), makeCourse({ id: 6, status: 'FINISHED' })],
+    });
+
+    const component = fixture.componentInstance as any;
+    expect(component.tabCounts()[0]).toBe(6);
+    expect(component.tabData[0].data.map((c: CourseListItem) => c.id).sort()).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  describe('search filter', () => {
+    it('matches title case-insensitively', () => {
+      flushAllTabs({
+        running: [
+          makeCourse({ id: 1, title: 'Bachata Fundamentals', danceStyle: 'BACHATA' }),
+          makeCourse({ id: 2, title: 'Salsa Intermediate', danceStyle: 'SALSA' }),
+        ],
+      });
+      const component = fixture.componentInstance as any;
+      component.searchText = 'fundamentals';
+      component.applyFilter();
+
+      expect(component.tabData[0].filteredData.map((c: CourseListItem) => c.id)).toEqual([1]);
+    });
+
+    it('matches dance style, level, and day of week', () => {
+      flushAllTabs({
+        running: [
+          makeCourse({ id: 1, danceStyle: 'BACHATA', level: 'BEGINNER', dayOfWeek: 'FRIDAY' }),
+          makeCourse({ id: 2, danceStyle: 'SALSA', level: 'ADVANCED', dayOfWeek: 'MONDAY' }),
+        ],
+      });
+      const component = fixture.componentInstance as any;
+
+      component.searchText = 'salsa';
+      component.applyFilter();
+      expect(component.tabData[0].filteredData.map((c: CourseListItem) => c.id)).toEqual([2]);
+
+      component.searchText = 'beginner';
+      component.applyFilter();
+      expect(component.tabData[0].filteredData.map((c: CourseListItem) => c.id)).toEqual([1]);
+
+      component.searchText = 'monday';
+      component.applyFilter();
+      expect(component.tabData[0].filteredData.map((c: CourseListItem) => c.id)).toEqual([2]);
+    });
+  });
+
   it('should display error state', () => {
     fixture.detectChanges();
     const reqs = httpTesting.match(req => req.url.includes('/api/courses/me'));

--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -84,7 +84,7 @@ describe('CoursesComponent', () => {
     expect(el.querySelector('.empty-state-title')?.textContent?.trim()).toBe('No courses yet');
   });
 
-  it('should render 4 tabs with correct labels and counts', () => {
+  it('should render 5 tabs with labels and counts (All + 4 statuses)', () => {
     flushAllTabs({
       running: [makeCourse({ id: 1 }), makeCourse({ id: 2 })],
       open: [makeCourse({ id: 3, status: 'OPEN' })],
@@ -93,31 +93,38 @@ describe('CoursesComponent', () => {
     });
 
     const tabs = el.querySelectorAll('a[mat-tab-link]');
-    expect(tabs.length).toBe(4);
-    // Order: Draft, Open, Running, Finished
-    expect(tabs[0].textContent?.trim()).toBe('Draft (0)');
-    expect(tabs[1].textContent?.trim()).toBe('Open (1)');
-    expect(tabs[2].textContent?.trim()).toBe('Running (2)');
-    expect(tabs[3].textContent?.trim()).toBe('Finished (1)');
+    expect(tabs.length).toBe(5);
+
+    const labels = Array.from(tabs).map(t => t.querySelector('.tab-label')?.textContent?.trim());
+    const counts = Array.from(tabs).map(t => t.querySelector('.tab-count')?.textContent?.trim());
+    expect(labels).toEqual(['All', 'Draft', 'Open', 'Running', 'Finished']);
+    expect(counts).toEqual(['4', '0', '1', '2', '1']);
   });
 
-  it('should show Running tab columns by default', () => {
+  it('should show unified column set across tabs', () => {
     flushAllTabs({ running: [makeCourse()] });
 
     const headers = Array.from(el.querySelectorAll('th')).map(th => th.textContent?.trim());
-    expect(headers).toContain('Status');
-    expect(headers).toContain('Course Name');
-    expect(headers).toContain('Progress');
-    expect(headers).toContain('Participants');
-    expect(headers).not.toContain('Price');
-    expect(headers).not.toContain('Starts In');
+    expect(headers).toEqual(['Status', 'Course Name', 'Type', 'Level', 'Start / End', 'Enrollment']);
   });
 
-  it('should display progress in Running tab', () => {
-    flushAllTabs({ running: [makeCourse({ completedSessions: 3, numberOfSessions: 8 })] });
+  it('should display enrollment for non-draft courses', () => {
+    flushAllTabs({ running: [makeCourse({ enrolledStudents: 12, maxParticipants: 20 })] });
 
     const cells = Array.from(el.querySelectorAll('td')).map(td => td.textContent?.trim());
-    expect(cells.some(c => c?.includes('Session 3/8'))).toBe(true);
+    expect(cells.some(c => c?.includes('12 / 20'))).toBe(true);
+  });
+
+  it('should leave enrollment blank for draft courses', () => {
+    flushAllTabs({ draft: [makeCourse({ status: 'DRAFT', enrolledStudents: 0, maxParticipants: 20 })] });
+    // Switch to Draft tab (index 1)
+    const component = fixture.componentInstance as any;
+    component.selectTab(1);
+    fixture.detectChanges();
+
+    const enrollmentCells = Array.from(el.querySelectorAll('td.mat-column-enrollment'));
+    expect(enrollmentCells.length).toBe(1);
+    expect(enrollmentCells[0].textContent?.trim()).toBe('');
   });
 
   it('should display status chip with dot indicator', () => {
@@ -131,12 +138,12 @@ describe('CoursesComponent', () => {
   it('should show correct count in table footer', () => {
     flushAllTabs({ running: [makeCourse({ id: 1 }), makeCourse({ id: 2 })] });
     const footer = el.querySelector('.ds-table-footer')?.textContent?.trim();
+    // All tab is default and aggregates all statuses
     expect(footer).toContain('2 of 2');
   });
 
   it('should display error state', () => {
     fixture.detectChanges();
-    // Error the first request — forkJoin cancels the rest
     const reqs = httpTesting.match(req => req.url.includes('/api/courses/me'));
     if (reqs.length > 0) {
       reqs[0].error(new ProgressEvent('error'));
@@ -155,33 +162,19 @@ describe('CoursesComponent', () => {
       expect(component.statusChipClass('FINISHED')).toBe('ds-chip-default');
     });
 
-    it('should calculate starts in days', () => {
-      const component = fixture.componentInstance as any;
-      const futureDate = new Date();
-      futureDate.setDate(futureDate.getDate() + 10);
-      const dateStr = futureDate.toISOString().split('T')[0];
-      expect(component.startsIn(dateStr)).toBe('10 days');
-    });
-
-    it('should return "1 day" for tomorrow', () => {
-      const component = fixture.componentInstance as any;
-      const tomorrow = new Date();
-      tomorrow.setDate(tomorrow.getDate() + 1);
-      const dateStr = tomorrow.toISOString().split('T')[0];
-      expect(component.startsIn(dateStr)).toBe('1 day');
-    });
-
-    it('should return "Today" for today or past dates', () => {
-      const component = fixture.componentInstance as any;
-      const today = new Date();
-      const dateStr = today.toISOString().split('T')[0];
-      expect(component.startsIn(dateStr)).toBe('Today');
-    });
-
     it('should calculate session duration in minutes', () => {
       const component = fixture.componentInstance as any;
       expect(component.sessionDuration('19:30:00', '20:45:00')).toBe(75);
       expect(component.sessionDuration('18:00:00', '19:00:00')).toBe(60);
+    });
+
+    it('should format date range with short month and year on end', () => {
+      const component = fixture.componentInstance as any;
+      const result: string = component.formatDateRange('2026-05-15', '2026-07-03');
+      expect(result).toContain('May');
+      expect(result).toContain('Jul');
+      expect(result).toContain('2026');
+      expect(result).toContain('–');
     });
 
     it('should return correct dance style chip class', () => {

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit, ViewChild, computed } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CurrencyPipe, NgClass, TitleCasePipe } from '@angular/common';
+import { NgClass, TitleCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
@@ -9,33 +9,27 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
 import { MatTabsModule } from '@angular/material/tabs';
 import { forkJoin } from 'rxjs';
 import { CourseListItem, CourseService } from './course.service';
-import { formatDayShort, formatTime as stripSeconds, statusChipClass } from './shared/format-utils';
-import { DANCE_STYLES, COURSE_LEVELS } from '../shared/course-constants';
-
-interface CourseFilter {
-  text: string;
-  danceStyle: string;
-  level: string;
-}
+import { statusChipClass } from './shared/format-utils';
 
 interface TabConfig {
   status: string;
   label: string;
-  columns: string[];
 }
 
+const COLUMNS = ['status', 'title', 'danceStyle', 'level', 'dateRange', 'enrollment'];
+
 const TAB_CONFIGS: TabConfig[] = [
-  { status: 'DRAFT', label: 'Draft', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'price'] },
-  { status: 'OPEN', label: 'Open', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'enrollment', 'startsIn'] },
-  { status: 'RUNNING', label: 'Running', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'progress', 'participants'] },
-  { status: 'FINISHED', label: 'Finished', columns: ['status', 'title', 'danceStyle', 'level', 'schedule', 'participants'] },
+  { status: 'ALL', label: 'All' },
+  { status: 'DRAFT', label: 'Draft' },
+  { status: 'OPEN', label: 'Open' },
+  { status: 'RUNNING', label: 'Running' },
+  { status: 'FINISHED', label: 'Finished' },
 ];
 
-const DEFAULT_TAB_INDEX = 2; // Running tab
+const DEFAULT_TAB_INDEX = 0; // All tab
 
 const DAY_ORDER: Record<string, number> = {
   MONDAY: 1, TUESDAY: 2, WEDNESDAY: 3,
@@ -46,8 +40,8 @@ const DAY_ORDER: Record<string, number> = {
   selector: 'app-courses',
   imports: [
     MatTableModule, MatSortModule, MatIconModule, MatButtonModule,
-    MatFormFieldModule, MatInputModule, MatSelectModule, MatTabsModule,
-    FormsModule, RouterLink, CurrencyPipe, TitleCasePipe, NgClass,
+    MatFormFieldModule, MatInputModule, MatTabsModule,
+    FormsModule, RouterLink, TitleCasePipe, NgClass,
   ],
   templateUrl: './courses.html',
   styleUrl: './courses.scss',
@@ -65,15 +59,11 @@ export class CoursesComponent implements OnInit {
 
   // Per-tab data
   protected tabData: MatTableDataSource<CourseListItem>[] = TAB_CONFIGS.map(() => new MatTableDataSource<CourseListItem>([]));
-  protected tabCounts = signal<number[]>([0, 0, 0, 0]);
+  protected tabCounts = signal<number[]>(TAB_CONFIGS.map(() => 0));
 
   protected searchText = '';
-  protected selectedDanceStyle = '';
-  protected selectedLevel = '';
 
-  protected danceStyles = DANCE_STYLES.map(d => d.value);
-  protected levels = COURSE_LEVELS.map(l => l.value);
-
+  protected columns = COLUMNS;
   protected activeDataSource = computed(() => this.tabData[this.activeTabIndex()]);
   protected activeTab = computed(() => TAB_CONFIGS[this.activeTabIndex()]);
 
@@ -87,22 +77,28 @@ export class CoursesComponent implements OnInit {
     this.tabData.forEach(ds => {
       ds.filterPredicate = this.createFilterPredicate();
       ds.sortingDataAccessor = (course, column) => {
-        if (column === 'schedule') return DAY_ORDER[course.dayOfWeek] ?? 0;
+        if (column === 'dateRange') return course.startDate;
+        if (column === 'enrollment') return course.enrolledStudents;
         return (course as unknown as Record<string, string | number>)[column];
       };
     });
 
+    const statusTabs = TAB_CONFIGS.slice(1);
     forkJoin(
-      TAB_CONFIGS.map(tab => this.courseService.getCoursesByStatus(tab.status))
+      statusTabs.map(tab => this.courseService.getCoursesByStatus(tab.status))
     ).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (results) => {
-        const counts: number[] = [];
+        const counts: number[] = [0];
+        const all: CourseListItem[] = [];
         results.forEach((courses, i) => {
-          this.tabData[i].data = courses;
+          this.tabData[i + 1].data = courses;
           counts.push(courses.length);
+          all.push(...courses);
         });
+        counts[0] = all.length;
+        this.tabData[0].data = all;
         this.tabCounts.set(counts);
-        this.hasAnyCourses.set(counts.some(c => c > 0));
+        this.hasAnyCourses.set(all.length > 0);
         this.loaded.set(true);
       },
       error: () => {
@@ -117,50 +113,31 @@ export class CoursesComponent implements OnInit {
   }
 
   protected applyFilter(): void {
-    const filter: CourseFilter = {
-      text: this.searchText.trim().toLowerCase(),
-      danceStyle: this.selectedDanceStyle,
-      level: this.selectedLevel,
-    };
-    const serialized = JSON.stringify(filter);
-    this.tabData.forEach(ds => ds.filter = serialized);
+    const text = this.searchText.trim().toLowerCase();
+    this.tabData.forEach(ds => ds.filter = text);
   }
 
   private createFilterPredicate(): (data: CourseListItem, filter: string) => boolean {
     return (data: CourseListItem, filter: string): boolean => {
-      const f: CourseFilter = JSON.parse(filter);
-      if (f.danceStyle && data.danceStyle !== f.danceStyle) return false;
-      if (f.level && data.level !== f.level) return false;
-      if (f.text) {
-        const searchable = [data.title, data.danceStyle, data.level, data.dayOfWeek].join(' ').toLowerCase();
-        if (!searchable.includes(f.text)) return false;
-      }
-      return true;
+      if (!filter) return true;
+      const searchable = [data.title, data.danceStyle, data.level, data.dayOfWeek].join(' ').toLowerCase();
+      return searchable.includes(filter);
     };
   }
 
-  protected formatDay(dayOfWeek: string): string {
-    return formatDayShort(dayOfWeek);
-  }
-
-  protected formatTime(time: string): string {
-    return stripSeconds(time);
+  protected formatDateRange(startDate: string, endDate: string): string {
+    const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
+    const start = new Date(startDate + 'T00:00:00');
+    const end = new Date(endDate + 'T00:00:00');
+    const startStr = start.toLocaleDateString(undefined, opts);
+    const endStr = end.toLocaleDateString(undefined, { ...opts, year: 'numeric' });
+    return `${startStr} – ${endStr}`;
   }
 
   protected sessionDuration(startTime: string, endTime: string): number {
     const [startH, startM] = startTime.split(':').map(Number);
     const [endH, endM] = endTime.split(':').map(Number);
     return (endH * 60 + endM) - (startH * 60 + startM);
-  }
-
-  protected startsIn(startDate: string): string {
-    const start = new Date(startDate + 'T00:00:00');
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const days = Math.ceil((start.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
-    if (days <= 0) return 'Today';
-    if (days === 1) return '1 day';
-    return `${days} days`;
   }
 
   protected statusChipClass = statusChipClass;

--- a/frontend/src/styles/_table.scss
+++ b/frontend/src/styles/_table.scss
@@ -1,11 +1,23 @@
-// Shared table styles — reusable across all table pages (Courses, Students, Subscriptions, Payments).
-// Import via: @use 'styles' as ds; then apply classes to your template.
+// Shared table-page styles — reusable across all list pages (Courses, Students,
+// Subscriptions, Payments). Loaded globally via `styles.scss`, so classes are
+// available without any @use in component SCSS.
 //
-// Typography rule inside .ds-table-card:
-//   - Chrome (tabs, header cells)    -> label-medium / label-large
-//   - Content (table cells)          -> body-medium
-// Filters / search live outside the card (on the page background) and follow
-// the same body-medium input scale for consistency.
+// Page layout (top → bottom):
+//   .ds-page-toolbar          ← tabs (left) + action buttons (right), hairline under
+//     .ds-page-toolbar__tabs  ← mat-tab-nav-bar
+//       .ds-tab-label / .ds-tab-count  ← label + pill badge
+//     .ds-page-toolbar__actions
+//   .ds-filter-bar            ← full-width search + optional trailing controls
+//     .ds-filter-search
+//   .ds-table-card            ← white card wrapping the mat-table + .ds-table-footer
+//
+// Typography inside .ds-table-card:
+//   - Header cells -> label-large, weight 500
+//   - Body cells   -> body-medium
+//
+// Each page keeps only its own column templates and column-width overrides in
+// its own SCSS. Do not wrap mat-table in a bespoke component — mat-table is the
+// reusable primitive; these styles are the shared chrome.
 
 // ── Table card wrapper ──
 // White card with border. May optionally start with a mat-tab-nav-bar acting as
@@ -17,14 +29,26 @@
   overflow: hidden;
 }
 
-// Optional: mat-tab-nav-bar used as the card header — left-align tabs and let
-// them size to their label instead of stretching.
-// NOTE: mat-tab-nav-bar does NOT support stretchTabs via config or binding
-// (angular/components#27211). When stretchTabs is (default) true, Material adds
-// `.mat-mdc-tab-nav-bar-stretch-tabs` and forces `flex: 1 0 auto` on both the
-// links container and each tab link. We disable that with a matching-specificity
-// override.
-.ds-table-card__tabs.mat-mdc-tab-nav-bar.mat-mdc-tab-nav-bar-stretch-tabs {
+// ── Page toolbar (tabs left + actions right, GitLab-style) ──
+// Sits above the table card on the page background. NOTE: mat-tab-nav-bar does
+// not support stretchTabs via config (angular/components#27211), so we disable
+// its default `flex: 1 0 auto` with a matching-specificity override.
+.ds-page-toolbar {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: var(--ds-spacing-4);
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+}
+
+.ds-page-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-2);
+  padding-bottom: var(--ds-spacing-2);
+}
+
+.ds-page-toolbar__tabs.mat-mdc-tab-nav-bar.mat-mdc-tab-nav-bar-stretch-tabs {
   .mat-mdc-tab-links {
     flex-grow: 0;
   }
@@ -34,24 +58,61 @@
     min-width: 0;
     padding: 0 var(--ds-spacing-4);
     font: var(--mat-sys-label-large);
-    text-transform: uppercase;
-    letter-spacing: var(--ds-letter-spacing-wide);
+    text-transform: none;
+    letter-spacing: normal;
   }
+}
+
+.ds-tab-label {
+  font-weight: 500;
+}
+
+.ds-tab-count {
+  margin-left: var(--ds-spacing-2);
+  padding: 0 var(--ds-spacing-2);
+  border-radius: var(--ds-radius-md);
+  background: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-label-small);
+  font-weight: 600;
+}
+
+// ── Filter bar (full-width search + optional trailing controls) ──
+.ds-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-3);
+
+  .mat-mdc-form-field {
+    --mat-form-field-container-height: 40px;
+    --mat-form-field-container-vertical-padding: 8px;
+    --mdc-outlined-text-field-input-text-size: var(--mat-sys-body-medium-size);
+    --mdc-outlined-text-field-outline-color: var(--mat-sys-outline-variant);
+  }
+}
+
+.ds-filter-search {
+  flex: 1;
 }
 
 // ── Mat-table overrides ──
 // Applied inside .ds-table-card via Angular Material's mat-table directive.
 .ds-table-card {
+  table {
+    table-layout: fixed;
+    width: 100%;
+  }
+
   .mat-mdc-header-row {
     height: 44px;
     border-bottom-color: var(--mat-sys-outline-variant);
-    background: var(--mat-sys-surface-container-low);
+    background: var(--mat-sys-surface);
   }
 
   .mat-mdc-header-cell {
-    font: var(--mat-sys-label-medium);
-    font-weight: 600;
-    color: var(--mat-sys-on-surface-variant);
+    font: var(--mat-sys-label-large);
+    font-weight: 500;
+    color: var(--mat-sys-on-surface);
   }
 
   .mat-mdc-row {
@@ -63,6 +124,12 @@
     font: var(--mat-sys-body-medium);
     color: var(--mat-sys-on-surface);
   }
+}
+
+// Clickable rows (when the whole row routes somewhere)
+.ds-table-card .clickable-row,
+.clickable-row {
+  cursor: pointer;
 }
 
 // ── Multi-line cell pattern ──


### PR DESCRIPTION
## Summary
- Tabs (with count badges) + Add Course action on a single toolbar row; full-width search input below
- New "All" tab aggregates courses across all statuses (now the default)
- Unified column set across tabs: Status, Course Name, Type, Level, Start / End (with session length), Enrollment
- Locked column widths via \`table-layout: fixed\` so widths match across tabs
- Quieter header weight (500) to reduce visual shouting
- Removed the Type/Level filter selects — free-text search already matches those fields

## Test plan
- [ ] CI passes (local chromium unavailable, frontend tests rewritten for new behavior)
- [ ] Manual: check /app/courses — tabs, counts, search, column widths, enrollment blank for Draft