### PR TITLE
Make CourseSummary sections collapsible (#248)

### DIFF
--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -242,7 +242,7 @@
         <!-- Review Step -->
         <div class="review-step">
           <!-- Course Summary -->
-          <app-course-summary [data]="reviewData" (edit)="goToStep($event)" />
+          <app-course-summary [data]="reviewData" [defaultOpen]="true" (edit)="goToStep($event)" />
         </div>
       }
     }

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -116,7 +116,7 @@
     <!-- Content Card -->
     <div class="content-card">
       <h2 class="content-card-title">Course Summary</h2>
-      <app-course-summary [data]="summaryData" (edit)="onEdit($event)" />
+      <app-course-summary [data]="summaryData" [defaultOpen]="false" (edit)="onEdit($event)" />
     </div>
   }
 } @else {

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -104,6 +104,7 @@ export class CourseOverviewComponent implements OnInit {
       numberOfSessions: c.numberOfSessions,
       completedSessions: c.completedSessions,
       status: c.status,
+      publishedAt: formatDate(c.publishedAt ?? ''),
       endDate: formatDate(c.endDate),
       startTime: formatTime(c.startTime),
       endTime: formatTime(c.endTime),

--- a/frontend/src/app/courses/shared/course-summary.html
+++ b/frontend/src/app/courses/shared/course-summary.html
@@ -1,129 +1,196 @@
 @let d = data();
 
-<!-- Details Card -->
-<div class="summary-card">
-  <div class="summary-card-header">
-    <h3 class="summary-card-title">Details</h3>
-    <button mat-button class="edit-link" (click)="edit.emit(0)" type="button">Edit</button>
+<!-- Course Details -->
+<section class="summary-card" [class.is-open]="isOpen('details')">
+  <div
+    class="summary-card-header"
+    role="button"
+    tabindex="0"
+    [attr.aria-expanded]="isOpen('details')"
+    (click)="toggle('details')"
+    (keydown.enter)="$event.preventDefault(); toggle('details')"
+    (keydown.space)="$event.preventDefault(); toggle('details')">
+    <h3 class="summary-card-title">Course Details</h3>
+    <button mat-button class="edit-link" (click)="onEdit($event, 'details')" type="button">Edit</button>
+    <mat-icon class="chevron" aria-hidden="true">{{ isOpen('details') ? 'expand_less' : 'expand_more' }}</mat-icon>
   </div>
-  <div class="summary-card-fields">
-    <div class="summary-field">
-      <span class="summary-label">Title</span>
-      <span class="summary-value">{{ d.title }}</span>
-    </div>
-    <div class="summary-field">
-      <span class="summary-label">Dance Style</span>
-      <span class="summary-value">{{ label(danceStyles, d.danceStyle) }}</span>
-    </div>
-    <div class="summary-field">
-      <span class="summary-label">Level</span>
-      <span class="summary-value">{{ label(levels, d.level) }}</span>
-    </div>
-    <div class="summary-field">
-      <span class="summary-label">Course Type</span>
-      <span class="summary-value">{{ label(courseTypes, d.courseType) }}</span>
-    </div>
-    @if (d.description) {
-      <div class="summary-field summary-field--full">
-        <span class="summary-label">Description</span>
-        <span class="summary-value">{{ d.description }}</span>
-      </div>
-    }
-  </div>
-</div>
-
-<!-- Schedule Card -->
-<div class="summary-card">
-  <div class="summary-card-header">
-    <h3 class="summary-card-title">Schedule</h3>
-    <button mat-button class="edit-link" (click)="edit.emit(1)" type="button">Edit</button>
-  </div>
-  <div class="summary-card-fields">
-    <div class="summary-field">
-      <span class="summary-label">Start Date</span>
-      <span class="summary-value">{{ d.startDate }}</span>
-    </div>
-    <div class="summary-field">
-      <span class="summary-label">Recurrence</span>
-      <span class="summary-value">{{ label(recurrenceTypes, d.recurrenceType) }}</span>
-    </div>
-    <div class="summary-field">
-      <span class="summary-label">Day of Week</span>
-      <span class="summary-value">{{ d.dayOfWeek }}</span>
-    </div>
-    <div class="summary-field">
-      <span class="summary-label">Sessions</span>
-      <span class="summary-value">
-        @if (d.status === 'RUNNING' && d.completedSessions != null) {
-          Session {{ d.completedSessions }}/{{ d.numberOfSessions }}
-        } @else {
-          {{ d.numberOfSessions }}
-        }
-      </span>
-    </div>
-    <div class="summary-field">
-      <span class="summary-label">Time</span>
-      <span class="summary-value">{{ d.startTime }} – {{ d.endTime }}</span>
-    </div>
-    @if (d.endDate) {
+  @if (isOpen('details')) {
+    <div class="summary-card-fields">
       <div class="summary-field">
-        <span class="summary-label">End Date</span>
-        <span class="summary-value">{{ d.endDate }}</span>
+        <span class="summary-label">Title</span>
+        <span class="summary-value">{{ d.title }}</span>
       </div>
-    }
-    <div class="summary-field summary-field--full">
-      <span class="summary-label">Location</span>
-      <span class="summary-value">{{ d.location }}</span>
-    </div>
-    @if (d.teachers) {
-      <div class="summary-field summary-field--full">
-        <span class="summary-label">Teachers</span>
-        <span class="summary-value">{{ d.teachers }}</span>
-      </div>
-    }
-  </div>
-</div>
-
-<!-- Registration Card -->
-<div class="summary-card">
-  <div class="summary-card-header">
-    <h3 class="summary-card-title">Registration</h3>
-    <button mat-button class="edit-link" (click)="edit.emit(2)" type="button">Edit</button>
-  </div>
-  <div class="summary-card-fields">
-    <div class="summary-field">
-      <span class="summary-label">Max Participants</span>
-      <span class="summary-value">{{ d.maxParticipants }}</span>
-    </div>
-    @if (d.courseType === 'PARTNER') {
       <div class="summary-field">
-        <span class="summary-label">Role Balancing</span>
-        <span class="summary-value">{{ d.roleBalancingEnabled ? 'Enabled' : 'Disabled' }}</span>
+        <span class="summary-label">Dance Style</span>
+        <span class="summary-value">{{ label(danceStyles, d.danceStyle) }}</span>
       </div>
-      @if (d.roleBalancingEnabled && d.roleBalanceThreshold) {
-        <div class="summary-field">
-          <span class="summary-label">Max Imbalance</span>
-          <span class="summary-value">{{ d.roleBalanceThreshold }}</span>
+      <div class="summary-field">
+        <span class="summary-label">Level</span>
+        <span class="summary-value">{{ label(levels, d.level) }}</span>
+      </div>
+      <div class="summary-field">
+        <span class="summary-label">Course Type</span>
+        <span class="summary-value">{{ label(courseTypes, d.courseType) }}</span>
+      </div>
+      @if (d.description) {
+        <div class="summary-field summary-field--full">
+          <span class="summary-label">Description</span>
+          <span class="summary-value">{{ d.description }}</span>
         </div>
       }
-    }
-  </div>
-</div>
+    </div>
+  }
+</section>
 
-<!-- Pricing Card -->
-<div class="summary-card">
-  <div class="summary-card-header">
+<!-- Schedule -->
+<section class="summary-card" [class.is-open]="isOpen('schedule')">
+  <div
+    class="summary-card-header"
+    role="button"
+    tabindex="0"
+    [attr.aria-expanded]="isOpen('schedule')"
+    (click)="toggle('schedule')"
+    (keydown.enter)="$event.preventDefault(); toggle('schedule')"
+    (keydown.space)="$event.preventDefault(); toggle('schedule')">
+    <h3 class="summary-card-title">Schedule</h3>
+    <button mat-button class="edit-link" (click)="onEdit($event, 'schedule')" type="button">Edit</button>
+    <mat-icon class="chevron" aria-hidden="true">{{ isOpen('schedule') ? 'expand_less' : 'expand_more' }}</mat-icon>
+  </div>
+  @if (isOpen('schedule')) {
+    <div class="summary-card-fields">
+      <div class="summary-field">
+        <span class="summary-label">Start Date</span>
+        <span class="summary-value">{{ d.startDate }}</span>
+      </div>
+      <div class="summary-field">
+        <span class="summary-label">Recurrence</span>
+        <span class="summary-value">{{ label(recurrenceTypes, d.recurrenceType) }}</span>
+      </div>
+      <div class="summary-field">
+        <span class="summary-label">Day of Week</span>
+        <span class="summary-value">{{ d.dayOfWeek }}</span>
+      </div>
+      <div class="summary-field">
+        <span class="summary-label">Sessions</span>
+        <span class="summary-value">
+          @if (d.status === 'RUNNING' && d.completedSessions != null) {
+            Session {{ d.completedSessions }}/{{ d.numberOfSessions }}
+          } @else {
+            {{ d.numberOfSessions }}
+          }
+        </span>
+      </div>
+      <div class="summary-field">
+        <span class="summary-label">Time</span>
+        <span class="summary-value">{{ d.startTime }} – {{ d.endTime }}</span>
+      </div>
+      @if (d.endDate) {
+        <div class="summary-field">
+          <span class="summary-label">End Date</span>
+          <span class="summary-value">{{ d.endDate }}</span>
+        </div>
+      }
+      <div class="summary-field summary-field--full">
+        <span class="summary-label">Location</span>
+        <span class="summary-value">{{ d.location }}</span>
+      </div>
+      @if (d.teachers) {
+        <div class="summary-field summary-field--full">
+          <span class="summary-label">Teachers</span>
+          <span class="summary-value">{{ d.teachers }}</span>
+        </div>
+      }
+    </div>
+  }
+</section>
+
+<!-- Registration -->
+<section class="summary-card" [class.is-open]="isOpen('registration')">
+  <div
+    class="summary-card-header"
+    role="button"
+    tabindex="0"
+    [attr.aria-expanded]="isOpen('registration')"
+    (click)="toggle('registration')"
+    (keydown.enter)="$event.preventDefault(); toggle('registration')"
+    (keydown.space)="$event.preventDefault(); toggle('registration')">
+    <h3 class="summary-card-title">Registration</h3>
+    <button mat-button class="edit-link" (click)="onEdit($event, 'registration')" type="button">Edit</button>
+    <mat-icon class="chevron" aria-hidden="true">{{ isOpen('registration') ? 'expand_less' : 'expand_more' }}</mat-icon>
+  </div>
+  @if (isOpen('registration')) {
+    <div class="summary-card-fields">
+      <div class="summary-field">
+        <span class="summary-label">Max Participants</span>
+        <span class="summary-value">{{ d.maxParticipants }}</span>
+      </div>
+      @if (d.courseType === 'PARTNER') {
+        <div class="summary-field">
+          <span class="summary-label">Role Balancing</span>
+          <span class="summary-value">{{ d.roleBalancingEnabled ? 'Enabled' : 'Disabled' }}</span>
+        </div>
+        @if (d.roleBalancingEnabled && d.roleBalanceThreshold) {
+          <div class="summary-field">
+            <span class="summary-label">Max Imbalance</span>
+            <span class="summary-value">{{ d.roleBalanceThreshold }}</span>
+          </div>
+        }
+      }
+    </div>
+  }
+</section>
+
+<!-- Pricing -->
+<section class="summary-card" [class.is-open]="isOpen('pricing')">
+  <div
+    class="summary-card-header"
+    role="button"
+    tabindex="0"
+    [attr.aria-expanded]="isOpen('pricing')"
+    (click)="toggle('pricing')"
+    (keydown.enter)="$event.preventDefault(); toggle('pricing')"
+    (keydown.space)="$event.preventDefault(); toggle('pricing')">
     <h3 class="summary-card-title">Pricing</h3>
-    <button mat-button class="edit-link" (click)="edit.emit(3)" type="button">Edit</button>
+    <button mat-button class="edit-link" (click)="onEdit($event, 'pricing')" type="button">Edit</button>
+    <mat-icon class="chevron" aria-hidden="true">{{ isOpen('pricing') ? 'expand_less' : 'expand_more' }}</mat-icon>
   </div>
-  <div class="summary-card-fields">
-    <div class="summary-field">
-      <span class="summary-label">Price Model</span>
-      <span class="summary-value">{{ label(priceModels, d.priceModel) }}</span>
+  @if (isOpen('pricing')) {
+    <div class="summary-card-fields">
+      <div class="summary-field">
+        <span class="summary-label">Price Model</span>
+        <span class="summary-value">{{ label(priceModels, d.priceModel) }}</span>
+      </div>
+      <div class="summary-field">
+        <span class="summary-label">Price</span>
+        <span class="summary-value">CHF {{ d.price }}</span>
+      </div>
     </div>
-    <div class="summary-field">
-      <span class="summary-label">Price</span>
-      <span class="summary-value">CHF {{ d.price }}</span>
-    </div>
+  }
+</section>
+
+<!-- Publication -->
+<section class="summary-card" [class.is-open]="isOpen('publication')">
+  <div
+    class="summary-card-header"
+    role="button"
+    tabindex="0"
+    [attr.aria-expanded]="isOpen('publication')"
+    (click)="toggle('publication')"
+    (keydown.enter)="$event.preventDefault(); toggle('publication')"
+    (keydown.space)="$event.preventDefault(); toggle('publication')">
+    <h3 class="summary-card-title">Publication</h3>
+    <mat-icon class="chevron" aria-hidden="true">{{ isOpen('publication') ? 'expand_less' : 'expand_more' }}</mat-icon>
   </div>
-</div>
+  @if (isOpen('publication')) {
+    <div class="summary-card-fields">
+      <div class="summary-field">
+        <span class="summary-label">Publish Status</span>
+        <span class="summary-value">{{ statusLabel(d.status) }}</span>
+      </div>
+      <div class="summary-field">
+        <span class="summary-label">Publish Date</span>
+        <span class="summary-value">{{ d.publishedAt || '—' }}</span>
+      </div>
+    </div>
+  }
+</section>

--- a/frontend/src/app/courses/shared/course-summary.scss
+++ b/frontend/src/app/courses/shared/course-summary.scss
@@ -16,11 +16,20 @@
 .summary-card-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: var(--ds-spacing-4);
+  gap: var(--ds-spacing-4);
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--mat-sys-primary);
+    outline-offset: 2px;
+    border-radius: var(--ds-radius-md);
+  }
 }
 
 .summary-card-title {
+  flex: 1 1 auto;
   font: var(--mat-sys-title-medium);
   color: var(--mat-sys-on-surface);
   margin: 0;
@@ -30,10 +39,16 @@
   color: var(--mat-sys-primary);
 }
 
