### PR TITLE
Slugify name fragments in Dev Tools email generator

### DIFF
--- a/frontend/src/app/dev-tools/dev-tools.ts
+++ b/frontend/src/app/dev-tools/dev-tools.ts
@@ -21,6 +21,8 @@ const FIRST_NAMES = ['Anna', 'Marco', 'Laura', 'David', 'Sofia', 'Jan', 'Yuki', 
 const LAST_NAMES = ['Mueller', 'Rossi', 'Weber', 'Kim', 'Martinez', 'de Vries', 'Tanaka', 'Fischer', 'Bauer', 'Schmidt',
   'Meier', 'Huber', 'Keller', 'Wagner', 'Braun', 'Steiner', 'Frey', 'Berger', 'Hess', 'Maurer'];
 
+const slugify = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
 @Component({
   selector: 'app-dev-tools',
   imports: [
@@ -225,7 +227,7 @@ export class DevToolsComponent implements OnInit {
     const firstName = FIRST_NAMES[Math.floor(Math.random() * FIRST_NAMES.length)];
     const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)];
     const name = `${firstName} ${lastName}`;
-    const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}.${Date.now()}.${this.studentCounter++}@test.com`;
+    const email = `${slugify(firstName)}.${slugify(lastName)}.${Date.now()}.${this.studentCounter++}@test.com`;
 
     return this.http.post<{ id: number }>(`${environment.apiUrl}/api/students`, { name, email });
   }


### PR DESCRIPTION
## Summary
- Fix the `/api/students` 400 "not a valid email" that Fill Course occasionally hit
- Root cause: `LAST_NAMES` contains `'de Vries'` (space). With `lastName.toLowerCase()` embedded directly in the email local part, the result was e.g. `anna.de vries.1760828876431.5@test.com` — invalid per the backend's `@Email` check
- `slugify()` normalises whitespace (and any other non-`[a-z0-9]` char) to hyphens before the fragments go into the email. The displayed `name` still uses the original spelling
- Protects against someone adding another name with a space / umlaut / diacritic later

Fixes #267

## Test plan
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] Manual: Fill Course 16 seats → no 400s

🤖 Generated with [Claude Code](https://claude.com/claude-code)