### PR TITLE
Add enrollment system: direct booking, mark-paid, and Dev Tools (#249)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
@@ -82,4 +82,6 @@ public class Course {
     private LocalDate publishedAt;
 
     private int enrolledStudents;
+
+    private boolean requiresApproval;
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -130,14 +130,20 @@ public class CourseService {
      * Seeds a course for dev/test data. Skips domain validation (seed data may have past dates).
      */
     @Transactional
-    public void seedCourse(Long userId, CreateCourseDto dto, int enrolledStudents, LocalDate publishedAt) {
+    public Course seedCourse(Long userId, CreateCourseDto dto, int enrolledStudents, LocalDate publishedAt) {
         School school = schoolService.findSchoolByMember(userId);
         Course course = new Course();
         course.setSchool(school);
         applyDto(course, dto);
         course.setEnrolledStudents(enrolledStudents);
         course.setPublishedAt(publishedAt);
-        courseRepository.save(course);
+        return courseRepository.save(course);
+    }
+
+    @Transactional(readOnly = true)
+    public Course findCourseByIdAndSchool(Long courseId, School school) {
+        return courseRepository.findByIdAndSchoolId(courseId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.dev;
 
+import ch.ruppen.danceschool.course.Course;
 import ch.ruppen.danceschool.course.CourseLevel;
 import ch.ruppen.danceschool.course.CourseService;
 import ch.ruppen.danceschool.course.CourseType;
@@ -7,10 +8,14 @@ import ch.ruppen.danceschool.course.CreateCourseDto;
 import ch.ruppen.danceschool.course.DanceStyle;
 import ch.ruppen.danceschool.course.PriceModel;
 import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.enrollment.DanceRole;
+import ch.ruppen.danceschool.enrollment.EnrollmentService;
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.school.SchoolUpdateDto;
 import ch.ruppen.danceschool.student.CreateStudentDto;
+import ch.ruppen.danceschool.student.Student;
 import ch.ruppen.danceschool.student.StudentService;
 import ch.ruppen.danceschool.user.AppUser;
 import ch.ruppen.danceschool.user.UserService;
@@ -23,8 +28,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -43,6 +51,7 @@ public class DevDataSeeder implements ApplicationRunner {
     private final SchoolService schoolService;
     private final CourseService courseService;
     private final StudentService studentService;
+    private final EnrollmentService enrollmentService;
 
     @Override
     @Transactional
@@ -64,131 +73,151 @@ public class DevDataSeeder implements ApplicationRunner {
             schoolService.createSchool(school2Dto, owner2.getId());
         }
 
-        seedCourses(owner, owner2);
-        seedStudents(owner, owner2);
+        List<Course> courses1 = seedCourses(owner);
+        List<Course> courses2 = seedCoursesForOwner2(owner2);
+        List<Student> students1 = seedStudents(owner, owner2);
+        seedEnrollments(owner, courses1, students1);
 
         log.info("Dev data seeded: owner@test.com (School 1), owner2@test.com (School 2)");
     }
 
-    private void seedCourses(AppUser owner, AppUser owner2) {
+    private List<Course> seedCourses(AppUser owner) {
         LocalDate today = LocalDate.now();
 
-        if (!courseService.hasCoursesForMember(owner.getId())) {
-            // --- RUNNING courses (published, start in the past, end in the future) ---
-            courseService.seedCourse(owner.getId(), new CreateCourseDto(
-                    "Salsa, Merengue, Bachata Solo", DanceStyle.SALSA, CourseLevel.BEGINNER,
-                    CourseType.SOLO, "Learn the basics of Salsa, Merengue, and Bachata in solo style.",
-                    today.minusWeeks(1), RecurrenceType.WEEKLY,
-                    6, LocalTime.of(19, 30), LocalTime.of(20, 45),
-                    "Studio A", "Maria", 12, false, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 8, today.minusWeeks(2));
-
-            courseService.seedCourse(owner.getId(), new CreateCourseDto(
-                    "Bachata Intermediate", DanceStyle.BACHATA, CourseLevel.INTERMEDIATE,
-                    CourseType.PARTNER, "Take your Bachata to the next level with partner work and musicality.",
-                    today.minusWeeks(2), RecurrenceType.WEEKLY,
-                    8, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                    "Studio B", "Carlos", 15, true, 3,
-                    PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 12, today.minusWeeks(3));
-
-            // --- OPEN courses (published, start in the future) ---
-            courseService.seedCourse(owner.getId(), new CreateCourseDto(
-                    "Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED,
-                    CourseType.PARTNER, "Advanced Salsa patterns, styling, and performance preparation.",
-                    today.plusWeeks(4), RecurrenceType.WEEKLY,
-                    10, LocalTime.of(20, 0), LocalTime.of(21, 15),
-                    "Studio A", "Maria, Carlos", 10, true, 2,
-                    PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 7, today.minusDays(5));
-
-            courseService.seedCourse(owner.getId(), new CreateCourseDto(
-                    "Bachata Beginners", DanceStyle.BACHATA, CourseLevel.BEGINNER,
-                    CourseType.PARTNER, "Start your Bachata journey with the fundamentals of partner dancing.",
-                    today.plusWeeks(5), RecurrenceType.WEEKLY,
-                    6, LocalTime.of(18, 30), LocalTime.of(19, 45),
-                    "Studio B", "Carlos", 16, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 5, today.minusDays(3));
-
-            // --- DRAFT courses (not published) ---
-            courseService.seedCourse(owner.getId(), new CreateCourseDto(
-                    "Salsa Social Dancing", DanceStyle.SALSA, CourseLevel.INTERMEDIATE,
-                    CourseType.PARTNER, "Social dancing techniques and floor craft.",
-                    today.plusWeeks(8), RecurrenceType.WEEKLY,
-                    8, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                    "Studio A", "Maria", 20, false, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 0, null);
-
-            courseService.seedCourse(owner.getId(), new CreateCourseDto(
-                    "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
-                    CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
-                    today.plusWeeks(10), RecurrenceType.WEEKLY,
-                    6, LocalTime.of(14, 0), LocalTime.of(15, 30),
-                    "Studio B", "Carlos, Ana", 12, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, null);
-
-            // --- FINISHED course (end date in the past) ---
-            courseService.seedCourse(owner.getId(), new CreateCourseDto(
-                    "Kizomba Fundamentals", DanceStyle.KIZOMBA, CourseLevel.BEGINNER,
-                    CourseType.PARTNER, "Introduction to Kizomba connection and movement.",
-                    today.minusWeeks(12), RecurrenceType.WEEKLY,
-                    8, LocalTime.of(20, 0), LocalTime.of(21, 0),
-                    "Studio A", "Luis", 14, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 11, today.minusWeeks(14));
+        if (courseService.hasCoursesForMember(owner.getId())) {
+            return List.of();
         }
 
-        if (!courseService.hasCoursesForMember(owner2.getId())) {
-            courseService.seedCourse(owner2.getId(), new CreateCourseDto(
-                    "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
-                    CourseType.PARTNER, "Introduction to Salsa for complete beginners.",
-                    today.minusWeeks(1), RecurrenceType.WEEKLY,
-                    8, LocalTime.of(18, 0), LocalTime.of(19, 0),
-                    "Main Hall", "Ana", 20, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 5, today.minusWeeks(2));
+        List<Course> courses = new ArrayList<>();
 
-            courseService.seedCourse(owner2.getId(), new CreateCourseDto(
-                    "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
-                    CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
-                    today.plusWeeks(3), RecurrenceType.WEEKLY,
-                    6, LocalTime.of(14, 0), LocalTime.of(15, 30),
-                    "Main Hall", "Ana, Luis", 12, true, null,
-                    PriceModel.FIXED_COURSE, new BigDecimal("200.00")), 8, today.minusDays(2));
-        }
+        // --- RUNNING courses (published, start in the past, end in the future) ---
+        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+                "Salsa, Merengue, Bachata Solo", DanceStyle.SALSA, CourseLevel.BEGINNER,
+                CourseType.SOLO, "Learn the basics of Salsa, Merengue, and Bachata in solo style.",
+                today.minusWeeks(1), RecurrenceType.WEEKLY,
+                6, LocalTime.of(19, 30), LocalTime.of(20, 45),
+                "Studio A", "Maria", 12, false, null,
+                PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 0, today.minusWeeks(2)));
+
+        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+                "Bachata Intermediate", DanceStyle.BACHATA, CourseLevel.INTERMEDIATE,
+                CourseType.PARTNER, "Take your Bachata to the next level with partner work and musicality.",
+                today.minusWeeks(2), RecurrenceType.WEEKLY,
+                8, LocalTime.of(19, 0), LocalTime.of(20, 0),
+                "Studio B", "Carlos", 15, true, 3,
+                PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 0, today.minusWeeks(3)));
+
+        // --- OPEN courses (published, start in the future) ---
+        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+                "Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED,
+                CourseType.PARTNER, "Advanced Salsa patterns, styling, and performance preparation.",
+                today.plusWeeks(4), RecurrenceType.WEEKLY,
+                10, LocalTime.of(20, 0), LocalTime.of(21, 15),
+                "Studio A", "Maria, Carlos", 10, true, 2,
+                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, today.minusDays(5)));
+
+        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+                "Bachata Beginners", DanceStyle.BACHATA, CourseLevel.BEGINNER,
+                CourseType.PARTNER, "Start your Bachata journey with the fundamentals of partner dancing.",
+                today.plusWeeks(5), RecurrenceType.WEEKLY,
+                6, LocalTime.of(18, 30), LocalTime.of(19, 45),
+                "Studio B", "Carlos", 16, true, null,
+                PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 0, today.minusDays(3)));
+
+        // --- DRAFT courses (not published) ---
+        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+                "Salsa Social Dancing", DanceStyle.SALSA, CourseLevel.INTERMEDIATE,
+                CourseType.PARTNER, "Social dancing techniques and floor craft.",
+                today.plusWeeks(8), RecurrenceType.WEEKLY,
+                8, LocalTime.of(19, 0), LocalTime.of(20, 0),
+                "Studio A", "Maria", 20, false, null,
+                PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 0, null));
+
+        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+                "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
+                CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
+                today.plusWeeks(10), RecurrenceType.WEEKLY,
+                6, LocalTime.of(14, 0), LocalTime.of(15, 30),
+                "Studio B", "Carlos, Ana", 12, true, null,
+                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, null));
+
+        // --- FINISHED course (end date in the past) ---
+        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+                "Kizomba Fundamentals", DanceStyle.KIZOMBA, CourseLevel.BEGINNER,
+                CourseType.PARTNER, "Introduction to Kizomba connection and movement.",
+                today.minusWeeks(12), RecurrenceType.WEEKLY,
+                8, LocalTime.of(20, 0), LocalTime.of(21, 0),
+                "Studio A", "Luis", 14, true, null,
+                PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 0, today.minusWeeks(14)));
+
+        return courses;
     }
 
-    private void seedStudents(AppUser owner, AppUser owner2) {
+    private List<Course> seedCoursesForOwner2(AppUser owner2) {
+        LocalDate today = LocalDate.now();
+
+        if (courseService.hasCoursesForMember(owner2.getId())) {
+            return List.of();
+        }
+
+        List<Course> courses = new ArrayList<>();
+
+        courses.add(courseService.seedCourse(owner2.getId(), new CreateCourseDto(
+                "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
+                CourseType.PARTNER, "Introduction to Salsa for complete beginners.",
+                today.minusWeeks(1), RecurrenceType.WEEKLY,
+                8, LocalTime.of(18, 0), LocalTime.of(19, 0),
+                "Main Hall", "Ana", 20, true, null,
+                PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 0, today.minusWeeks(2)));
+
+        courses.add(courseService.seedCourse(owner2.getId(), new CreateCourseDto(
+                "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
+                CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
+                today.plusWeeks(3), RecurrenceType.WEEKLY,
+                6, LocalTime.of(14, 0), LocalTime.of(15, 30),
+                "Main Hall", "Ana, Luis", 12, true, null,
+                PriceModel.FIXED_COURSE, new BigDecimal("200.00")), 0, today.minusDays(2)));
+
+        return courses;
+    }
+
+    private List<Student> seedStudents(AppUser owner, AppUser owner2) {
         if (studentService.hasStudentsForSchool(owner.getId())) {
-            return;
+            return List.of();
         }
 
         School school1 = schoolService.findSchoolByMember(owner.getId());
         School school2 = schoolService.findSchoolByMember(owner2.getId());
 
-        // School 1: 7 students with varied dance levels
-        studentService.seedStudent(school1, "Anna Müller", "anna.mueller@example.com", "+41 79 100 0001",
-                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE),
-                        new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.BEGINNER)));
+        List<Student> students = new ArrayList<>();
 
-        studentService.seedStudent(school1, "Marco Rossi", "marco.rossi@example.com", "+41 79 100 0002",
+        // School 1: 7 students with varied dance levels
+        students.add(studentService.seedStudent(school1, "Anna Mueller", "anna.mueller@example.com", "+41 79 100 0001",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.BEGINNER))));
+
+        students.add(studentService.seedStudent(school1, "Marco Rossi", "marco.rossi@example.com", "+41 79 100 0002",
                 List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.ADVANCED),
                         new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.INTERMEDIATE),
-                        new CreateStudentDto.DanceLevelEntry(DanceStyle.KIZOMBA, CourseLevel.BEGINNER)));
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.KIZOMBA, CourseLevel.BEGINNER))));
 