+.chevron {
+  flex: 0 0 auto;
+  color: var(--mat-sys-on-surface-variant);
+}
+
 .summary-card-fields {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--ds-spacing-3) var(--ds-spacing-5);
+  margin-top: var(--ds-spacing-4);
 
   @include ds.bp-down(sm) {
     grid-template-columns: 1fr;

--- a/frontend/src/app/courses/shared/course-summary.spec.ts
+++ b/frontend/src/app/courses/shared/course-summary.spec.ts
@@ -30,18 +30,60 @@ describe('CourseSummaryComponent', () => {
   let fixture: ComponentFixture<CourseSummaryComponent>;
   let el: HTMLElement;
 
-  function setup(data: CourseSummaryData): void {
+  function setup(data: CourseSummaryData, defaultOpen = true): void {
     TestBed.configureTestingModule({ imports: [CourseSummaryComponent] });
     fixture = TestBed.createComponent(CourseSummaryComponent);
     fixture.componentRef.setInput('data', data);
+    fixture.componentRef.setInput('defaultOpen', defaultOpen);
     fixture.detectChanges();
     el = fixture.nativeElement;
   }
 
-  it('should render all 4 section titles', () => {
+  function titles(): (string | undefined)[] {
+    return Array.from(el.querySelectorAll('.summary-card-title')).map(e => e.textContent?.trim());
+  }
+
+  function openHeaders(): HTMLElement[] {
+    return Array.from(el.querySelectorAll('.summary-card-header[aria-expanded="true"]'));
+  }
+
+  function clickHeader(title: string): void {
+    const header = Array.from(el.querySelectorAll<HTMLElement>('.summary-card-header'))
+      .find(h => h.querySelector('.summary-card-title')?.textContent?.trim() === title);
+    header?.click();
+    fixture.detectChanges();
+  }
+
+  it('should render all 5 section titles', () => {
     setup(makeSummaryData());
-    const titles = Array.from(el.querySelectorAll('.summary-card-title')).map(e => e.textContent?.trim());
-    expect(titles).toEqual(['Details', 'Schedule', 'Registration', 'Pricing']);
+    expect(titles()).toEqual(['Course Details', 'Schedule', 'Registration', 'Pricing', 'Publication']);
+  });
+
+  it('should start with all sections collapsed when defaultOpen=false', () => {
+    setup(makeSummaryData(), false);
+    expect(openHeaders().length).toBe(0);
+    expect(el.querySelectorAll('.summary-card-fields').length).toBe(0);
+  });
+
+  it('should start with all sections expanded when defaultOpen=true', () => {
+    setup(makeSummaryData(), true);
+    expect(openHeaders().length).toBe(5);
+    expect(el.querySelectorAll('.summary-card-fields').length).toBe(5);
+  });
+
+  it('should toggle a single section independently of the others', () => {
+    setup(makeSummaryData(), true);
+    clickHeader('Schedule');
+
+    const expanded = openHeaders().map(h => h.querySelector('.summary-card-title')?.textContent?.trim());
+    expect(expanded).toEqual(['Course Details', 'Registration', 'Pricing', 'Publication']);
+  });
+
+  it('should re-open a collapsed section when its header is clicked again', () => {
+    setup(makeSummaryData(), false);
+    clickHeader('Pricing');
+    expect(openHeaders().length).toBe(1);
+    expect(openHeaders()[0].querySelector('.summary-card-title')?.textContent?.trim()).toBe('Pricing');
   });
 
   it('should display course details fields with labels', () => {
@@ -106,6 +148,23 @@ describe('CourseSummaryComponent', () => {
     expect(values).toContain('CHF 166.5');
   });
 
+  it('should display Publication section with status and publish date', () => {
+    setup(makeSummaryData({ status: 'OPEN', publishedAt: '01.03.2026' }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).toContain('Publish Status');
+    expect(labels).toContain('Publish Date');
+
+    const values = Array.from(el.querySelectorAll('.summary-value')).map(e => e.textContent?.trim());
+    expect(values).toContain('Open');
+    expect(values).toContain('01.03.2026');
+  });
+
+  it('should show Draft status when status is missing', () => {
+    setup(makeSummaryData({ status: undefined }));
+    const values = Array.from(el.querySelectorAll('.summary-value')).map(e => e.textContent?.trim());
+    expect(values).toContain('Draft');
+  });
+
   it('should emit edit event with correct section index when Edit is clicked', () => {
     setup(makeSummaryData());
     const editSpy = vi.fn();
@@ -125,5 +184,15 @@ describe('CourseSummaryComponent', () => {
 
     (editButtons[3] as HTMLButtonElement).click();
     expect(editSpy).toHaveBeenCalledWith(3);
+  });
+
+  it('should not toggle the section when Edit is clicked', () => {
+    setup(makeSummaryData(), true);
+    const firstEdit = el.querySelector<HTMLButtonElement>('.edit-link');
+    firstEdit?.click();
+    fixture.detectChanges();
+
+    // All 5 sections should still be expanded after clicking Edit
+    expect(openHeaders().length).toBe(5);
   });
 });

--- a/frontend/src/app/courses/shared/course-summary.ts
+++ b/frontend/src/app/courses/shared/course-summary.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, linkedSignal, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import {
   DANCE_STYLES, COURSE_LEVELS, COURSE_TYPES, RECURRENCE_TYPES, PRICE_MODELS, labelOf,
 } from '../../shared/course-constants';
@@ -16,6 +17,7 @@ export interface CourseSummaryData {
   numberOfSessions: number;
   completedSessions?: number;
   status?: string;
+  publishedAt?: string | null;
   endDate?: string | null;
   startTime: string;
   endTime: string;
@@ -28,19 +30,61 @@ export interface CourseSummaryData {
   price: number;
 }
 
+export type CourseSummarySection =
+  | 'details' | 'schedule' | 'registration' | 'pricing' | 'publication';
+
+const ALL_SECTIONS: readonly CourseSummarySection[] =
+  ['details', 'schedule', 'registration', 'pricing', 'publication'];
+
+/** Maps section keys to the wizard step index used by the `edit` output. */
+const EDIT_STEP_INDEX: Record<Exclude<CourseSummarySection, 'publication'>, number> = {
+  details: 0,
+  schedule: 1,
+  registration: 2,
+  pricing: 3,
+};
+
 @Component({
   selector: 'app-course-summary',
-  imports: [MatButtonModule],
+  imports: [MatButtonModule, MatIconModule],
   templateUrl: './course-summary.html',
   styleUrl: './course-summary.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CourseSummaryComponent {
   data = input.required<CourseSummaryData>();
+  defaultOpen = input(false);
   edit = output<number>();
+
+  protected openSections = linkedSignal<Set<CourseSummarySection>>(
+    () => new Set(this.defaultOpen() ? ALL_SECTIONS : []),
+  );
+
+  protected isOpen(section: CourseSummarySection): boolean {
+    return this.openSections().has(section);
+  }
+
+  protected toggle(section: CourseSummarySection): void {
+    this.openSections.update(current => {
+      const next = new Set(current);
+      if (next.has(section)) next.delete(section);
+      else next.add(section);
+      return next;
+    });
+  }
+
+  protected onEdit(event: Event, section: keyof typeof EDIT_STEP_INDEX): void {
+    event.stopPropagation();
+    this.edit.emit(EDIT_STEP_INDEX[section]);
+  }
 
   protected label(items: { value: string; label: string }[], value: string): string {
     return labelOf(items, value);
+  }
+
+  protected statusLabel(status: string | undefined): string {
+    if (!status) return 'Draft';
+    return status.charAt(0) + status.slice(1).toLowerCase();
   }
 
   protected readonly danceStyles = DANCE_STYLES;


### PR DESCRIPTION
## Summary

- Refactors `CourseSummaryComponent` into five collapsible sections (Course Details, Schedule, Registration, Pricing, Publication), each independently toggleable.
- Adds a `defaultOpen` input — the course detail view passes `false` (keeps the enrollment table prominent), the create/edit wizard review step passes `true` (user verifies every field before submitting).
- Adds a new Publication section wired to the existing `publishedAt` + `status` fields on `CourseDetail`.

Closes #248.

## Test plan
- [x] `npx ng build`
- [x] `npx ng test --browsers chromium --no-watch` — 71 tests pass
- [x] Course detail page: sections start collapsed, chevrons flip and bodies expand on click independently
- [x] Wizard review (edit mode): all five sections start expanded by default
- [x] Edit button in a section header does not toggle the section

🤖 Generated with [Claude Code](https://claude.com/claude-code)