### PR TITLE
Route full-course approvals to waitlist; don't block applications

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -45,7 +45,13 @@ public class EnrollmentService {
 
         validateDanceRole(course, dto.danceRole());
         validateNoDuplicate(student.getId(), course.getId());
-        validateCapacity(course);
+
+        EnrollmentStatus status = resolveBookingStatus(course, student);
+        if (status == EnrollmentStatus.PENDING_PAYMENT) {
+            // Only the committed (direct-pay) path is capped by capacity at enroll time.
+            // PENDING_APPROVAL applicants queue up for owner review; approve-time rechecks capacity.
+            validateCapacity(course);
+        }
 
         SchoolMember enrolledBy = schoolMemberService.findByUserIdAndSchoolId(userId, school.getId())
                 .orElse(null);
@@ -54,7 +60,7 @@ public class EnrollmentService {
         enrollment.setStudent(student);
         enrollment.setCourse(course);
         enrollment.setDanceRole(dto.danceRole());
-        enrollment.setStatus(resolveBookingStatus(course, student));
+        enrollment.setStatus(status);
         enrollment.setEnrolledAt(Instant.now(clock));
         enrollment.setEnrolledBy(enrolledBy);
 
@@ -90,11 +96,21 @@ public class EnrollmentService {
             throw new DomainRuleViolationException("Enrollment is not pending approval");
         }
 
-        enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
         enrollment.setApprovedAt(Instant.now(clock));
 
         Course course = enrollment.getCourse();
         upsertStudentDanceLevel(enrollment.getStudent(), course.getDanceStyle(), course.getLevel());
+
+        // If the course is already full of committed enrollments, route the approval to the waitlist.
+        long committedCount = enrollmentRepository.countByCourseIdAndStatusIn(
+                course.getId(),
+                List.of(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.CONFIRMED));
+        if (committedCount >= course.getMaxParticipants()) {
+            enrollment.setStatus(EnrollmentStatus.WAITLISTED);
+            enrollment.setWaitlistReason(WaitlistReason.CAPACITY);
+        } else {
+            enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
+        }
 
         return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
     }
@@ -154,11 +170,11 @@ public class EnrollmentService {
     }
 
     private void validateCapacity(Course course) {
+        // Only count committed seats. PENDING_APPROVAL applicants do not reserve capacity —
+        // the approve step re-checks and routes to WAITLISTED if the course has since filled.
         long activeCount = enrollmentRepository.countByCourseIdAndStatusIn(
                 course.getId(),
-                List.of(EnrollmentStatus.PENDING_APPROVAL,
-                        EnrollmentStatus.PENDING_PAYMENT,
-                        EnrollmentStatus.CONFIRMED));
+                List.of(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.CONFIRMED));
         if (activeCount >= course.getMaxParticipants()) {
             throw new DomainRuleViolationException("Course is at capacity");
         }

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -338,6 +338,98 @@ class EnrollmentIntegrationTest {
     // --- Approve / reject ---
 
     @Test
+    void enroll_withPendingApprovalApplicants_doesNotBlockCommittedEnrollment() throws Exception {
+        // Course with capacity 2, no requiresApproval, ADVANCED level.
+        Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
+                CourseLevel.ADVANCED, CourseType.PARTNER, 2, true, 1);
+        entityManager.flush();
+
+        // student (BEGINNER salsa) → PENDING_APPROVAL; should NOT reserve a seat.
+        mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"));
+
+        // Two matching-level students can still take both direct-pay seats.
+        Student qualified1 = createStudent(school, "Q1", "q1@example.com", null);
+        addDanceLevel(qualified1, DanceStyle.SALSA, CourseLevel.ADVANCED);
+        Student qualified2 = createStudent(school, "Q2", "q2@example.com", null);
+        addDanceLevel(qualified2, DanceStyle.SALSA, CourseLevel.ADVANCED);
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "FOLLOW"}
+                                """.formatted(qualified1.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(qualified2.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+    }
+
+    @Test
+    void approve_whenCourseFull_routesToWaitlistWithCapacityReason() throws Exception {
+        // Course capacity 1, ADVANCED salsa.
+        Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
+                CourseLevel.ADVANCED, CourseType.PARTNER, 1, true, 1);
+        entityManager.flush();
+
+        // Fill the one seat with a qualified direct-pay student.
+        Student qualified = createStudent(school, "Qualified", "qualified@example.com", null);
+        addDanceLevel(qualified, DanceStyle.SALSA, CourseLevel.ADVANCED);
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(qualified.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+
+        // Under-leveled student enrolls → PENDING_APPROVAL.
+        String pendingResponse = mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "FOLLOW"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"))
+                .andReturn().getResponse().getContentAsString();
+        Long pendingId = com.jayway.jsonpath.JsonPath.parse(pendingResponse).read("$.enrollmentId", Long.class);
+
+        // Approve: course is at capacity → WAITLISTED with reason CAPACITY.
+        mockMvc.perform(put("/api/enrollments/{id}/approve", pendingId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("WAITLISTED"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Enrollment updated = entityManager.find(Enrollment.class, pendingId);
+        org.junit.jupiter.api.Assertions.assertEquals(EnrollmentStatus.WAITLISTED, updated.getStatus());
+        org.junit.jupiter.api.Assertions.assertEquals(WaitlistReason.CAPACITY, updated.getWaitlistReason());
+        // approvedAt is still set — approval decision is separate from slot outcome.
+        org.junit.jupiter.api.Assertions.assertNotNull(updated.getApprovedAt());
+    }
+
+    @Test
     void approve_transitionsToPendingPayment_setsApprovedAt_andUpgradesStudentLevel() throws Exception {
         Long enrollmentId = createPendingApprovalForInsufficientLevel();
 

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -154,8 +154,11 @@ export class CourseOverviewComponent implements OnInit {
 
   protected onApprove(enrollmentId: number): void {
     this.enrollmentService.approve(enrollmentId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: () => {
-        this.snackBar.open('Enrollment approved', 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+      next: (response) => {
+        const message = response.status === 'WAITLISTED'
+          ? 'Approved — course is full, moved to waitlist'
+          : 'Enrollment approved';
+        this.snackBar.open(message, 'Close', { duration: 4000, panelClass: 'snackbar-success' });
         const courseId = this.course()?.id;
         if (courseId) this.loadEnrollments(courseId);
       },


### PR DESCRIPTION
## Summary
Follow-up to #265. Fixes two related issues with approval + capacity:

- **Before:** PENDING_APPROVAL counted toward capacity. A selective (`requiresApproval`) course couldn't collect more applications than it had seats — owners couldn't curate.
- **Before:** An under-leveled student applying to a full course was blocked with 409, even though their application would have gone to PENDING_APPROVAL.
- **Now:** Enroll-time capacity check only fires when the resolved status is PENDING_PAYMENT. PENDING_APPROVAL applicants skip the check and queue for owner review.
- **Now:** `/approve` rechecks committed-seat count (PP + CONFIRMED). If the course has filled between application and approval, the enrollment is routed to `WAITLISTED` with `waitlistReason = CAPACITY`. `approvedAt` is still set — approval is a capability decision, waitlist is a slot outcome.

Frontend snackbar reflects the routing: "Approved — course is full, moved to waitlist" vs "Enrollment approved".

## Test plan
- [x] Backend integration (26 passing), new tests cover: PENDING_APPROVAL applicants don't block committed direct-pay enrollments; approving a full course routes to WAITLISTED with reason=CAPACITY and still sets approvedAt
- [x] Frontend unit tests (75 passing)

## Note on waitlist position
`waitlistPosition` is left null here. Actual waitlist management (positioning, promotion) is scoped to #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)