### PR TITLE
Approval flow: end-to-end (#250)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -108,13 +108,15 @@ public class DevDataSeeder implements ApplicationRunner {
                 PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 0, today.minusWeeks(3)));
 
         // --- OPEN courses (published, start in the future) ---
-        courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
+        Course salsaAdvanced = courseService.seedCourse(owner.getId(), new CreateCourseDto(
                 "Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED,
                 CourseType.PARTNER, "Advanced Salsa patterns, styling, and performance preparation.",
                 today.plusWeeks(4), RecurrenceType.WEEKLY,
                 10, LocalTime.of(20, 0), LocalTime.of(21, 15),
                 "Studio A", "Maria, Carlos", 10, true, 2,
-                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, today.minusDays(5)));
+                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, today.minusDays(5));
+        salsaAdvanced.setRequiresApproval(true);
+        courses.add(salsaAdvanced);
 
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
                 "Bachata Beginners", DanceStyle.BACHATA, CourseLevel.BEGINNER,
@@ -271,5 +273,16 @@ public class DevDataSeeder implements ApplicationRunner {
         enrollmentService.seedEnrollment(partnerCourse, students.get(4), DanceRole.FOLLOW,
                 EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
         partnerCourse.setEnrolledStudents(5);
+
+        // courses[2] = "Salsa Advanced" (PARTNER, ADVANCED, requiresApproval=true)
+        // Seed two PENDING_APPROVAL rows so the Approve tab has visible content.
+        // students[0] Anna: INTERMEDIATE salsa (under-level)
+        // students[5] Jan de Vries: no salsa level at all
+        Course salsaAdvanced = courses.get(2);
+        enrollmentService.seedEnrollment(salsaAdvanced, students.get(0), DanceRole.FOLLOW,
+                EnrollmentStatus.PENDING_APPROVAL, now.minus(1, ChronoUnit.DAYS), null);
+        enrollmentService.seedEnrollment(salsaAdvanced, students.get(5), DanceRole.LEAD,
+                EnrollmentStatus.PENDING_APPROVAL, now.minus(12, ChronoUnit.HOURS), null);
+        salsaAdvanced.setEnrolledStudents(2);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
@@ -42,4 +42,16 @@ public class EnrollmentController {
                                           @AuthenticationPrincipal AuthenticatedUser principal) {
         return enrollmentService.confirmPayment(principal.userId(), enrollmentId);
     }
+
+    @PutMapping("/enrollments/{enrollmentId}/approve")
+    public EnrollmentResponseDto approve(@PathVariable Long enrollmentId,
+                                         @AuthenticationPrincipal AuthenticatedUser principal) {
+        return enrollmentService.approveEnrollment(principal.userId(), enrollmentId);
+    }
+
+    @PutMapping("/enrollments/{enrollmentId}/reject")
+    public EnrollmentResponseDto reject(@PathVariable Long enrollmentId,
+                                        @AuthenticationPrincipal AuthenticatedUser principal) {
+        return enrollmentService.rejectEnrollment(principal.userId(), enrollmentId);
+    }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentListDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentListDto.java
@@ -1,5 +1,7 @@
 package ch.ruppen.danceschool.enrollment;
 
+import ch.ruppen.danceschool.course.CourseLevel;
+
 import java.time.Instant;
 
 public record EnrollmentListDto(
@@ -13,6 +15,7 @@ public record EnrollmentListDto(
         Instant approvedAt,
         Instant paidAt,
         Integer waitlistPosition,
-        WaitlistReason waitlistReason
+        WaitlistReason waitlistReason,
+        CourseLevel studentDanceLevel
 ) {
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.course.Course;
 import ch.ruppen.danceschool.course.CourseLevel;
 import ch.ruppen.danceschool.course.CourseService;
 import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.schoolmember.SchoolMember;
@@ -45,7 +46,6 @@ public class EnrollmentService {
         validateDanceRole(course, dto.danceRole());
         validateNoDuplicate(student.getId(), course.getId());
         validateCapacity(course);
-        validateLevelForDirectBooking(course, student);
 
         SchoolMember enrolledBy = schoolMemberService.findByUserIdAndSchoolId(userId, school.getId())
                 .orElse(null);
@@ -54,7 +54,7 @@ public class EnrollmentService {
         enrollment.setStudent(student);
         enrollment.setCourse(course);
         enrollment.setDanceRole(dto.danceRole());
-        enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
+        enrollment.setStatus(resolveBookingStatus(course, student));
         enrollment.setEnrolledAt(Instant.now(clock));
         enrollment.setEnrolledBy(enrolledBy);
 
@@ -76,6 +76,41 @@ public class EnrollmentService {
 
         enrollment.setStatus(EnrollmentStatus.CONFIRMED);
         enrollment.setPaidAt(Instant.now(clock));
+        return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
+    }
+
+    @Transactional
+    @BusinessOperation(event = "EnrollmentApproved")
+    public EnrollmentResponseDto approveEnrollment(Long userId, Long enrollmentId) {
+        School school = schoolService.findSchoolByMember(userId);
+        Enrollment enrollment = enrollmentRepository.findByIdAndCourseSchoolId(enrollmentId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Enrollment", enrollmentId));
+
+        if (enrollment.getStatus() != EnrollmentStatus.PENDING_APPROVAL) {
+            throw new DomainRuleViolationException("Enrollment is not pending approval");
+        }
+
+        enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
+        enrollment.setApprovedAt(Instant.now(clock));
+
+        Course course = enrollment.getCourse();
+        upsertStudentDanceLevel(enrollment.getStudent(), course.getDanceStyle(), course.getLevel());
+
+        return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
+    }
+
+    @Transactional
+    @BusinessOperation(event = "EnrollmentRejected")
+    public EnrollmentResponseDto rejectEnrollment(Long userId, Long enrollmentId) {
+        School school = schoolService.findSchoolByMember(userId);
+        Enrollment enrollment = enrollmentRepository.findByIdAndCourseSchoolId(enrollmentId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Enrollment", enrollmentId));
+
+        if (enrollment.getStatus() != EnrollmentStatus.PENDING_APPROVAL) {
+            throw new DomainRuleViolationException("Enrollment is not pending approval");
+        }
+
+        enrollment.setStatus(EnrollmentStatus.REJECTED);
         return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
     }
 
@@ -121,33 +156,60 @@ public class EnrollmentService {
     private void validateCapacity(Course course) {
         long activeCount = enrollmentRepository.countByCourseIdAndStatusIn(
                 course.getId(),
-                List.of(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.CONFIRMED));
+                List.of(EnrollmentStatus.PENDING_APPROVAL,
+                        EnrollmentStatus.PENDING_PAYMENT,
+                        EnrollmentStatus.CONFIRMED));
         if (activeCount >= course.getMaxParticipants()) {
             throw new DomainRuleViolationException("Course is at capacity");
         }
     }
 
-    private void validateLevelForDirectBooking(Course course, Student student) {
-        // BEGINNER and STARTER courses always allow direct booking
+    private EnrollmentStatus resolveBookingStatus(Course course, Student student) {
+        // BEGINNER and STARTER courses always skip approval
         if (course.getLevel().ordinal() <= CourseLevel.BEGINNER.ordinal()) {
-            return;
+            return EnrollmentStatus.PENDING_PAYMENT;
         }
 
-        // For higher-level courses, check if the student has sufficient level for the dance style
-        CourseLevel studentLevel = student.getDanceLevels().stream()
-                .filter(dl -> dl.getDanceStyle() == course.getDanceStyle())
+        if (course.isRequiresApproval()) {
+            return EnrollmentStatus.PENDING_APPROVAL;
+        }
+
+        CourseLevel studentLevel = findStudentLevel(student, course.getDanceStyle());
+        if (studentLevel == null || studentLevel.ordinal() < course.getLevel().ordinal()) {
+            return EnrollmentStatus.PENDING_APPROVAL;
+        }
+
+        return EnrollmentStatus.PENDING_PAYMENT;
+    }
+
+    private CourseLevel findStudentLevel(Student student, DanceStyle style) {
+        return student.getDanceLevels().stream()
+                .filter(dl -> dl.getDanceStyle() == style)
                 .map(StudentDanceLevel::getLevel)
                 .findFirst()
                 .orElse(null);
+    }
 
-        if (studentLevel == null || studentLevel.ordinal() < course.getLevel().ordinal()) {
-            throw new DomainRuleViolationException(
-                    "Student does not meet the level requirement for this course");
+    private void upsertStudentDanceLevel(Student student, DanceStyle style, CourseLevel level) {
+        StudentDanceLevel existing = student.getDanceLevels().stream()
+                .filter(dl -> dl.getDanceStyle() == style)
+                .findFirst()
+                .orElse(null);
+
+        if (existing == null) {
+            StudentDanceLevel dl = new StudentDanceLevel();
+            dl.setStudent(student);
+            dl.setDanceStyle(style);
+            dl.setLevel(level);
+            student.getDanceLevels().add(dl);
+        } else if (existing.getLevel().ordinal() < level.ordinal()) {
+            existing.setLevel(level);
         }
     }
 
     private EnrollmentListDto toListDto(Enrollment enrollment) {
         Student student = enrollment.getStudent();
+        Course course = enrollment.getCourse();
         return new EnrollmentListDto(
                 enrollment.getId(),
                 student.getName(),
@@ -159,7 +221,8 @@ public class EnrollmentService {
                 enrollment.getApprovedAt(),
                 enrollment.getPaidAt(),
                 enrollment.getWaitlistPosition(),
-                enrollment.getWaitlistReason()
+                enrollment.getWaitlistReason(),
+                findStudentLevel(student, course.getDanceStyle())
         );
     }
 }

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -174,19 +174,71 @@ class EnrollmentIntegrationTest {
     }
 
     @Test
-    void enrollStudent_insufficientLevel_returns409() throws Exception {
+    void enrollStudent_insufficientLevel_returnsPendingApproval() throws Exception {
         Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
                 CourseLevel.ADVANCED, CourseType.PARTNER, 10, true, 2);
         entityManager.flush();
 
-        // Student has BEGINNER salsa level, course requires ADVANCED
+        // Student has BEGINNER salsa level, course requires ADVANCED → needs approval
         mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {"studentId": %d, "danceRole": "LEAD"}
                                 """.formatted(student.getId()))
                         .with(authentication(authToken(owner))))
-                .andExpect(status().isConflict());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"));
+    }
+
+    @Test
+    void enrollStudent_noLevelForStyle_returnsPendingApproval() throws Exception {
+        Course intermediateZouk = createCourse(school, "Zouk Intermediate", DanceStyle.ZOUK,
+                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 10, false, null);
+        entityManager.flush();
+
+        // Student has no ZOUK level at all → needs approval
+        mockMvc.perform(post("/api/courses/{id}/enrollments", intermediateZouk.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "FOLLOW"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"));
+    }
+
+    @Test
+    void enrollStudent_requiresApprovalFlag_returnsPendingApproval_evenWithMatchingLevel() throws Exception {
+        Course approvalCourse = createCourseWithApproval(school, "Bachata Approval", DanceStyle.BACHATA,
+                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 10, true);
+        entityManager.flush();
+
+        // Student has INTERMEDIATE bachata (matches course level), but requiresApproval=true
+        mockMvc.perform(post("/api/courses/{id}/enrollments", approvalCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"));
+    }
+
+    @Test
+    void enrollStudent_beginnerCourseWithRequiresApproval_bypassesApproval() throws Exception {
+        // Even with requiresApproval=true, BEGINNER courses skip approval
+        Course approvalBeginner = createCourseWithApproval(school, "Kizomba Beginner Approval",
+                DanceStyle.KIZOMBA, CourseLevel.BEGINNER, CourseType.PARTNER, 10, true);
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", approvalBeginner.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "FOLLOW"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
     }
 
     @Test
@@ -283,6 +335,159 @@ class EnrollmentIntegrationTest {
                 .andExpect(status().isConflict());
     }
 
+    // --- Approve / reject ---
+
+    @Test
+    void approve_transitionsToPendingPayment_setsApprovedAt_andUpgradesStudentLevel() throws Exception {
+        Long enrollmentId = createPendingApprovalForInsufficientLevel();
+
+        mockMvc.perform(put("/api/enrollments/{id}/approve", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Enrollment updated = entityManager.find(Enrollment.class, enrollmentId);
+        org.junit.jupiter.api.Assertions.assertNotNull(updated.getApprovedAt());
+
+        // Student had BEGINNER Salsa; approving an ADVANCED Salsa course should upgrade to ADVANCED
+        Student refreshed = entityManager.find(Student.class, student.getId());
+        CourseLevel salsaLevel = refreshed.getDanceLevels().stream()
+                .filter(dl -> dl.getDanceStyle() == DanceStyle.SALSA)
+                .map(StudentDanceLevel::getLevel)
+                .findFirst()
+                .orElse(null);
+        org.junit.jupiter.api.Assertions.assertEquals(CourseLevel.ADVANCED, salsaLevel);
+    }
+
+    @Test
+    void approve_doesNotDowngradeExistingHigherDanceLevel() throws Exception {
+        // Course is INTERMEDIATE bachata with requiresApproval=true; student has INTERMEDIATE bachata
+        // But to trigger PENDING_APPROVAL we need requiresApproval; and to test non-downgrade we use ADVANCED student
+        Student advancedStudent = createStudent(school, "Laura Advanced", "laura@example.com", null);
+        addDanceLevel(advancedStudent, DanceStyle.BACHATA, CourseLevel.ADVANCED);
+        Course approvalCourse = createCourseWithApproval(school, "Bachata Approval", DanceStyle.BACHATA,
+                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 10, true);
+        entityManager.flush();
+
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", approvalCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(advancedStudent.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long enrollmentId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
+
+        mockMvc.perform(put("/api/enrollments/{id}/approve", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Student refreshed = entityManager.find(Student.class, advancedStudent.getId());
+        CourseLevel bachataLevel = refreshed.getDanceLevels().stream()
+                .filter(dl -> dl.getDanceStyle() == DanceStyle.BACHATA)
+                .map(StudentDanceLevel::getLevel)
+                .findFirst()
+                .orElse(null);
+        org.junit.jupiter.api.Assertions.assertEquals(CourseLevel.ADVANCED, bachataLevel);
+    }
+
+    @Test
+    void reject_transitionsToRejected() throws Exception {
+        Long enrollmentId = createPendingApprovalForInsufficientLevel();
+
+        mockMvc.perform(put("/api/enrollments/{id}/reject", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REJECTED"));
+    }
+
+    @Test
+    void approve_onNonPendingApproval_returns409() throws Exception {
+        // soloCourse is BEGINNER → goes directly to PENDING_PAYMENT
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long enrollmentId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
+
+        mockMvc.perform(put("/api/enrollments/{id}/approve", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void reject_onNonPendingApproval_returns409() throws Exception {
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", soloCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long enrollmentId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
+
+        mockMvc.perform(put("/api/enrollments/{id}/reject", enrollmentId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void rejectedEnrollment_excludedFromCapacity_allowsReenrollment() throws Exception {
+        Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
+                CourseLevel.ADVANCED, CourseType.PARTNER, 10, true, 2);
+        entityManager.flush();
+
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long firstId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
+
+        mockMvc.perform(put("/api/enrollments/{id}/reject", firstId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk());
+
+        // Re-enroll the same student — should succeed with a new enrollment
+        String response2 = mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"))
+                .andReturn().getResponse().getContentAsString();
+        Long secondId = com.jayway.jsonpath.JsonPath.parse(response2).read("$.enrollmentId", Long.class);
+        org.junit.jupiter.api.Assertions.assertNotEquals(firstId, secondId);
+    }
+
+    @Test
+    void listEnrollments_includesStudentDanceLevel() throws Exception {
+        Long enrollmentId = createPendingApprovalForInsufficientLevel();
+
+        mockMvc.perform(get("/api/courses/{id}/enrollments",
+                        entityManager.find(Enrollment.class, enrollmentId).getCourse().getId())
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].studentDanceLevel").value("BEGINNER"));
+    }
+
     // --- Tenant isolation ---
 
     @Test
@@ -360,6 +565,29 @@ class EnrollmentIntegrationTest {
         entityManager.persist(member);
 
         return s;
+    }
+
+    private Course createCourseWithApproval(School s, String title, DanceStyle danceStyle, CourseLevel level,
+                                            CourseType courseType, int maxParticipants, boolean requiresApproval) {
+        Course c = createCourse(s, title, danceStyle, level, courseType, maxParticipants, false, null);
+        c.setRequiresApproval(requiresApproval);
+        return c;
+    }
+
+    private Long createPendingApprovalForInsufficientLevel() throws Exception {
+        Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
+                CourseLevel.ADVANCED, CourseType.PARTNER, 10, true, 2);
+        entityManager.flush();
+
+        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        return com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
     }
 
     private Course createCourse(School s, String title, DanceStyle danceStyle, CourseLevel level,

--- a/frontend/src/app/courses/enrollment.service.ts
+++ b/frontend/src/app/courses/enrollment.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../../environments/environment';
 export type EnrollmentStatus = 'PENDING_APPROVAL' | 'PENDING_PAYMENT' | 'CONFIRMED' | 'WAITLISTED' | 'REJECTED';
 export type DanceRole = 'LEAD' | 'FOLLOW';
 export type WaitlistReason = 'CAPACITY' | 'ROLE_IMBALANCE';
+export type CourseLevel = 'STARTER' | 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED' | 'MASTERCLASS';
 
 export interface EnrollmentListItem {
   id: number;
@@ -19,6 +20,7 @@ export interface EnrollmentListItem {
   paidAt: string | null;
   waitlistPosition: number | null;
   waitlistReason: WaitlistReason | null;
+  studentDanceLevel: CourseLevel | null;
 }
 
 export interface EnrollmentResponse {
@@ -45,5 +47,13 @@ export class EnrollmentService {
 
   markPaid(enrollmentId: number): Observable<EnrollmentResponse> {
     return this.http.put<EnrollmentResponse>(`${environment.apiUrl}/api/enrollments/${enrollmentId}/mark-paid`, null);
+  }
+
+  approve(enrollmentId: number): Observable<EnrollmentResponse> {
+    return this.http.put<EnrollmentResponse>(`${environment.apiUrl}/api/enrollments/${enrollmentId}/approve`, null);
+  }
+
+  reject(enrollmentId: number): Observable<EnrollmentResponse> {
+    return this.http.put<EnrollmentResponse>(`${environment.apiUrl}/api/enrollments/${enrollmentId}/reject`, null);
   }
 }

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -71,6 +71,7 @@
                   <th mat-header-cell *matHeaderCellDef>
                     @switch (activeTabIndex()) {
                       @case (0) { Paid }
+                      @case (2) { Level }
                       @case (3) { Approved on }
                       @default { }
                     }
@@ -78,6 +79,23 @@
                   <td mat-cell *matCellDef="let row">
                     @switch (activeTabIndex()) {
                       @case (0) { {{ formatEnrollmentDate(row.paidAt) }} }
+                      @case (2) {
+                        <div class="approve-cell">
+                          <span class="ds-chip" [ngClass]="levelChipClass(row.studentDanceLevel)">
+                            {{ formatLevel(row.studentDanceLevel) }}
+                          </span>
+                          <div class="approve-actions">
+                            <button mat-icon-button class="approve-button" aria-label="Approve enrollment"
+                                    matTooltip="Approve" (click)="onApprove(row.id)">
+                              <mat-icon>check_circle</mat-icon>
+                            </button>
+                            <button mat-icon-button class="reject-button" aria-label="Reject enrollment"
+                                    matTooltip="Reject" (click)="onReject(row.id)">
+                              <mat-icon>cancel</mat-icon>
+                            </button>
+                          </div>
+                        </div>
+                      }
                       @case (3) {
                         @if (row.approvedAt) {
                           {{ formatEnrollmentDate(row.approvedAt) }}

--- a/frontend/src/app/courses/overview/course-overview.scss
+++ b/frontend/src/app/courses/overview/course-overview.scss
@@ -97,6 +97,27 @@
   --mdc-outlined-button-label-text-size: var(--mat-sys-label-medium-size);
 }
 
+.approve-cell {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-spacing-3);
+}
+
+.approve-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-1);
+}
+
+.approve-button {
+  color: var(--ds-color-success);
+}
+
+.reject-button {
+  color: var(--mat-sys-error);
+}
+
 .enrollment-empty-state {
   display: flex;
   align-items: center;

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -5,6 +5,7 @@ import { provideHttpClientTesting, HttpTestingController } from '@angular/common
 import { CourseOverviewComponent } from './course-overview';
 import { ActivatedRoute } from '@angular/router';
 import { CourseDetail } from '../course.service';
+import { EnrollmentListItem } from '../enrollment.service';
 
 function makeCourseDetail(overrides: Partial<CourseDetail> = {}): CourseDetail {
   return {
@@ -125,5 +126,108 @@ describe('CourseOverviewComponent', () => {
 
     // No enrollment request should have been made — httpTesting.verify() in afterEach confirms this
     expect(el.querySelector('.enrollment-section')).toBeFalsy();
+  });
+
+  /** Flush the course detail request and the enrollment list with provided items. */
+  function flushCourseWithEnrollments(enrollments: EnrollmentListItem[], overrides: Partial<CourseDetail> = {}): void {
+    const course = makeCourseDetail(overrides);
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1') && !req.url.includes('enrollments')).flush(course);
+    httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush(enrollments);
+  }
+
+  function makeEnrollment(overrides: Partial<EnrollmentListItem> = {}): EnrollmentListItem {
+    return {
+      id: 1,
+      studentName: 'Anna Mueller',
+      studentEmail: 'anna@example.com',
+      studentPhoneNumber: '+41 79 100 0001',
+      danceRole: 'FOLLOW',
+      status: 'PENDING_APPROVAL',
+      enrolledAt: '2026-04-10T10:00:00Z',
+      approvedAt: null,
+      paidAt: null,
+      waitlistPosition: null,
+      waitlistReason: null,
+      studentDanceLevel: 'INTERMEDIATE',
+      ...overrides,
+    };
+  }
+
+  describe('Approve tab', () => {
+    it('renders PENDING_APPROVAL rows with level chip and action buttons', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([makeEnrollment()]);
+      fixture.detectChanges();
+
+      // Switch to the Approve tab (index 2)
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[2] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const row = el.querySelector('tr[mat-row]');
+      expect(row).toBeTruthy();
+      expect(row?.textContent).toContain('Anna Mueller');
+
+      const levelChip = row?.querySelector('.approve-cell .ds-chip');
+      expect(levelChip?.textContent?.trim()).toBe('Intermediate');
+      expect(levelChip?.classList.contains('ds-chip-primary')).toBe(true);
+
+      expect(row?.querySelector('button[aria-label="Approve enrollment"]')).toBeTruthy();
+      expect(row?.querySelector('button[aria-label="Reject enrollment"]')).toBeTruthy();
+    });
+
+    it('shows "No level" chip when studentDanceLevel is null', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([makeEnrollment({ studentDanceLevel: null })]);
+      fixture.detectChanges();
+
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[2] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const levelChip = el.querySelector('tr[mat-row] .approve-cell .ds-chip');
+      expect(levelChip?.textContent?.trim()).toBe('No level');
+    });
+
+    it('calls approve endpoint and refreshes list when approve clicked', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([makeEnrollment({ id: 42 })]);
+      fixture.detectChanges();
+
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[2] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const approveBtn = el.querySelector('button[aria-label="Approve enrollment"]') as HTMLButtonElement;
+      approveBtn.click();
+      fixture.detectChanges();
+
+      const approveReq = httpTesting.expectOne(req =>
+        req.url.includes('/api/enrollments/42/approve') && req.method === 'PUT');
+      approveReq.flush({ enrollmentId: 42, status: 'PENDING_PAYMENT' });
+
+      // List refresh: the component re-fetches enrollments
+      httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
+    });
+
+    it('calls reject endpoint and refreshes list when reject clicked', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([makeEnrollment({ id: 77 })]);
+      fixture.detectChanges();
+
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[2] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const rejectBtn = el.querySelector('button[aria-label="Reject enrollment"]') as HTMLButtonElement;
+      rejectBtn.click();
+      fixture.detectChanges();
+
+      const rejectReq = httpTesting.expectOne(req =>
+        req.url.includes('/api/enrollments/77/reject') && req.method === 'PUT');
+      rejectReq.flush({ enrollmentId: 77, status: 'REJECTED' });
+
+      httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
+    });
   });
 });

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -3,14 +3,16 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { NgClass, TitleCasePipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { HttpErrorResponse } from '@angular/common/http';
 import { CourseDetail, CourseService } from '../course.service';
 import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summary';
 import { EnrollmentListItem, EnrollmentService } from '../enrollment.service';
-import { formatDate, formatDayFull, formatTime, statusChipClass } from '../shared/format-utils';
+import { formatDate, formatDayFull, formatLevel, formatTime, levelChipClass, statusChipClass } from '../shared/format-utils';
 import { extractErrorMessage } from '../../shared/error-utils';
 
 interface EnrollmentTab {
@@ -29,7 +31,7 @@ const ENROLLMENT_TABS: EnrollmentTab[] = [
   selector: 'app-course-overview',
   imports: [
     RouterLink, NgClass, TitleCasePipe,
-    MatButtonModule, MatTableModule, MatTabsModule,
+    MatButtonModule, MatIconModule, MatTableModule, MatTabsModule, MatTooltipModule,
     CourseSummaryComponent,
   ],
   templateUrl: './course-overview.html',
@@ -118,6 +120,8 @@ export class CourseOverviewComponent implements OnInit {
   }
 
   protected statusChipClass = statusChipClass;
+  protected levelChipClass = levelChipClass;
+  protected formatLevel = formatLevel;
 
   protected selectTab(index: number): void {
     this.activeTabIndex.set(index);
@@ -143,6 +147,32 @@ export class CourseOverviewComponent implements OnInit {
       },
       error: (err: HttpErrorResponse) => {
         this.snackBar.open(extractErrorMessage(err, 'Failed to confirm payment'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+      },
+    });
+  }
+
+  protected onApprove(enrollmentId: number): void {
+    this.enrollmentService.approve(enrollmentId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.snackBar.open('Enrollment approved', 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        const courseId = this.course()?.id;
+        if (courseId) this.loadEnrollments(courseId);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.snackBar.open(extractErrorMessage(err, 'Failed to approve enrollment'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+      },
+    });
+  }
+
+  protected onReject(enrollmentId: number): void {
+    this.enrollmentService.reject(enrollmentId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.snackBar.open('Enrollment rejected', 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        const courseId = this.course()?.id;
+        if (courseId) this.loadEnrollments(courseId);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.snackBar.open(extractErrorMessage(err, 'Failed to reject enrollment'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
       },
     });
   }

--- a/frontend/src/app/courses/shared/format-utils.ts
+++ b/frontend/src/app/courses/shared/format-utils.ts
@@ -35,3 +35,21 @@ export function statusChipClass(status: string): string {
     default: return 'ds-chip-default';
   }
 }
+
+/** Map a dance level to its chip class. Null → neutral "No level" variant. */
+export function levelChipClass(level: string | null): string {
+  switch (level) {
+    case 'BEGINNER': return 'ds-chip-info';
+    case 'INTERMEDIATE': return 'ds-chip-primary';
+    case 'ADVANCED': return 'ds-chip-success';
+    case 'MASTERCLASS': return 'ds-chip-primary';
+    case 'STARTER':
+    default: return 'ds-chip-default';
+  }
+}
+
+/** Display label for a dance level; null becomes "No level". */
+export function formatLevel(level: string | null): string {
+  if (!level) return 'No level';
+  return level.charAt(0) + level.slice(1).toLowerCase();
+}


### PR DESCRIPTION
## Summary
- Booking logic resolves to `PENDING_APPROVAL` when a course has `requiresApproval=true` or the student lacks sufficient level for the course's style. STARTER/BEGINNER courses always bypass approval.
- New `PUT /api/enrollments/{id}/approve` and `/reject` endpoints transition `PENDING_APPROVAL` → `PENDING_PAYMENT` (with `approvedAt` + auto-upgrade of student dance level, never downgrade) or `REJECTED`.
- Capacity count now includes `PENDING_APPROVAL`; `REJECTED` stays excluded so rejected students can re-enroll.
- Frontend: Approve tab now renders pending-approval enrollments with a Level chip + approve/reject icon buttons; actions call the new endpoints and refresh.
- DevDataSeeder: Salsa Advanced is `requiresApproval=true` with two seeded `PENDING_APPROVAL` rows so the tab has content on startup.

Closes #250.

## Test plan
- [x] Backend integration tests (24 passing), covering: insufficient level → PENDING_APPROVAL, no-level-for-style → PENDING_APPROVAL, requiresApproval flag, BEGINNER/STARTER bypass, approve (level upgrade + no downgrade), reject, approve/reject on non-pending returns 409, REJECTED excluded from capacity, re-enrollment after rejection, listing includes studentDanceLevel
- [x] Frontend unit tests (68 passing), covering: Approve tab rendering, level chip, action buttons, approve/reject API calls + list refresh
- [x] Playwright visual: login, open Salsa Advanced → Approve tab shows two seeded rows with level chips; click approve → moves to Open Payment; click reject → row disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)