### PR TITLE
Document Phase 3 payment plan in roadmap

### DIFF
--- a/.claude/rules/product-roadmap.md
+++ b/.claude/rules/product-roadmap.md
@@ -11,4 +11,11 @@
 - Dance events feed — community-oriented: school owners post events, plus external sources (scraped data, festival organizations)
 - Community building is a core goal
 
+**Phase 3 — Online payments (future)**
+- Processor: **Stripe**. Mobile clients use the **Stripe Mobile SDK (PaymentSheet)** — native bottom sheet, Apple Pay / Google Pay out of the box. Web admin uses Stripe Checkout (hosted redirect).
+- **Direct-pay happy path:** student applies → booking logic resolves to direct path → backend creates a PaymentIntent → phone presents PaymentSheet inline → Stripe webhook flips enrollment to CONFIRMED. Payment happens on-the-fly as part of enrollment.
+- **Deferred-payment path (`PENDING_PAYMENT`) reserved for unhappy / non-inline cases:** approval-required enrollments, waitlist promotions, and admin walk-ins paid offline. These wait in `PENDING_PAYMENT` until resolved (payment link sent, or admin marks paid).
+- **Marketplace model (TBD):** each school is a tenant and receives its own payouts → need a Stripe Connect-style solution. **Stripe Connect** is the leading candidate; research still needed on Connect flavor (Standard / Express / Custom), fee structure, onboarding UX, tax handling, and payout cadence.
+- **v1 ships without real payment integration** — all enrollments handled offline (admin marks paid). Architectural stubs in place (a `PENDING_PAYMENT` state and a single `confirmPayment` seam on the backend) so Stripe can be wired in without reshaping the enrollment flow or the API contract.
+
 **Business model:** Solve admin pain for teachers → get students onto the platform → build community via events → monetize via ads, school subscriptions, and other revenue streams TBD


### PR DESCRIPTION
## Summary
- Adds a Phase 3 section to `product-roadmap.md` capturing the payment decisions we made while scoping #224
- Commits to Stripe Mobile SDK (PaymentSheet) for the student app, with Apple Pay / Google Pay out of the box
- Flags Stripe Connect as the leading candidate for per-school payouts — research still pending on Connect flavor, fees, onboarding, and tax handling
- Records the v1-ships-without-payment decision and the forward-compatibility shape (`PENDING_PAYMENT` state + `confirmPayment` seam) that keeps Stripe a surgical add later

## Test plan
- [ ] Roadmap reads clearly standalone (no external context required)
- [ ] Consistent with #224's Phase 3 Forward-Compatibility subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)