### PR TITLE
Expose Dev Tools nav in production

### DIFF
--- a/frontend/src/app/shell/shell.ts
+++ b/frontend/src/app/shell/shell.ts
@@ -10,7 +10,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatDividerModule } from '@angular/material/divider';
 import { AuthService } from '../shared/auth/auth.service';
-import { environment } from '../../environments/environment';
 
 interface NavChild {
   label: string;
@@ -65,7 +64,7 @@ export class ShellComponent {
     },
     { label: 'Courses', icon: 'school', route: '/app/courses' },
     { label: 'Payments', icon: 'payments', route: '/app/payments' },
-    ...(!environment.production ? [{ label: 'Dev Tools', icon: 'build', route: '/app/dev-tools' } as NavItem] : []),
+    { label: 'Dev Tools', icon: 'build', route: '/app/dev-tools' },
   ];
 
   constructor() {


### PR DESCRIPTION
## Summary
- Drops the `!environment.production` gate on the Dev Tools sidebar entry so it appears in both dev and prod builds
- Useful for now while testing and demoing the enrollment flows against the deployed environment

## Notes
- The Dev Tools route itself was already defined unconditionally — only the nav entry was gated
- Backend endpoints Dev Tools uses (students, enrollments) are existing production endpoints, so no backend change is needed
- Pre-existing restrictions still apply: generated students have no dance levels, so Fill Course still only works for beginner-level courses

## Test plan
- [x] `ng build --configuration production` succeeds
- [ ] CI green
- [ ] Verify the "Dev Tools" entry appears in the sidebar on the deployed site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)