### PR TITLE
Rebalance courses table column widths (#244)

### DIFF
--- a/frontend/src/app/courses/courses.scss
+++ b/frontend/src/app/courses/courses.scss
@@ -4,14 +4,15 @@
   gap: var(--ds-spacing-4);
 }
 
-// Column widths specific to the courses table
+// Column widths specific to the courses table — proportions of the card width
+// (table-layout: fixed + width: 100% means these stretch evenly on wider viewports).
 .courses-table {
-  ::ng-deep .mat-column-status      { width: 120px; }
-  ::ng-deep .mat-column-title       { width: auto; }
-  ::ng-deep .mat-column-danceStyle  { width: 120px; }
-  ::ng-deep .mat-column-level       { width: 140px; }
-  ::ng-deep .mat-column-dateRange   { width: 200px; }
-  ::ng-deep .mat-column-enrollment  { width: 120px; }
+  ::ng-deep .mat-column-status      { width: 12%; }
+  ::ng-deep .mat-column-title       { width: 28%; }
+  ::ng-deep .mat-column-danceStyle  { width: 14%; }
+  ::ng-deep .mat-column-level       { width: 13%; }
+  ::ng-deep .mat-column-dateRange   { width: 20%; }
+  ::ng-deep .mat-column-enrollment  { width: 13%; }
 }
 
 // ── Empty / loading / error ──


### PR DESCRIPTION
## Summary
- Replaces `width: auto` on the Course Name column with explicit percentage widths across all columns so no single column dominates.
- Course Name stays the widest (28%) — next largest is Start/End (20%) — with Status, Type, Level, and Enrollment evenly distributed.

Closes #244

## Test plan
- [x] Verified `All` tab on courses page at 1440×900 — columns are evenly distributed.
- [x] Verified `Draft` tab (no enrollment value) renders correctly.
- [x] Dev server build clean, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)