### PR TITLE
Document Phase 1 auth assumptions in product roadmap

### DIFF
--- a/.claude/rules/product-roadmap.md
+++ b/.claude/rules/product-roadmap.md
@@ -19,3 +19,11 @@
 - **v1 ships without real payment integration** — all enrollments handled offline (admin marks paid). Architectural stubs in place (a `PENDING_PAYMENT` state and a single `confirmPayment` seam on the backend) so Stripe can be wired in without reshaping the enrollment flow or the API contract.
 
 **Business model:** Solve admin pain for teachers → get students onto the platform → build community via events → monetize via ads, school subscriptions, and other revenue streams TBD
+
+## Authentication & Authorization — Phase 1 assumptions that will change
+
+- **Single school per user.** A user has at most one `SchoolMember` row — enforced via DB unique constraint on `school_member.user_id`. Lets admin authz collapse to "is caller a member of any school?" and keeps `/me` URLs unambiguous. **Phase 2 drops the cap** (a user may be OWNER at School A and Student at Schools B, C…).
+- **OWNER == TEACHER.** Both roles treated identically in Phase 1. **Split when a concrete capability difference appears** (e.g., only OWNER can manage members or delete the school).
+- **Implicit school in `/me` URLs.** Works only because of the single-school cap. **Phase 2 refactors admin endpoints to `/api/schools/{schoolId}/...`** with parameterized authz.
+- **No student login.** Students are admin-created data rows. **Phase 2 activates student sign-in** and layers student-specific authz onto enrollment endpoints.
+- **Auth providers: email/password + Google only.** **Phase 2 adds Sign in with Apple** (App Store Guideline 4.8 — mandatory once iOS ships). Skip Instagram/Facebook for auth.


### PR DESCRIPTION
## Summary

- Add auth/authz assumptions section to product roadmap
- Documents Phase 1 constraints (single school per user, OWNER==TEACHER, no student login) and when they change

🤖 Generated with [Claude Code](https://claude.com/claude-code)