### PR TITLE
Add Student entity, API, seed data, and integration tests

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -7,8 +7,11 @@ import ch.ruppen.danceschool.course.CreateCourseDto;
 import ch.ruppen.danceschool.course.DanceStyle;
 import ch.ruppen.danceschool.course.PriceModel;
 import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.school.SchoolUpdateDto;
+import ch.ruppen.danceschool.student.CreateStudentDto;
+import ch.ruppen.danceschool.student.StudentService;
 import ch.ruppen.danceschool.user.AppUser;
 import ch.ruppen.danceschool.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 /**
  * Seeds development users and a school on startup so that local dev login
@@ -38,6 +42,7 @@ public class DevDataSeeder implements ApplicationRunner {
     private final UserService userService;
     private final SchoolService schoolService;
     private final CourseService courseService;
+    private final StudentService studentService;
 
     @Override
     @Transactional
@@ -60,6 +65,7 @@ public class DevDataSeeder implements ApplicationRunner {
         }
 
         seedCourses(owner, owner2);
+        seedStudents(owner, owner2);
 
         log.info("Dev data seeded: owner@test.com (School 1), owner2@test.com (School 2)");
     }
@@ -146,5 +152,53 @@ public class DevDataSeeder implements ApplicationRunner {
                     "Main Hall", "Ana, Luis", 12, true, null,
                     PriceModel.FIXED_COURSE, new BigDecimal("200.00")), 8, today.minusDays(2));
         }
+    }
+
+    private void seedStudents(AppUser owner, AppUser owner2) {
+        if (studentService.hasStudentsForSchool(owner.getId())) {
+            return;
+        }
+
+        School school1 = schoolService.findSchoolByMember(owner.getId());
+        School school2 = schoolService.findSchoolByMember(owner2.getId());
+
+        // School 1: 7 students with varied dance levels
+        studentService.seedStudent(school1, "Anna Müller", "anna.mueller@example.com", "+41 79 100 0001",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.BEGINNER)));
+
+        studentService.seedStudent(school1, "Marco Rossi", "marco.rossi@example.com", "+41 79 100 0002",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.ADVANCED),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.INTERMEDIATE),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.KIZOMBA, CourseLevel.BEGINNER)));
+
+        studentService.seedStudent(school1, "Laura Weber", "laura.weber@example.com", "+41 79 100 0003",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.ADVANCED)));
+
+        studentService.seedStudent(school1, "David Kim", "david.kim@example.com", null,
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.STARTER)));
+
+        studentService.seedStudent(school1, "Sofia Martinez", "sofia.martinez@example.com", "+41 79 100 0005",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.BEGINNER),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.KIZOMBA, CourseLevel.INTERMEDIATE)));
+
+        studentService.seedStudent(school1, "Jan de Vries", "jan.devries@example.com", "+41 79 100 0006",
+                List.of());
+
+        studentService.seedStudent(school1, "Yuki Tanaka", "yuki.tanaka@example.com", "+41 79 100 0007",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.INTERMEDIATE),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.ZOUK, CourseLevel.BEGINNER)));
+
+        // School 2: 3 students
+        studentService.seedStudent(school2, "Elena Fischer", "elena.fischer@example.com", "+41 79 200 0001",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.BEGINNER)));
+
+        studentService.seedStudent(school2, "Thomas Bauer", "thomas.bauer@example.com", "+41 79 200 0002",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.INTERMEDIATE),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE)));
+
+        studentService.seedStudent(school2, "Mia Schmidt", "mia.schmidt@example.com", null,
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.STARTER)));
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/student/CreateStudentDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/CreateStudentDto.java
@@ -1,0 +1,23 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.DanceStyle;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateStudentDto(
+        @NotBlank @Size(max = 255) String name,
+        @NotBlank @Email @Size(max = 255) String email,
+        @Size(max = 50) String phoneNumber,
+        @Valid List<DanceLevelEntry> danceLevels
+) {
+    public record DanceLevelEntry(
+            @NotNull DanceStyle danceStyle,
+            @NotNull CourseLevel level
+    ) {}
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/Student.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/Student.java
@@ -1,0 +1,50 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Student {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "app_user_id")
+    private AppUser user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_id", nullable = false)
+    private School school;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String phoneNumber;
+
+    @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudentDanceLevel> danceLevels = new ArrayList<>();
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
@@ -1,0 +1,46 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/students")
+@RequiredArgsConstructor
+public class StudentController {
+
+    private final StudentService studentService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Map<String, Long> create(@Valid @RequestBody CreateStudentDto dto,
+                                    @AuthenticationPrincipal AuthenticatedUser principal) {
+        Long id = studentService.createStudent(principal.userId(), dto);
+        return Map.of("id", id);
+    }
+
+    @GetMapping("/{id}")
+    public StudentDetailDto getDetail(@PathVariable Long id,
+                                      @AuthenticationPrincipal AuthenticatedUser principal) {
+        return studentService.getStudent(principal.userId(), id);
+    }
+
+    @PutMapping("/{id}/dance-levels")
+    public StudentDetailDto updateDanceLevels(@PathVariable Long id,
+                                              @Valid @RequestBody UpdateDanceLevelsDto dto,
+                                              @AuthenticationPrincipal AuthenticatedUser principal) {
+        return studentService.updateDanceLevels(principal.userId(), id, dto);
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentDanceLevel.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentDanceLevel.java
@@ -1,0 +1,42 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.DanceStyle;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "student_dance_level")
+@Getter
+@Setter
+@NoArgsConstructor
+public class StudentDanceLevel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "dance_style", nullable = false)
+    private DanceStyle danceStyle;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CourseLevel level;
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentDetailDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentDetailDto.java
@@ -1,0 +1,19 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.DanceStyle;
+
+import java.util.List;
+
+public record StudentDetailDto(
+        Long id,
+        String name,
+        String email,
+        String phoneNumber,
+        List<DanceLevelDto> danceLevels
+) {
+    record DanceLevelDto(
+            DanceStyle danceStyle,
+            CourseLevel level
+    ) {}
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
@@ -1,0 +1,15 @@
+package ch.ruppen.danceschool.student;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+interface StudentRepository extends JpaRepository<Student, Long> {
+
+    List<Student> findAllBySchoolId(Long schoolId);
+
+    Optional<Student> findByIdAndSchoolId(Long id, Long schoolId);
+
+    boolean existsBySchoolId(Long schoolId);
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
@@ -1,0 +1,116 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.school.SchoolService;
+import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
+import ch.ruppen.danceschool.shared.logging.BusinessOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentService {
+
+    private final StudentRepository studentRepository;
+    private final SchoolService schoolService;
+
+    @Transactional
+    @BusinessOperation(event = "StudentCreated")
+    public Long createStudent(Long userId, CreateStudentDto dto) {
+        School school = schoolService.findSchoolByMember(userId);
+
+        Student student = new Student();
+        student.setSchool(school);
+        student.setName(dto.name());
+        student.setEmail(dto.email());
+        student.setPhoneNumber(dto.phoneNumber());
+
+        if (dto.danceLevels() != null) {
+            for (CreateStudentDto.DanceLevelEntry entry : dto.danceLevels()) {
+                StudentDanceLevel level = new StudentDanceLevel();
+                level.setStudent(student);
+                level.setDanceStyle(entry.danceStyle());
+                level.setLevel(entry.level());
+                student.getDanceLevels().add(level);
+            }
+        }
+
+        studentRepository.save(student);
+        return student.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public StudentDetailDto getStudent(Long userId, Long studentId) {
+        School school = schoolService.findSchoolByMember(userId);
+        Student student = studentRepository.findByIdAndSchoolId(studentId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Student", studentId));
+        return toDetailDto(student);
+    }
+
+    @Transactional
+    @BusinessOperation(event = "StudentDanceLevelsUpdated")
+    public StudentDetailDto updateDanceLevels(Long userId, Long studentId, UpdateDanceLevelsDto dto) {
+        School school = schoolService.findSchoolByMember(userId);
+        Student student = studentRepository.findByIdAndSchoolId(studentId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Student", studentId));
+
+        student.getDanceLevels().clear();
+        for (UpdateDanceLevelsDto.DanceLevelEntry entry : dto.danceLevels()) {
+            StudentDanceLevel level = new StudentDanceLevel();
+            level.setStudent(student);
+            level.setDanceStyle(entry.danceStyle());
+            level.setLevel(entry.level());
+            student.getDanceLevels().add(level);
+        }
+
+        return toDetailDto(student);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasStudentsForSchool(Long userId) {
+        School school = schoolService.findSchoolByMember(userId);
+        return studentRepository.existsBySchoolId(school.getId());
+    }
+
+    /**
+     * Seeds a student for dev/test data directly via the school entity.
+     */
+    @Transactional
+    public Student seedStudent(School school, String name, String email, String phoneNumber,
+                               List<CreateStudentDto.DanceLevelEntry> danceLevels) {
+        Student student = new Student();
+        student.setSchool(school);
+        student.setName(name);
+        student.setEmail(email);
+        student.setPhoneNumber(phoneNumber);
+
+        if (danceLevels != null) {
+            for (CreateStudentDto.DanceLevelEntry entry : danceLevels) {
+                StudentDanceLevel level = new StudentDanceLevel();
+                level.setStudent(student);
+                level.setDanceStyle(entry.danceStyle());
+                level.setLevel(entry.level());
+                student.getDanceLevels().add(level);
+            }
+        }
+
+        return studentRepository.save(student);
+    }
+
+    private StudentDetailDto toDetailDto(Student student) {
+        return new StudentDetailDto(
+                student.getId(),
+                student.getName(),
+                student.getEmail(),
+                student.getPhoneNumber(),
+                student.getDanceLevels().stream()
+                        .map(dl -> new StudentDetailDto.DanceLevelDto(dl.getDanceStyle(), dl.getLevel()))
+                        .toList()
+        );
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/UpdateDanceLevelsDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/UpdateDanceLevelsDto.java
@@ -1,0 +1,17 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.DanceStyle;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record UpdateDanceLevelsDto(
+        @Valid @NotNull List<DanceLevelEntry> danceLevels
+) {
+    record DanceLevelEntry(
+            @NotNull DanceStyle danceStyle,
+            @NotNull CourseLevel level
+    ) {}
+}

--- a/backend/src/main/resources/db/changelog/015-create-student.yaml
+++ b/backend/src/main/resources/db/changelog/015-create-student.yaml
@@ -1,0 +1,56 @@
+databaseChangeLog:
+  - changeSet:
+      id: 015-create-student
+      author: claude
+      changes:
+        - createTable:
+            tableName: student
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: app_user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: true
+              - column:
+                  name: school_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: phone_number
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: true
+        - addForeignKeyConstraint:
+            baseTableName: student
+            baseColumnNames: app_user_id
+            referencedTableName: app_user
+            referencedColumnNames: id
+            constraintName: fk_student_app_user
+        - addForeignKeyConstraint:
+            baseTableName: student
+            baseColumnNames: school_id
+            referencedTableName: school
+            referencedColumnNames: id
+            constraintName: fk_student_school
+        - addUniqueConstraint:
+            tableName: student
+            columnNames: app_user_id, school_id
+            constraintName: uq_student_app_user_school

--- a/backend/src/main/resources/db/changelog/016-create-student-dance-level.yaml
+++ b/backend/src/main/resources/db/changelog/016-create-student-dance-level.yaml
@@ -1,0 +1,40 @@
+databaseChangeLog:
+  - changeSet:
+      id: 016-create-student-dance-level
+      author: claude
+      changes:
+        - createTable:
+            tableName: student_dance_level
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: student_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dance_style
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: level
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: student_dance_level
+            baseColumnNames: student_id
+            referencedTableName: student
+            referencedColumnNames: id
+            constraintName: fk_student_dance_level_student
+        - addUniqueConstraint:
+            tableName: student_dance_level
+            columnNames: student_id, dance_style
+            constraintName: uq_student_dance_level_style

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -27,3 +27,7 @@ databaseChangeLog:
       file: db/changelog/013-index-school-member-school-id.yaml
   - include:
       file: db/changelog/014-derived-course-status.yaml
+  - include:
+      file: db/changelog/015-create-student.yaml
+  - include:
+      file: db/changelog/016-create-student-dance-level.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentCrudIntegrationTest.java
@@ -1,0 +1,242 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class StudentCrudIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser owner;
+
+    @BeforeEach
+    void setUp() {
+        owner = createUser("owner@example.com", "Owner", "firebase-owner");
+        createSchoolWithOwner("Test School", owner);
+        entityManager.flush();
+    }
+
+    @Test
+    void createStudent_returnsId() throws Exception {
+        mockMvc.perform(post("/api/students")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "Anna Müller",
+                                    "email": "anna@example.com",
+                                    "phoneNumber": "+41 79 100 0001",
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "INTERMEDIATE"},
+                                        {"danceStyle": "BACHATA", "level": "BEGINNER"}
+                                    ]
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNumber());
+    }
+
+    @Test
+    void createStudent_withoutDanceLevels_returnsId() throws Exception {
+        mockMvc.perform(post("/api/students")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "David Kim",
+                                    "email": "david@example.com"
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNumber());
+    }
+
+    @Test
+    void createStudent_invalidEmail_returns400() throws Exception {
+        mockMvc.perform(post("/api/students")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "Bad Email",
+                                    "email": "not-an-email"
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createStudent_missingName_returns400() throws Exception {
+        mockMvc.perform(post("/api/students")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "email": "test@example.com"
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getStudent_returnsProfileWithDanceLevels() throws Exception {
+        Student student = createStudent("Anna Müller", "anna@example.com", "+41 79 100 0001");
+        addDanceLevel(student, "SALSA", "INTERMEDIATE");
+        addDanceLevel(student, "BACHATA", "BEGINNER");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/students/{id}", student.getId())
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(student.getId()))
+                .andExpect(jsonPath("$.name").value("Anna Müller"))
+                .andExpect(jsonPath("$.email").value("anna@example.com"))
+                .andExpect(jsonPath("$.phoneNumber").value("+41 79 100 0001"))
+                .andExpect(jsonPath("$.danceLevels.length()").value(2));
+    }
+
+    @Test
+    void getStudent_notFound_returns404() throws Exception {
+        mockMvc.perform(get("/api/students/{id}", 9999)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateDanceLevels_replacesAllLevels() throws Exception {
+        Student student = createStudent("Anna Müller", "anna@example.com", null);
+        addDanceLevel(student, "SALSA", "BEGINNER");
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/students/{id}/dance-levels", student.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "ADVANCED"},
+                                        {"danceStyle": "KIZOMBA", "level": "STARTER"}
+                                    ]
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.danceLevels.length()").value(2))
+                .andExpect(jsonPath("$.danceLevels[?(@.danceStyle=='SALSA')].level").value("ADVANCED"))
+                .andExpect(jsonPath("$.danceLevels[?(@.danceStyle=='KIZOMBA')].level").value("STARTER"));
+    }
+
+    @Test
+    void updateDanceLevels_clearAll() throws Exception {
+        Student student = createStudent("Anna Müller", "anna@example.com", null);
+        addDanceLevel(student, "SALSA", "BEGINNER");
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/students/{id}/dance-levels", student.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": []
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.danceLevels.length()").value(0));
+    }
+
+    @Test
+    void updateDanceLevels_notFound_returns404() throws Exception {
+        mockMvc.perform(put("/api/students/{id}/dance-levels", 9999)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": []
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isNotFound());
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser ownerUser) {
+        School school = new School();
+        school.setName(name);
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(ownerUser);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return school;
+    }
+
+    private Student createStudent(String name, String email, String phoneNumber) {
+        School school = entityManager.createQuery(
+                        "SELECT s FROM School s JOIN SchoolMember m ON m.school = s WHERE m.user = :user", School.class)
+                .setParameter("user", owner)
+                .getSingleResult();
+
+        Student student = new Student();
+        student.setSchool(school);
+        student.setName(name);
+        student.setEmail(email);
+        student.setPhoneNumber(phoneNumber);
+        entityManager.persist(student);
+        return student;
+    }
+
+    private void addDanceLevel(Student student, String style, String level) {
+        StudentDanceLevel dl = new StudentDanceLevel();
+        dl.setStudent(student);
+        dl.setDanceStyle(ch.ruppen.danceschool.course.DanceStyle.valueOf(style));
+        dl.setLevel(ch.ruppen.danceschool.course.CourseLevel.valueOf(level));
+        student.getDanceLevels().add(dl);
+        entityManager.persist(dl);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentTenantIsolationTest.java
@@ -1,0 +1,154 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class StudentTenantIsolationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser ownerA;
+    private AppUser ownerB;
+    private School schoolA;
+    private School schoolB;
+
+    @BeforeEach
+    void setUp() {
+        ownerA = createUser("owner-a@example.com", "Owner A", "firebase-a");
+        ownerB = createUser("owner-b@example.com", "Owner B", "firebase-b");
+
+        schoolA = createSchoolWithOwner("School A", ownerA);
+        schoolB = createSchoolWithOwner("School B", ownerB);
+
+        entityManager.flush();
+    }
+
+    @Test
+    void getStudent_returns404_forOtherSchoolsStudent() throws Exception {
+        Student studentB = createStudent(schoolB, "Student B", "studentb@example.com");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/students/{id}", studentB.getId())
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getStudent_returnsOwnSchoolStudent() throws Exception {
+        Student studentA = createStudent(schoolA, "Student A", "studenta@example.com");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/students/{id}", studentA.getId())
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void updateDanceLevels_returns404_forOtherSchoolsStudent() throws Exception {
+        Student studentB = createStudent(schoolB, "Student B", "studentb@example.com");
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/students/{id}/dance-levels", studentB.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "BEGINNER"}
+                                    ]
+                                }
+                                """)
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void createStudent_scopesToCallerSchool() throws Exception {
+        // Owner A creates a student — it should be scoped to School A
+        String response = mockMvc.perform(post("/api/students")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name": "Test Student",
+                                    "email": "test@example.com"
+                                }
+                                """)
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long studentId = Long.parseLong(response.replaceAll(".*\"id\"\\s*:\\s*(\\d+).*", "$1"));
+
+        // Owner B cannot see Owner A's student
+        mockMvc.perform(get("/api/students/{id}", studentId)
+                        .with(authentication(authToken(ownerB))))
+                .andExpect(status().isNotFound());
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser ownerUser) {
+        School school = new School();
+        school.setName(name);
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(ownerUser);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return school;
+    }
+
+    private Student createStudent(School school, String name, String email) {
+        Student student = new Student();
+        student.setSchool(school);
+        student.setName(name);
+        student.setEmail(email);
+        entityManager.persist(student);
+        return student;
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #247

- Add `student` and `student_dance_level` tables via Liquibase migrations with proper FK constraints and unique constraints
- Introduce `Student` and `StudentDanceLevel` JPA entities in a new `student` package, scoped to `School` for tenant isolation
- Implement three API endpoints: `POST /api/students` (create), `GET /api/students/{id}` (get with dance levels), `PUT /api/students/{id}/dance-levels` (update)
- Seed ~10 sample students with varied dance levels across both dev schools in `DevDataSeeder`
- Add 13 integration tests covering CRUD operations (create, get, update dance levels, validation errors, 404s) and tenant isolation (cross-school access denied)

## Test plan

- [x] All 116 backend tests pass (`mvn test`)
- [x] 9 CRUD integration tests: create with/without dance levels, validation (bad email, missing name), get with dance levels, get 404, update dance levels (replace all, clear all), update 404
- [x] 4 tenant isolation tests: get/update returns 404 for other school's student, own school student accessible, create scoped to caller's school

🤖 Generated with [Claude Code](https://claude.com/claude-code)