-        studentService.seedStudent(school1, "Laura Weber", "laura.weber@example.com", "+41 79 100 0003",
-                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.ADVANCED)));
+        students.add(studentService.seedStudent(school1, "Laura Weber", "laura.weber@example.com", "+41 79 100 0003",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.ADVANCED))));
 
-        studentService.seedStudent(school1, "David Kim", "david.kim@example.com", null,
-                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.STARTER)));
+        students.add(studentService.seedStudent(school1, "David Kim", "david.kim@example.com", null,
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.STARTER))));
 
-        studentService.seedStudent(school1, "Sofia Martinez", "sofia.martinez@example.com", "+41 79 100 0005",
+        students.add(studentService.seedStudent(school1, "Sofia Martinez", "sofia.martinez@example.com", "+41 79 100 0005",
                 List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.BEGINNER),
-                        new CreateStudentDto.DanceLevelEntry(DanceStyle.KIZOMBA, CourseLevel.INTERMEDIATE)));
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.KIZOMBA, CourseLevel.INTERMEDIATE))));
 
-        studentService.seedStudent(school1, "Jan de Vries", "jan.devries@example.com", "+41 79 100 0006",
-                List.of());
+        students.add(studentService.seedStudent(school1, "Jan de Vries", "jan.devries@example.com", "+41 79 100 0006",
+                List.of()));
 
-        studentService.seedStudent(school1, "Yuki Tanaka", "yuki.tanaka@example.com", "+41 79 100 0007",
+        students.add(studentService.seedStudent(school1, "Yuki Tanaka", "yuki.tanaka@example.com", "+41 79 100 0007",
                 List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE),
                         new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.INTERMEDIATE),
-                        new CreateStudentDto.DanceLevelEntry(DanceStyle.ZOUK, CourseLevel.BEGINNER)));
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.ZOUK, CourseLevel.BEGINNER))));
 
         // School 2: 3 students
         studentService.seedStudent(school2, "Elena Fischer", "elena.fischer@example.com", "+41 79 200 0001",
@@ -200,5 +229,47 @@ public class DevDataSeeder implements ApplicationRunner {
 
         studentService.seedStudent(school2, "Mia Schmidt", "mia.schmidt@example.com", null,
                 List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.STARTER)));
