### PR TITLE
Pull main before creating worktree in /start-issue

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -7,9 +7,10 @@ The user provides a GitHub issue number as an argument (e.g., `/start-issue 100`
 ## Phase 1 — Setup
 
 1. **Load the issue:** `gh issue view <number>` (include comments for full context)
-2. **Create worktree:** Use `EnterWorktree` with a descriptive name derived from the issue (e.g., `100-multi-tenancy-isolation`)
-3. **Install frontend deps:** Run `npm install` in `frontend/` (fresh worktrees need this)
-4. **Create branch:** Create a feature branch from main
+2. **Update main:** `git checkout main && git pull --ff-only origin main`
+3. **Create worktree:** Use `EnterWorktree` with a descriptive name derived from the issue (e.g., `100-multi-tenancy-isolation`)
+4. **Install frontend deps:** Run `npm install` in `frontend/` (fresh worktrees need this)
+5. **Create branch:** Create a feature branch from main
 
 ## Phase 2 — Planning
 


### PR DESCRIPTION
## Summary
- Adds a `git pull --ff-only origin main` step before the worktree is created, so new branches start from the latest upstream commit rather than a stale local main
- Renumbers the subsequent setup steps

## Test plan
- [ ] Run `/start-issue <n>` on a fresh worktree and confirm the Phase 1 checklist includes the pull step

🤖 Generated with [Claude Code](https://claude.com/claude-code)