+
+        return students;
+    }
+
+    private void seedEnrollments(AppUser owner, List<Course> courses, List<Student> students) {
+        if (courses.isEmpty() || students.isEmpty()) {
+            return;
+        }
+
+        Instant now = Instant.now();
+
+        // courses[0] = "Salsa, Merengue, Bachata Solo" (SOLO, BEGINNER, max 12)
+        // Enroll 4 students as CONFIRMED, 2 as PENDING_PAYMENT
+        Course soloCourse = courses.get(0);
+        enrollmentService.seedEnrollment(soloCourse, students.get(0), null,
+                EnrollmentStatus.CONFIRMED, now.minus(10, ChronoUnit.DAYS), now.minus(8, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(soloCourse, students.get(1), null,
+                EnrollmentStatus.CONFIRMED, now.minus(9, ChronoUnit.DAYS), now.minus(7, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(soloCourse, students.get(3), null,
+                EnrollmentStatus.CONFIRMED, now.minus(8, ChronoUnit.DAYS), now.minus(6, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(soloCourse, students.get(4), null,
+                EnrollmentStatus.CONFIRMED, now.minus(7, ChronoUnit.DAYS), now.minus(5, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(soloCourse, students.get(5), null,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(3, ChronoUnit.DAYS), null);
+        enrollmentService.seedEnrollment(soloCourse, students.get(6), null,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
+        soloCourse.setEnrolledStudents(6);
+
+        // courses[1] = "Bachata Intermediate" (PARTNER, INTERMEDIATE, max 15, roleBalancing=true, threshold=3)
+        // Enroll 5 students with LEAD/FOLLOW roles, mix of CONFIRMED and PENDING_PAYMENT
+        Course partnerCourse = courses.get(1);
+        enrollmentService.seedEnrollment(partnerCourse, students.get(0), DanceRole.FOLLOW,
+                EnrollmentStatus.CONFIRMED, now.minus(12, ChronoUnit.DAYS), now.minus(10, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(partnerCourse, students.get(1), DanceRole.LEAD,
+                EnrollmentStatus.CONFIRMED, now.minus(11, ChronoUnit.DAYS), now.minus(9, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(partnerCourse, students.get(2), DanceRole.FOLLOW,
+                EnrollmentStatus.CONFIRMED, now.minus(10, ChronoUnit.DAYS), now.minus(8, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(partnerCourse, students.get(6), DanceRole.LEAD,
+                EnrollmentStatus.CONFIRMED, now.minus(9, ChronoUnit.DAYS), now.minus(7, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(partnerCourse, students.get(4), DanceRole.FOLLOW,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
+        partnerCourse.setEnrolledStudents(5);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/DanceRole.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/DanceRole.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.enrollment;
+
+public enum DanceRole {
+    LEAD,
+    FOLLOW
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollStudentDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollStudentDto.java
@@ -1,0 +1,9 @@
+package ch.ruppen.danceschool.enrollment;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EnrollStudentDto(
+        @NotNull Long studentId,
+        DanceRole danceRole
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/Enrollment.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/Enrollment.java
@@ -1,0 +1,62 @@
+package ch.ruppen.danceschool.enrollment;
+
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.student.Student;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Enrollment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Enumerated(EnumType.STRING)
+    private DanceRole danceRole;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EnrollmentStatus status;
+
+    @Column(nullable = false)
+    private Instant enrolledAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "enrolled_by_member_id")
+    private SchoolMember enrolledBy;
+
+    private Instant approvedAt;
+
+    private Instant paidAt;
+
+    private Integer waitlistPosition;
+
+    @Enumerated(EnumType.STRING)
+    private WaitlistReason waitlistReason;
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
@@ -1,0 +1,45 @@
+package ch.ruppen.danceschool.enrollment;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+    @PostMapping("/courses/{courseId}/enrollments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public EnrollmentResponseDto enroll(@PathVariable Long courseId,
+                                        @Valid @RequestBody EnrollStudentDto dto,
+                                        @AuthenticationPrincipal AuthenticatedUser principal) {
+        return enrollmentService.enrollStudent(principal.userId(), courseId, dto);
+    }
+
+    @GetMapping("/courses/{courseId}/enrollments")
+    public List<EnrollmentListDto> list(@PathVariable Long courseId,
+                                        @AuthenticationPrincipal AuthenticatedUser principal) {
+        return enrollmentService.getEnrollments(principal.userId(), courseId);
+    }
+
+    @PutMapping("/enrollments/{enrollmentId}/mark-paid")
+    public EnrollmentResponseDto markPaid(@PathVariable Long enrollmentId,
+                                          @AuthenticationPrincipal AuthenticatedUser principal) {
+        return enrollmentService.confirmPayment(principal.userId(), enrollmentId);
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentListDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentListDto.java
@@ -1,0 +1,18 @@
+package ch.ruppen.danceschool.enrollment;
+
+import java.time.Instant;
+
+public record EnrollmentListDto(
+        Long id,
+        String studentName,
+        String studentEmail,
+        String studentPhoneNumber,
+        DanceRole danceRole,
+        EnrollmentStatus status,
+        Instant enrolledAt,
+        Instant approvedAt,
+        Instant paidAt,
+        Integer waitlistPosition,
+        WaitlistReason waitlistReason
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
@@ -1,0 +1,17 @@
+package ch.ruppen.danceschool.enrollment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+    List<Enrollment> findAllByCourseId(Long courseId);
+
+    Optional<Enrollment> findByIdAndCourseSchoolId(Long id, Long schoolId);
+
+    long countByCourseIdAndStatusIn(Long courseId, List<EnrollmentStatus> statuses);
+
+    boolean existsByStudentIdAndCourseIdAndStatusNot(Long studentId, Long courseId, EnrollmentStatus status);
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentResponseDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentResponseDto.java
@@ -1,0 +1,7 @@
+package ch.ruppen.danceschool.enrollment;
+
+public record EnrollmentResponseDto(
+        Long enrollmentId,
+        EnrollmentStatus status
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -1,0 +1,164 @@
+package ch.ruppen.danceschool.enrollment;
+
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseService;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.school.SchoolService;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
+import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
+import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
+import ch.ruppen.danceschool.shared.logging.BusinessOperation;
+import ch.ruppen.danceschool.student.Student;
+import ch.ruppen.danceschool.student.StudentDanceLevel;
+import ch.ruppen.danceschool.student.StudentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EnrollmentService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final SchoolService schoolService;
+    private final CourseService courseService;
+    private final StudentService studentService;
+    private final SchoolMemberService schoolMemberService;
+    private final Clock clock;
+
+    @Transactional
+    @BusinessOperation(event = "StudentEnrolled")
+    public EnrollmentResponseDto enrollStudent(Long userId, Long courseId, EnrollStudentDto dto) {
+        School school = schoolService.findSchoolByMember(userId);
+        Course course = courseService.findCourseByIdAndSchool(courseId, school);
+        Student student = studentService.findStudentByIdAndSchool(dto.studentId(), school);
+
+        validateDanceRole(course, dto.danceRole());
+        validateNoDuplicate(student.getId(), course.getId());
+        validateCapacity(course);
+        validateLevelForDirectBooking(course, student);
+
+        SchoolMember enrolledBy = schoolMemberService.findByUserIdAndSchoolId(userId, school.getId())
+                .orElse(null);
+
+        Enrollment enrollment = new Enrollment();
+        enrollment.setStudent(student);
+        enrollment.setCourse(course);
+        enrollment.setDanceRole(dto.danceRole());
+        enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
+        enrollment.setEnrolledAt(Instant.now(clock));
+        enrollment.setEnrolledBy(enrolledBy);
+
+        enrollmentRepository.save(enrollment);
+        return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
+    }
+
+    @Transactional
+    @BusinessOperation(event = "EnrollmentPaymentConfirmed")
+    public EnrollmentResponseDto confirmPayment(Long userId, Long enrollmentId) {
+        School school = schoolService.findSchoolByMember(userId);
+        Enrollment enrollment = enrollmentRepository.findByIdAndCourseSchoolId(enrollmentId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Enrollment", enrollmentId));
+
+        if (enrollment.getStatus() != EnrollmentStatus.PENDING_PAYMENT) {
+            throw new DomainRuleViolationException("Enrollment is not pending payment");
+        }
+
+        enrollment.setStatus(EnrollmentStatus.CONFIRMED);
+        enrollment.setPaidAt(Instant.now(clock));
+        return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public List<EnrollmentListDto> getEnrollments(Long userId, Long courseId) {
+        School school = schoolService.findSchoolByMember(userId);
+        courseService.findCourseByIdAndSchool(courseId, school);
+
+        return enrollmentRepository.findAllByCourseId(courseId).stream()
+                .map(this::toListDto)
+                .toList();
+    }
+
+    @Transactional
+    public void seedEnrollment(Course course, Student student, DanceRole danceRole,
+                               EnrollmentStatus status, Instant enrolledAt, Instant paidAt) {
+        Enrollment enrollment = new Enrollment();
+        enrollment.setCourse(course);
+        enrollment.setStudent(student);
+        enrollment.setDanceRole(danceRole);
+        enrollment.setStatus(status);
+        enrollment.setEnrolledAt(enrolledAt);
+        enrollment.setPaidAt(paidAt);
+        enrollmentRepository.save(enrollment);
+    }
+
+    private void validateDanceRole(Course course, DanceRole danceRole) {
+        if (course.getCourseType() == CourseType.PARTNER && danceRole == null) {
+            throw new DomainRuleViolationException("Dance role is required for partner courses");
+        }
+        if (course.getCourseType() == CourseType.SOLO && danceRole != null) {
+            throw new DomainRuleViolationException("Dance role must not be set for solo courses");
+        }
+    }
+
+    private void validateNoDuplicate(Long studentId, Long courseId) {
+        if (enrollmentRepository.existsByStudentIdAndCourseIdAndStatusNot(
+                studentId, courseId, EnrollmentStatus.REJECTED)) {
+            throw new DomainRuleViolationException("Student is already enrolled in this course");
+        }
+    }
+
+    private void validateCapacity(Course course) {
+        long activeCount = enrollmentRepository.countByCourseIdAndStatusIn(
+                course.getId(),
+                List.of(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.CONFIRMED));
+        if (activeCount >= course.getMaxParticipants()) {
+            throw new DomainRuleViolationException("Course is at capacity");
+        }
+    }
+
+    private void validateLevelForDirectBooking(Course course, Student student) {
+        // BEGINNER and STARTER courses always allow direct booking
+        if (course.getLevel().ordinal() <= CourseLevel.BEGINNER.ordinal()) {
+            return;
+        }
+
+        // For higher-level courses, check if the student has sufficient level for the dance style
+        CourseLevel studentLevel = student.getDanceLevels().stream()
+                .filter(dl -> dl.getDanceStyle() == course.getDanceStyle())
+                .map(StudentDanceLevel::getLevel)
+                .findFirst()
+                .orElse(null);
+
+        if (studentLevel == null || studentLevel.ordinal() < course.getLevel().ordinal()) {
+            throw new DomainRuleViolationException(
+                    "Student does not meet the level requirement for this course");
+        }
+    }
+
+    private EnrollmentListDto toListDto(Enrollment enrollment) {
+        Student student = enrollment.getStudent();
+        return new EnrollmentListDto(
+                enrollment.getId(),
+                student.getName(),
+                student.getEmail(),
+                student.getPhoneNumber(),
+                enrollment.getDanceRole(),
+                enrollment.getStatus(),
+                enrollment.getEnrolledAt(),
+                enrollment.getApprovedAt(),
+                enrollment.getPaidAt(),
+                enrollment.getWaitlistPosition(),
+                enrollment.getWaitlistReason()
+        );
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentStatus.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentStatus.java
@@ -1,0 +1,9 @@
+package ch.ruppen.danceschool.enrollment;
+
+public enum EnrollmentStatus {
+    PENDING_APPROVAL,
+    PENDING_PAYMENT,
+    CONFIRMED,
+    WAITLISTED,
+    REJECTED
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/WaitlistReason.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/WaitlistReason.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.enrollment;
+
+public enum WaitlistReason {
+    CAPACITY,
+    ROLE_IMBALANCE
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberRepository.java
@@ -3,8 +3,11 @@ package ch.ruppen.danceschool.schoolmember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 interface SchoolMemberRepository extends JpaRepository<SchoolMember, Long> {
 
     List<SchoolMember> findByUserId(Long userId);
+
+    Optional<SchoolMember> findByUserIdAndSchoolId(Long userId, Long schoolId);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +20,10 @@ public class SchoolMemberService {
                         member.getSchool().getName(),
                         member.getRole()))
                 .toList();
+    }
+
+    public Optional<SchoolMember> findByUserIdAndSchoolId(Long userId, Long schoolId) {
+        return schoolMemberRepository.findByUserIdAndSchoolId(userId, schoolId);
     }
 
     @BusinessOperation(event = "MembershipCreated")

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
@@ -72,6 +72,17 @@ public class StudentService {
     }
 
     @Transactional(readOnly = true)
+    public Student findStudentByIdAndSchool(Long studentId, School school) {
+        return studentRepository.findByIdAndSchoolId(studentId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Student", studentId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Student> findAllBySchool(School school) {
+        return studentRepository.findAllBySchoolId(school.getId());
+    }
+
+    @Transactional(readOnly = true)
     public boolean hasStudentsForSchool(Long userId) {
         School school = schoolService.findSchoolByMember(userId);
         return studentRepository.existsBySchoolId(school.getId());

--- a/backend/src/main/resources/db/changelog/017-create-enrollment.yaml
+++ b/backend/src/main/resources/db/changelog/017-create-enrollment.yaml
@@ -1,0 +1,81 @@
+databaseChangeLog:
+  - changeSet:
+      id: 017-create-enrollment
+      author: claude
+      changes:
+        - createTable:
+            tableName: enrollment
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: student_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: course_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: dance_role
+                  type: VARCHAR(50)
+              - column:
+                  name: status
+                  type: VARCHAR(50)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: enrolled_at
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: false
+              - column:
+                  name: enrolled_by_member_id
+                  type: BIGINT
+              - column:
+                  name: approved_at
+                  type: TIMESTAMP
+              - column:
+                  name: paid_at
+                  type: TIMESTAMP
+              - column:
+                  name: waitlist_position
+                  type: INT
+              - column:
+                  name: waitlist_reason
+                  type: VARCHAR(50)
+
+        - addForeignKeyConstraint:
+            baseTableName: enrollment
+            baseColumnNames: student_id
+            referencedTableName: student
+            referencedColumnNames: id
+            constraintName: fk_enrollment_student
+
+        - addForeignKeyConstraint:
+            baseTableName: enrollment
+            baseColumnNames: course_id
+            referencedTableName: course
+            referencedColumnNames: id
+            constraintName: fk_enrollment_course
+
+        - addForeignKeyConstraint:
+            baseTableName: enrollment
+            baseColumnNames: enrolled_by_member_id
+            referencedTableName: school_member
+            referencedColumnNames: id
+            constraintName: fk_enrollment_enrolled_by
+
+        - createIndex:
+            tableName: enrollment
+            indexName: idx_enrollment_course_id
+            columns:
+              - column:
+                  name: course_id

--- a/backend/src/main/resources/db/changelog/018-add-requires-approval-to-course.yaml
+++ b/backend/src/main/resources/db/changelog/018-add-requires-approval-to-course.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 018-add-requires-approval-to-course
+      author: claude
+      changes:
+        - addColumn:
+            tableName: course
+            columns:
+              - column:
+                  name: requires_approval
+                  type: BOOLEAN
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -31,3 +31,7 @@ databaseChangeLog:
       file: db/changelog/015-create-student.yaml
   - include:
       file: db/changelog/016-create-student-dance-level.yaml
+  - include:
+      file: db/changelog/017-create-enrollment.yaml
+  - include:
+      file: db/changelog/018-add-requires-approval-to-course.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -1,0 +1,417 @@
+package ch.ruppen.danceschool.enrollment;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.course.PriceModel;
+import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.student.Student;
+import ch.ruppen.danceschool.student.StudentDanceLevel;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class EnrollmentIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser owner;
+    private School school;
+    private Course partnerCourse;
+    private Course soloCourse;
+    private Student student;
+
+    @BeforeEach
+    void setUp() {
+        owner = createUser("owner@example.com", "Owner", "firebase-owner");
+        school = createSchoolWithOwner("Test School", owner);
+
+        partnerCourse = createCourse(school, "Bachata Intermediate", DanceStyle.BACHATA,
+                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 15, true, 3);
+
+        soloCourse = createCourse(school, "Salsa Solo Beginner", DanceStyle.SALSA,
+                CourseLevel.BEGINNER, CourseType.SOLO, 12, false, null);
+
+        student = createStudent(school, "Anna Mueller", "anna@example.com", "+41 79 100 0001");
+        addDanceLevel(student, DanceStyle.BACHATA, CourseLevel.INTERMEDIATE);
+        addDanceLevel(student, DanceStyle.SALSA, CourseLevel.BEGINNER);
+
+        entityManager.flush();
+    }
+
+    // --- Enroll student ---
+
+    @Test
+    void enrollStudent_partnerCourse_returnsCreatedWithPendingPayment() throws Exception {
+        mockMvc.perform(post("/api/courses/{id}/enrollments", partnerCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.enrollmentId").isNumber())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+    }
+
+    @Test
+    void enrollStudent_soloCourse_noDanceRole_returnsCreated() throws Exception {
+        mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+    }
+
+    @Test
+    void enrollStudent_partnerCourse_missingDanceRole_returns409() throws Exception {
+        mockMvc.perform(post("/api/courses/{id}/enrollments", partnerCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void enrollStudent_soloCourse_withDanceRole_returns409() throws Exception {
+        mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void enrollStudent_duplicate_returns409() throws Exception {
+        // First enrollment succeeds
+        mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated());
+
+        // Second enrollment for same student/course fails
+        mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void enrollStudent_atCapacity_returns409() throws Exception {
+        Course tinyCourse = createCourse(school, "Tiny Course", DanceStyle.SALSA,
+                CourseLevel.BEGINNER, CourseType.SOLO, 1, false, null);
+        entityManager.flush();
+
+        Student student2 = createStudent(school, "Marco Rossi", "marco@example.com", null);
+        entityManager.flush();
+
+        // Fill the one spot
+        mockMvc.perform(post("/api/courses/{id}/enrollments", tinyCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated());
+
+        // Second student cannot enroll
+        mockMvc.perform(post("/api/courses/{id}/enrollments", tinyCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student2.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void enrollStudent_insufficientLevel_returns409() throws Exception {
+        Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
+                CourseLevel.ADVANCED, CourseType.PARTNER, 10, true, 2);
+        entityManager.flush();
+
+        // Student has BEGINNER salsa level, course requires ADVANCED
+        mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void enrollStudent_beginnerCourse_alwaysAllowed() throws Exception {
+        // Student with no Kizomba level can still enroll in BEGINNER Kizomba
+        Course beginnerKizomba = createCourse(school, "Kizomba Beginner", DanceStyle.KIZOMBA,
+                CourseLevel.BEGINNER, CourseType.PARTNER, 10, false, null);
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", beginnerKizomba.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "FOLLOW"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+    }
+
+    // --- List enrollments ---
+
+    @Test
+    void listEnrollments_returnsAllEnrollmentsForCourse() throws Exception {
+        Student student2 = createStudent(school, "Marco Rossi", "marco@example.com", null);
+        addDanceLevel(student2, DanceStyle.SALSA, CourseLevel.BEGINNER);
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student2.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].studentName").isString())
+                .andExpect(jsonPath("$[0].status").value("PENDING_PAYMENT"));
+    }
+
+    // --- Mark paid ---
+
+    @Test
+    void markPaid_transitionsToConfirmed() throws Exception {
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long enrollmentId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
+
+        mockMvc.perform(put("/api/enrollments/{id}/mark-paid", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CONFIRMED"));
+    }
+
+    @Test
+    void markPaid_alreadyConfirmed_returns409() throws Exception {
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long enrollmentId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
+
+        // First mark-paid succeeds
+        mockMvc.perform(put("/api/enrollments/{id}/mark-paid", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk());
+
+        // Second mark-paid fails (already CONFIRMED)
+        mockMvc.perform(put("/api/enrollments/{id}/mark-paid", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    // --- Tenant isolation ---
+
+    @Test
+    void enrollStudent_otherOwnersCourse_returns404() throws Exception {
+        AppUser owner2 = createUser("owner2@example.com", "Owner 2", "firebase-owner-2");
+        School school2 = createSchoolWithOwner("Other School", owner2);
+        Student student2 = createStudent(school2, "Elena Fischer", "elena@example.com", null);
+        entityManager.flush();
+
+        // Owner2 tries to enroll their student in owner1's course
+        mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student2.getId()))
+                        .with(authentication(authToken(owner2))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void listEnrollments_otherOwnersCourse_returns404() throws Exception {
+        AppUser owner2 = createUser("owner2@example.com", "Owner 2", "firebase-owner-2");
+        createSchoolWithOwner("Other School", owner2);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .with(authentication(authToken(owner2))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void markPaid_otherOwnersEnrollment_returns404() throws Exception {
+        // Enroll as owner1
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long enrollmentId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
+
+        // Owner2 tries to mark-paid
+        AppUser owner2 = createUser("owner2@example.com", "Owner 2", "firebase-owner-2");
+        createSchoolWithOwner("Other School", owner2);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/enrollments/{id}/mark-paid", enrollmentId)
+                        .with(authentication(authToken(owner2))))
+                .andExpect(status().isNotFound());
+    }
+
+    // --- Helpers ---
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser ownerUser) {
+        School s = new School();
+        s.setName(name);
+        entityManager.persist(s);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(ownerUser);
+        member.setSchool(s);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return s;
+    }
+
+    private Course createCourse(School s, String title, DanceStyle danceStyle, CourseLevel level,
+                                CourseType courseType, int maxParticipants,
+                                boolean roleBalancing, Integer roleBalanceThreshold) {
+        Course c = new Course();
+        c.setSchool(s);
+        c.setTitle(title);
+        c.setDanceStyle(danceStyle);
+        c.setLevel(level);
+        c.setCourseType(courseType);
+        c.setMaxParticipants(maxParticipants);
+        c.setRoleBalancingEnabled(roleBalancing);
+        c.setRoleBalanceThreshold(roleBalanceThreshold);
+        c.setStartDate(LocalDate.now().plusWeeks(2));
+        c.setEndDate(LocalDate.now().plusWeeks(10));
+        c.setLocation("Studio A");
+        c.setTeachers("Test Teacher");
+        c.setStartTime(LocalTime.of(19, 0));
+        c.setEndTime(LocalTime.of(20, 0));
+        c.setDayOfWeek(DayOfWeek.MONDAY);
+        c.setRecurrenceType(RecurrenceType.WEEKLY);
+        c.setNumberOfSessions(8);
+        c.setPriceModel(PriceModel.FIXED_COURSE);
+        c.setPrice(new BigDecimal("200.00"));
+        c.setPublishedAt(LocalDate.now().minusDays(1));
+        entityManager.persist(c);
+        return c;
+    }
+
+    private Student createStudent(School s, String name, String email, String phoneNumber) {
+        Student st = new Student();
+        st.setSchool(s);
+        st.setName(name);
+        st.setEmail(email);
+        st.setPhoneNumber(phoneNumber);
+        entityManager.persist(st);
+        return st;
+    }
+
+    private void addDanceLevel(Student st, DanceStyle style, CourseLevel level) {
+        StudentDanceLevel dl = new StudentDanceLevel();
+        dl.setStudent(st);
+        dl.setDanceStyle(style);
+        dl.setLevel(level);
+        st.getDanceLevels().add(dl);
+        entityManager.persist(dl);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -43,6 +43,7 @@ export const routes: Routes = [
       },
       { path: 'courses', loadComponent: () => import('./courses/courses').then(m => m.CoursesComponent) },
       { path: 'payments', loadComponent: () => import('./payments/payments').then(m => m.PaymentsComponent) },
+      { path: 'dev-tools', loadComponent: () => import('./dev-tools/dev-tools').then(m => m.DevToolsComponent) },
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
     ],
   },

--- a/frontend/src/app/courses/enrollment.service.ts
+++ b/frontend/src/app/courses/enrollment.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export type EnrollmentStatus = 'PENDING_APPROVAL' | 'PENDING_PAYMENT' | 'CONFIRMED' | 'WAITLISTED' | 'REJECTED';
+export type DanceRole = 'LEAD' | 'FOLLOW';
+export type WaitlistReason = 'CAPACITY' | 'ROLE_IMBALANCE';
+
+export interface EnrollmentListItem {
+  id: number;
+  studentName: string;
+  studentEmail: string;
+  studentPhoneNumber: string | null;
+  danceRole: DanceRole | null;
+  status: EnrollmentStatus;
+  enrolledAt: string;
+  approvedAt: string | null;
+  paidAt: string | null;
+  waitlistPosition: number | null;
+  waitlistReason: WaitlistReason | null;
+}
+
+export interface EnrollmentResponse {
+  enrollmentId: number;
+  status: EnrollmentStatus;
+}
+
+export interface EnrollStudentRequest {
+  studentId: number;
+  danceRole?: DanceRole;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EnrollmentService {
+  private http = inject(HttpClient);
+
+  enrollStudent(courseId: number, dto: EnrollStudentRequest): Observable<EnrollmentResponse> {
+    return this.http.post<EnrollmentResponse>(`${environment.apiUrl}/api/courses/${courseId}/enrollments`, dto);
+  }
+
+  getEnrollments(courseId: number): Observable<EnrollmentListItem[]> {
+    return this.http.get<EnrollmentListItem[]>(`${environment.apiUrl}/api/courses/${courseId}/enrollments`);
+  }
+
+  markPaid(enrollmentId: number): Observable<EnrollmentResponse> {
+    return this.http.put<EnrollmentResponse>(`${environment.apiUrl}/api/enrollments/${enrollmentId}/mark-paid`, null);
+  }
+}

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -19,6 +19,100 @@
       </div>
     </div>
 
+    <!-- Enrollment tabs (non-DRAFT courses only) -->
+    @if (c.status !== 'DRAFT') {
+      <div class="enrollment-section">
+        <nav mat-tab-nav-bar [tabPanel]="enrollmentTabPanel" mat-align-tabs="start"
+             class="ds-page-toolbar__tabs" mat-stretch-tabs="true">
+          @for (tab of tabs; track tab.key; let i = $index) {
+            <a mat-tab-link (click)="selectTab(i)" [active]="activeTabIndex() === i">
+              <span class="ds-tab-label">{{ tab.label }}</span>
+              <span class="ds-tab-count">{{ tabCounts()[i] }}</span>
+            </a>
+          }
+        </nav>
+
+        <mat-tab-nav-panel #enrollmentTabPanel>
+          @if (activeTabData().length > 0) {
+            <div class="ds-table-card enrollment-table">
+              <table mat-table [dataSource]="activeTabData()">
+                <!-- Name Column -->
+                <ng-container matColumnDef="name">
+                  <th mat-header-cell *matHeaderCellDef>Name</th>
+                  <td mat-cell *matCellDef="let row" class="cell-name">{{ row.studentName }}</td>
+                </ng-container>
+
+                <!-- Phone Column -->
+                <ng-container matColumnDef="phone">
+                  <th mat-header-cell *matHeaderCellDef>Phone Number</th>
+                  <td mat-cell *matCellDef="let row">{{ row.studentPhoneNumber || '—' }}</td>
+                </ng-container>
+
+                <!-- Role Column -->
+                <ng-container matColumnDef="role">
+                  <th mat-header-cell *matHeaderCellDef>Role</th>
+                  <td mat-cell *matCellDef="let row">
+                    @if (row.danceRole) {
+                      <span class="ds-chip ds-chip-default">{{ formatRole(row.danceRole) }}</span>
+                    } @else {
+                      —
+                    }
+                  </td>
+                </ng-container>
+
+                <!-- Enrolled on Column -->
+                <ng-container matColumnDef="enrolledAt">
+                  <th mat-header-cell *matHeaderCellDef>Enrolled on</th>
+                  <td mat-cell *matCellDef="let row">{{ formatEnrollmentDate(row.enrolledAt) }}</td>
+                </ng-container>
+
+                <!-- Last Column (varies by tab) -->
+                <ng-container matColumnDef="lastColumn">
+                  <th mat-header-cell *matHeaderCellDef>
+                    @switch (activeTabIndex()) {
+                      @case (0) { Paid }
+                      @case (3) { Approved on }
+                      @default { }
+                    }
+                  </th>
+                  <td mat-cell *matCellDef="let row">
+                    @switch (activeTabIndex()) {
+                      @case (0) { {{ formatEnrollmentDate(row.paidAt) }} }
+                      @case (3) {
+                        @if (row.approvedAt) {
+                          {{ formatEnrollmentDate(row.approvedAt) }}
+                        } @else {
+                          <button mat-stroked-button class="mark-paid-button" (click)="onMarkPaid(row.id)">
+                            Mark Paid
+                          </button>
+                        }
+                      }
+                    }
+                  </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="enrollmentColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: enrollmentColumns;"></tr>
+              </table>
+
+              <div class="ds-table-footer">
+                Showing {{ activeTabData().length }} of {{ activeTabData().length }}
+              </div>
+            </div>
+          } @else {
+            <div class="enrollment-empty-state">
+              @switch (activeTabIndex()) {
+                @case (0) { No enrolled students yet }
+                @case (1) { No students on the waitlist }
+                @case (2) { No students pending approval }
+                @case (3) { No students with open payments }
+              }
+            </div>
+          }
+        </mat-tab-nav-panel>
+      </div>
+    }
+
     <!-- Content Card -->
     <div class="content-card">
       <h2 class="content-card-title">Course Summary</h2>

--- a/frontend/src/app/courses/overview/course-overview.scss
+++ b/frontend/src/app/courses/overview/course-overview.scss
@@ -64,3 +64,47 @@
   color: var(--mat-sys-on-surface-variant);
   font: var(--mat-sys-body-large);
 }
+
+// ── Enrollment section ──
+
+.enrollment-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-4);
+}
+
+.enrollment-table {
+  // Column widths matching Figma: Name 260, Phone 200, Role 120, Enrolled on 180, rest flexible
+  .mat-column-name {
+    width: 260px;
+    font-weight: 600;
+  }
+
+  .mat-column-phone {
+    width: 200px;
+  }
+
+  .mat-column-role {
+    width: 120px;
+  }
+
+  .mat-column-enrolledAt {
+    width: 180px;
+  }
+}
+
+.mark-paid-button {
+  --mdc-outlined-button-label-text-size: var(--mat-sys-label-medium-size);
+}
+
+.enrollment-empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ds-spacing-12) var(--ds-spacing-6);
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-on-surface-variant);
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+}

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -64,19 +64,28 @@ describe('CourseOverviewComponent', () => {
     httpTesting.verify();
   });
 
+  /** Flush the course detail request and the enrollment request that follows for non-DRAFT courses. */
+  function flushCourse(overrides: Partial<CourseDetail> = {}): void {
+    const course = makeCourseDetail(overrides);
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1') && !req.url.includes('enrollments')).flush(course);
+    if (course.status !== 'DRAFT') {
+      httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
+    }
+  }
+
   it('should display loading state initially', () => {
     fixture.detectChanges();
     expect(el.querySelector('.loading')).toBeTruthy();
 
-    // Flush the pending request
-    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    // Flush the pending requests
+    flushCourse();
     fixture.detectChanges();
     expect(el.querySelector('.loading')).toBeFalsy();
   });
 
   it('should display course title and status chip after loading', () => {
     fixture.detectChanges();
-    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail({ title: 'Salsa Nights', status: 'OPEN' }));
+    flushCourse({ title: 'Salsa Nights', status: 'OPEN' });
     fixture.detectChanges();
 
     expect(el.querySelector('.overview-title')?.textContent?.trim()).toBe('Salsa Nights');
@@ -85,7 +94,7 @@ describe('CourseOverviewComponent', () => {
 
   it('should display the back link', () => {
     fixture.detectChanges();
-    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    flushCourse();
     fixture.detectChanges();
 
     const backLink = el.querySelector('.back-link') as HTMLAnchorElement;
@@ -95,7 +104,7 @@ describe('CourseOverviewComponent', () => {
 
   it('should render the course summary component', () => {
     fixture.detectChanges();
-    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    flushCourse();
     fixture.detectChanges();
 
     expect(el.querySelector('app-course-summary')).toBeTruthy();
@@ -103,9 +112,18 @@ describe('CourseOverviewComponent', () => {
 
   it('should display "Course Summary" heading inside the content card', () => {
     fixture.detectChanges();
-    httpTesting.expectOne(req => req.url.includes('/api/courses/1')).flush(makeCourseDetail());
+    flushCourse();
     fixture.detectChanges();
 
     expect(el.querySelector('.content-card-title')?.textContent?.trim()).toBe('Course Summary');
+  });
+
+  it('should not load enrollments for DRAFT courses', () => {
+    fixture.detectChanges();
+    flushCourse({ status: 'DRAFT' });
+    fixture.detectChanges();
+
+    // No enrollment request should have been made — httpTesting.verify() in afterEach confirms this
+    expect(el.querySelector('.enrollment-section')).toBeFalsy();
   });
 });

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -1,18 +1,37 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, signal, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { NgClass, TitleCasePipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { MatTabsModule } from '@angular/material/tabs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { CourseDetail, CourseService } from '../course.service';
 import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summary';
+import { EnrollmentListItem, EnrollmentService } from '../enrollment.service';
 import { formatDate, formatDayFull, formatTime, statusChipClass } from '../shared/format-utils';
 import { extractErrorMessage } from '../../shared/error-utils';
 
+interface EnrollmentTab {
+  label: string;
+  key: string;
+}
+
+const ENROLLMENT_TABS: EnrollmentTab[] = [
+  { label: 'Enrolled', key: 'CONFIRMED' },
+  { label: 'Waitlist', key: 'WAITLISTED' },
+  { label: 'Approve', key: 'PENDING_APPROVAL' },
+  { label: 'Open Payment', key: 'PENDING_PAYMENT' },
+];
+
 @Component({
   selector: 'app-course-overview',
-  imports: [RouterLink, NgClass, TitleCasePipe, MatButtonModule, CourseSummaryComponent],
+  imports: [
+    RouterLink, NgClass, TitleCasePipe,
+    MatButtonModule, MatTableModule, MatTabsModule,
+    CourseSummaryComponent,
+  ],
   templateUrl: './course-overview.html',
   styleUrl: './course-overview.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,10 +42,42 @@ export class CourseOverviewComponent implements OnInit {
   private snackBar = inject(MatSnackBar);
   private destroyRef = inject(DestroyRef);
   private courseService = inject(CourseService);
+  private enrollmentService = inject(EnrollmentService);
 
   protected course = signal<CourseDetail | null>(null);
   protected loading = signal(true);
   protected publishing = signal(false);
+  protected enrollments = signal<EnrollmentListItem[]>([]);
+  protected activeTabIndex = signal(0);
+
+  protected readonly tabs = ENROLLMENT_TABS;
+  protected readonly enrollmentColumns = ['name', 'phone', 'role', 'enrolledAt', 'lastColumn'];
+
+  protected enrolledList = computed(() =>
+    this.enrollments().filter(e => e.status === 'CONFIRMED'));
+  protected waitlistList = computed(() =>
+    this.enrollments().filter(e => e.status === 'WAITLISTED'));
+  protected approveList = computed(() =>
+    this.enrollments().filter(e => e.status === 'PENDING_APPROVAL'));
+  protected openPaymentList = computed(() =>
+    this.enrollments().filter(e => e.status === 'PENDING_PAYMENT'));
+
+  protected tabCounts = computed(() => [
+    this.enrolledList().length,
+    this.waitlistList().length,
+    this.approveList().length,
+    this.openPaymentList().length,
+  ]);
+
+  protected activeTabData = computed(() => {
+    switch (this.activeTabIndex()) {
+      case 0: return this.enrolledList();
+      case 1: return this.waitlistList();
+      case 2: return this.approveList();
+      case 3: return this.openPaymentList();
+      default: return [];
+    }
+  });
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -68,6 +119,34 @@ export class CourseOverviewComponent implements OnInit {
 
   protected statusChipClass = statusChipClass;
 
+  protected selectTab(index: number): void {
+    this.activeTabIndex.set(index);
+  }
+
+  protected formatEnrollmentDate(isoString: string | null): string {
+    if (!isoString) return '—';
+    const date = new Date(isoString);
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  protected formatRole(role: string | null): string {
+    if (!role) return '—';
+    return role === 'LEAD' ? 'Leader' : 'Follower';
+  }
+
+  protected onMarkPaid(enrollmentId: number): void {
+    this.enrollmentService.markPaid(enrollmentId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.snackBar.open('Payment confirmed', 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        const courseId = this.course()?.id;
+        if (courseId) this.loadEnrollments(courseId);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.snackBar.open(extractErrorMessage(err, 'Failed to confirm payment'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+      },
+    });
+  }
+
   protected onPublish(): void {
     const c = this.course();
     if (!c) return;
@@ -98,11 +177,21 @@ export class CourseOverviewComponent implements OnInit {
       next: (data) => {
         this.course.set(data);
         this.loading.set(false);
+        if (data.status !== 'DRAFT') {
+          this.loadEnrollments(data.id);
+        }
       },
       error: (err: HttpErrorResponse) => {
         this.snackBar.open(extractErrorMessage(err, 'Failed to load course'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
         this.router.navigate(['/app/courses']);
       },
+    });
+  }
+
+  private loadEnrollments(courseId: number): void {
+    this.enrollmentService.getEnrollments(courseId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (data) => this.enrollments.set(data),
+      error: () => this.enrollments.set([]),
     });
   }
 }

--- a/frontend/src/app/dev-tools/dev-tools.html
+++ b/frontend/src/app/dev-tools/dev-tools.html
@@ -1,0 +1,110 @@
+<div class="dev-tools-header">
+  <h1 class="dev-tools-title">Dev Tools</h1>
+  <p class="dev-tools-subtitle">Simulate enrollment flows using production endpoints</p>
+</div>
+
+<!-- Course selector -->
+<div class="dev-tools-card">
+  <h2 class="card-title">Course</h2>
+  <mat-form-field class="course-select">
+    <mat-label>Select a course</mat-label>
+    <mat-select (selectionChange)="onCourseSelected($event.value)">
+      @for (course of courses(); track course.id) {
+        <mat-option [value]="course.id">
+          {{ course.title }} ({{ course.status | lowercase }}) — {{ course.enrolledStudents }}/{{ course.maxParticipants }}
+        </mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+</div>
+
+<!-- Actions -->
+@if (selectedCourseId()) {
+  <div class="dev-tools-card">
+    <h2 class="card-title">Actions</h2>
+
+    <div class="actions-row">
+      <button mat-flat-button (click)="onFillCourse()" [disabled]="filling()">
+        @if (filling()) {
+          <mat-spinner diameter="18"></mat-spinner>
+        }
+        Fill Course
+      </button>
+
+      <button mat-stroked-button (click)="onAddStudent()" [disabled]="adding()">
+        @if (adding()) {
+          <mat-spinner diameter="18"></mat-spinner>
+        }
+        Add Student
+      </button>
+
+      <mat-form-field class="role-select">
+        <mat-label>Role</mat-label>
+        <mat-select [value]="danceRole()" (selectionChange)="danceRole.set($event.value)">
+          <mat-option value="LEAD">Leader</mat-option>
+          <mat-option value="FOLLOW">Follower</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <button mat-stroked-button (click)="onSimulatePayment()" [disabled]="paying()">
+        @if (paying()) {
+          <mat-spinner diameter="18"></mat-spinner>
+        }
+        Simulate Payment
+      </button>
+    </div>
+  </div>
+
+  <!-- Enrollment list -->
+  <div class="dev-tools-card">
+    <h2 class="card-title">Enrollments ({{ enrollments().length }})</h2>
+
+    @if (enrollments().length > 0) {
+      <div class="ds-table-card">
+        <table mat-table [dataSource]="enrollments()">
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let row" class="cell-name">{{ row.studentName }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="phone">
+            <th mat-header-cell *matHeaderCellDef>Phone</th>
+            <td mat-cell *matCellDef="let row">{{ row.studentPhoneNumber || '—' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="role">
+            <th mat-header-cell *matHeaderCellDef>Role</th>
+            <td mat-cell *matCellDef="let row">
+              @if (row.danceRole) {
+                <span class="ds-chip ds-chip-default">{{ formatRole(row.danceRole) }}</span>
+              } @else {
+                —
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="status">
+            <th mat-header-cell *matHeaderCellDef>Status</th>
+            <td mat-cell *matCellDef="let row">
+              <span class="ds-chip" [class.ds-chip-success]="row.status === 'CONFIRMED'"
+                    [class.ds-chip-info]="row.status === 'PENDING_PAYMENT'"
+                    [class.ds-chip-default]="row.status !== 'CONFIRMED' && row.status !== 'PENDING_PAYMENT'">
+                {{ formatStatus(row.status) }}
+              </span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="enrolledAt">
+            <th mat-header-cell *matHeaderCellDef>Enrolled on</th>
+            <td mat-cell *matCellDef="let row">{{ formatDate(row.enrolledAt) }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="enrollmentColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: enrollmentColumns;"></tr>
+        </table>
+      </div>
+    } @else {
+      <p class="empty-text">No enrollments yet. Use the buttons above to simulate enrollment flows.</p>
+    }
+  </div>
+}

--- a/frontend/src/app/dev-tools/dev-tools.scss
+++ b/frontend/src/app/dev-tools/dev-tools.scss
@@ -1,0 +1,67 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-6);
+}
+
+.dev-tools-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-1);
+}
+
+.dev-tools-title {
+  font: var(--mat-sys-headline-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.dev-tools-subtitle {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}
+
+.dev-tools-card {
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+  padding: var(--ds-card-padding);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-4);
+}
+
+.card-title {
+  font: var(--mat-sys-title-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.course-select {
+  width: 100%;
+}
+
+.actions-row {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-3);
+  flex-wrap: wrap;
+}
+
+.role-select {
+  width: 140px;
+
+  --mat-form-field-container-height: 36px;
+  --mat-form-field-container-vertical-padding: 6px;
+}
+
+.cell-name {
+  font-weight: 600;
+}
+
+.empty-text {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}

--- a/frontend/src/app/dev-tools/dev-tools.ts
+++ b/frontend/src/app/dev-tools/dev-tools.ts
@@ -1,0 +1,228 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { HttpClient } from '@angular/common/http';
+import { LowerCasePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { concat, EMPTY, Observable, of, switchMap, tap, toArray } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { CourseListItem, CourseService } from '../courses/course.service';
+import { EnrollmentListItem, EnrollmentService, EnrollStudentRequest } from '../courses/enrollment.service';
+
+const FIRST_NAMES = ['Anna', 'Marco', 'Laura', 'David', 'Sofia', 'Jan', 'Yuki', 'Elena', 'Thomas', 'Mia',
+  'Lukas', 'Sarah', 'Alex', 'Nina', 'Felix', 'Julia', 'Max', 'Lena', 'Tobias', 'Clara'];
+const LAST_NAMES = ['Mueller', 'Rossi', 'Weber', 'Kim', 'Martinez', 'de Vries', 'Tanaka', 'Fischer', 'Bauer', 'Schmidt',
+  'Meier', 'Huber', 'Keller', 'Wagner', 'Braun', 'Steiner', 'Frey', 'Berger', 'Hess', 'Maurer'];
+
+@Component({
+  selector: 'app-dev-tools',
+  imports: [
+    LowerCasePipe, FormsModule, MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule,
+    MatSelectModule, MatTableModule, MatProgressSpinnerModule,
+  ],
+  templateUrl: './dev-tools.html',
+  styleUrl: './dev-tools.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DevToolsComponent implements OnInit {
+  private http = inject(HttpClient);
+  private snackBar = inject(MatSnackBar);
+  private destroyRef = inject(DestroyRef);
+  private courseService = inject(CourseService);
+  private enrollmentService = inject(EnrollmentService);
+
+  protected courses = signal<CourseListItem[]>([]);
+  protected selectedCourseId = signal<number | null>(null);
+  protected selectedCourse = signal<CourseListItem | null>(null);
+  protected enrollments = signal<EnrollmentListItem[]>([]);
+  protected filling = signal(false);
+  protected adding = signal(false);
+  protected paying = signal(false);
+  protected danceRole = signal<'LEAD' | 'FOLLOW'>('LEAD');
+
+  protected readonly enrollmentColumns = ['name', 'phone', 'role', 'status', 'enrolledAt'];
+
+  ngOnInit(): void {
+    this.loadCourses();
+  }
+
+  protected onCourseSelected(courseId: number): void {
+    this.selectedCourseId.set(courseId);
+    this.selectedCourse.set(this.courses().find(c => c.id === courseId) ?? null);
+    this.loadEnrollments(courseId);
+  }
+
+  protected isPartnerCourse(): boolean {
+    const c = this.selectedCourse();
+    // CourseListItem doesn't have courseType, so check from detail
+    // For simplicity, look at enrollments for dance roles or check the course name
+    // Actually, CourseListItem doesn't expose courseType. Let's add a heuristic.
+    return c != null;
+  }
+
+  protected onFillCourse(): void {
+    const courseId = this.selectedCourseId();
+    if (!courseId) return;
+
+    this.filling.set(true);
+    const course = this.selectedCourse();
+    if (!course) return;
+
+    const activeCount = this.enrollments().filter(
+      e => e.status === 'CONFIRMED' || e.status === 'PENDING_PAYMENT',
+    ).length;
+    const spotsToFill = Math.max(0, course.maxParticipants - activeCount);
+
+    if (spotsToFill === 0) {
+      this.snackBar.open('Course is already full', 'Close', { duration: 3000 });
+      this.filling.set(false);
+      return;
+    }
+
+    // Create students and enroll them sequentially
+    const operations: Observable<unknown>[] = [];
+    for (let i = 0; i < spotsToFill; i++) {
+      const role = i % 2 === 0 ? 'LEAD' : 'FOLLOW';
+      operations.push(
+        this.createRandomStudent().pipe(
+          switchMap(result => {
+            const dto: EnrollStudentRequest = { studentId: result.id };
+            // If course has role-based enrollments, alternate roles
+            const hasRoles = this.enrollments().some(e => e.danceRole != null);
+            if (hasRoles) {
+              dto.danceRole = role;
+            }
+            return this.enrollmentService.enrollStudent(courseId, dto);
+          }),
+        ),
+      );
+    }
+
+    concat(...operations).pipe(
+      toArray(),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: () => {
+        this.snackBar.open(`Enrolled ${spotsToFill} students`, 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        this.filling.set(false);
+        this.loadEnrollments(courseId);
+      },
+      error: () => {
+        this.snackBar.open('Some enrollments failed', 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+        this.filling.set(false);
+        this.loadEnrollments(courseId);
+      },
+    });
+  }
+
+  protected onAddStudent(): void {
+    const courseId = this.selectedCourseId();
+    if (!courseId) return;
+
+    this.adding.set(true);
+    const hasRoles = this.enrollments().some(e => e.danceRole != null);
+
+    this.createRandomStudent().pipe(
+      switchMap(result => {
+        const dto: EnrollStudentRequest = { studentId: result.id };
+        if (hasRoles) {
+          dto.danceRole = this.danceRole();
+        }
+        return this.enrollmentService.enrollStudent(courseId, dto);
+      }),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: (res) => {
+        this.snackBar.open(`Student enrolled (${res.status})`, 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        this.adding.set(false);
+        this.loadEnrollments(courseId);
+      },
+      error: (err) => {
+        const msg = err?.error?.detail || 'Failed to add student';
+        this.snackBar.open(msg, 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+        this.adding.set(false);
+      },
+    });
+  }
+
+  protected onSimulatePayment(): void {
+    const courseId = this.selectedCourseId();
+    if (!courseId) return;
+
+    const pendingPayments = this.enrollments().filter(e => e.status === 'PENDING_PAYMENT');
+    if (pendingPayments.length === 0) {
+      this.snackBar.open('No pending payments', 'Close', { duration: 3000 });
+      return;
+    }
+
+    this.paying.set(true);
+    const operations = pendingPayments.map(e => this.enrollmentService.markPaid(e.id));
+
+    concat(...operations).pipe(
+      toArray(),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: () => {
+        this.snackBar.open(`Confirmed ${pendingPayments.length} payments`, 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        this.paying.set(false);
+        this.loadEnrollments(courseId);
+      },
+      error: () => {
+        this.snackBar.open('Some payments failed', 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+        this.paying.set(false);
+        this.loadEnrollments(courseId);
+      },
+    });
+  }
+
+  protected formatStatus(status: string): string {
+    return status.replace(/_/g, ' ');
+  }
+
+  protected formatRole(role: string | null): string {
+    if (!role) return '—';
+    return role === 'LEAD' ? 'Leader' : 'Follower';
+  }
+
+  protected formatDate(isoString: string | null): string {
+    if (!isoString) return '—';
+    return new Date(isoString).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  private loadCourses(): void {
+    const open$ = this.courseService.getCoursesByStatus('OPEN');
+    const running$ = this.courseService.getCoursesByStatus('RUNNING');
+
+    open$.pipe(
+      switchMap(open => running$.pipe(
+        tap(running => this.courses.set([...running, ...open])),
+      )),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe();
+  }
+
+  private loadEnrollments(courseId: number): void {
+    this.enrollmentService.getEnrollments(courseId).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: data => this.enrollments.set(data),
+      error: () => this.enrollments.set([]),
+    });
+  }
+
+  private createRandomStudent(): Observable<{ id: number }> {
+    const firstName = FIRST_NAMES[Math.floor(Math.random() * FIRST_NAMES.length)];
+    const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)];
+    const name = `${firstName} ${lastName}`;
+    const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}${Math.floor(Math.random() * 1000)}@test.com`;
+
+    return this.http.post<{ id: number }>(`${environment.apiUrl}/api/students`, { name, email });
+  }
+}

--- a/frontend/src/app/shell/shell.ts
+++ b/frontend/src/app/shell/shell.ts
@@ -10,6 +10,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatDividerModule } from '@angular/material/divider';
 import { AuthService } from '../shared/auth/auth.service';
+import { environment } from '../../environments/environment';
 
 interface NavChild {
   label: string;
@@ -64,6 +65,7 @@ export class ShellComponent {
     },
     { label: 'Courses', icon: 'school', route: '/app/courses' },
     { label: 'Payments', icon: 'payments', route: '/app/payments' },
+    ...(!environment.production ? [{ label: 'Dev Tools', icon: 'build', route: '/app/dev-tools' } as NavItem] : []),
   ];
 
   constructor() {


### PR DESCRIPTION
## Summary

- **Enrollment entity + API**: Full enrollment domain layer with direct booking endpoint (`POST /api/courses/{id}/enrollments`), enrollment listing (`GET`), and mark-paid (`PUT /api/enrollments/{id}/mark-paid`) — capacity checks, dance role validation, level checks, duplicate prevention, tenant isolation
- **Course detail enrollment tabs**: 4-tab layout (Enrolled / Waitlist / Approve / Open Payment) with 5-column tables matching the Figma design, Mark Paid button on the Open Payment tab
- **Dev Tools page**: Course selector, Fill Course / Add Student / Simulate Payment buttons — all using production endpoints via the owner-on-behalf path
- **14 integration tests**: Direct booking (PARTNER + SOLO), role validation, capacity, level checks, mark-paid, tenant isolation
- **Seed data**: Enrollments seeded for running courses with CONFIRMED + PENDING_PAYMENT mix

Closes #249

## Test plan

- [x] `./mvnw test` — 130 tests pass (14 new enrollment tests)
- [x] `ng build` — frontend compiles without errors
- [x] Visual verification: course detail Enrolled tab shows seeded data
- [x] Visual verification: Open Payment tab shows Mark Paid buttons
- [x] Visual verification: Dev Tools page with course selector
- [x] Dev Tools nav item visible in sidebar (dev environment only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)