### PR TITLE
Polish enrollment tables on course overview (#266)

### DIFF
--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -33,100 +33,111 @@
         </nav>
 
         <mat-tab-nav-panel #enrollmentTabPanel>
-          @if (activeTabData().length > 0) {
-            <div class="ds-table-card enrollment-table">
-              <table mat-table [dataSource]="activeTabData()">
-                <!-- Name Column -->
-                <ng-container matColumnDef="name">
-                  <th mat-header-cell *matHeaderCellDef>Name</th>
-                  <td mat-cell *matCellDef="let row" class="cell-name">{{ row.studentName }}</td>
-                </ng-container>
+          <div class="ds-table-card enrollment-table">
+            <table mat-table [dataSource]="activeTabData()">
+              <!-- Name Column -->
+              <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef>Name</th>
+                <td mat-cell *matCellDef="let row">{{ row.studentName }}</td>
+              </ng-container>
 
-                <!-- Phone Column -->
-                <ng-container matColumnDef="phone">
-                  <th mat-header-cell *matHeaderCellDef>Phone Number</th>
-                  <td mat-cell *matCellDef="let row">{{ row.studentPhoneNumber || '—' }}</td>
-                </ng-container>
+              <!-- Phone Column -->
+              <ng-container matColumnDef="phone">
+                <th mat-header-cell *matHeaderCellDef>Phone Number</th>
+                <td mat-cell *matCellDef="let row">{{ row.studentPhoneNumber || '—' }}</td>
+              </ng-container>
 
-                <!-- Role Column -->
-                <ng-container matColumnDef="role">
-                  <th mat-header-cell *matHeaderCellDef>Role</th>
-                  <td mat-cell *matCellDef="let row">
-                    @if (row.danceRole) {
-                      <span class="ds-chip ds-chip-default">{{ formatRole(row.danceRole) }}</span>
-                    } @else {
-                      —
-                    }
-                  </td>
-                </ng-container>
+              <!-- Role Column -->
+              <ng-container matColumnDef="role">
+                <th mat-header-cell *matHeaderCellDef>Role</th>
+                <td mat-cell *matCellDef="let row">
+                  @if (row.danceRole) {
+                    <span class="ds-chip ds-chip-default">{{ formatRole(row.danceRole) }}</span>
+                  } @else {
+                    —
+                  }
+                </td>
+              </ng-container>
 
-                <!-- Enrolled on Column -->
-                <ng-container matColumnDef="enrolledAt">
-                  <th mat-header-cell *matHeaderCellDef>Enrolled on</th>
-                  <td mat-cell *matCellDef="let row">{{ formatEnrollmentDate(row.enrolledAt) }}</td>
-                </ng-container>
+              <!-- Status Column -->
+              <ng-container matColumnDef="status">
+                <th mat-header-cell *matHeaderCellDef>Status</th>
+                <td mat-cell *matCellDef="let row">
+                  <span class="ds-chip" [ngClass]="enrollmentStatusChipClass(row.status)">
+                    {{ formatEnrollmentStatus(row.status) }}
+                  </span>
+                </td>
+              </ng-container>
 
-                <!-- Last Column (varies by tab) -->
-                <ng-container matColumnDef="lastColumn">
-                  <th mat-header-cell *matHeaderCellDef>
-                    @switch (activeTabIndex()) {
-                      @case (0) { Paid }
-                      @case (2) { Level }
-                      @case (3) { Approved on }
-                      @default { }
-                    }
-                  </th>
-                  <td mat-cell *matCellDef="let row">
-                    @switch (activeTabIndex()) {
-                      @case (0) { {{ formatEnrollmentDate(row.paidAt) }} }
-                      @case (2) {
-                        <div class="approve-cell">
-                          <span class="ds-chip" [ngClass]="levelChipClass(row.studentDanceLevel)">
-                            {{ formatLevel(row.studentDanceLevel) }}
-                          </span>
-                          <div class="approve-actions">
-                            <button mat-icon-button class="approve-button" aria-label="Approve enrollment"
-                                    matTooltip="Approve" (click)="onApprove(row.id)">
-                              <mat-icon>check_circle</mat-icon>
-                            </button>
-                            <button mat-icon-button class="reject-button" aria-label="Reject enrollment"
-                                    matTooltip="Reject" (click)="onReject(row.id)">
-                              <mat-icon>cancel</mat-icon>
-                            </button>
-                          </div>
-                        </div>
-                      }
-                      @case (3) {
-                        @if (row.approvedAt) {
-                          {{ formatEnrollmentDate(row.approvedAt) }}
-                        } @else {
-                          <button mat-stroked-button class="mark-paid-button" (click)="onMarkPaid(row.id)">
-                            Mark Paid
+              <!-- Enrolled on Column -->
+              <ng-container matColumnDef="enrolledAt">
+                <th mat-header-cell *matHeaderCellDef>Enrolled on</th>
+                <td mat-cell *matCellDef="let row">{{ formatEnrollmentDate(row.enrolledAt) }}</td>
+              </ng-container>
+
+              <!-- Last Column (varies by tab) -->
+              <ng-container matColumnDef="lastColumn">
+                <th mat-header-cell *matHeaderCellDef>
+                  @switch (activeTabIndex()) {
+                    @case (0) { Paid }
+                    @case (2) { Level }
+                    @case (3) { Approved on }
+                    @default { }
+                  }
+                </th>
+                <td mat-cell *matCellDef="let row">
+                  @switch (activeTabIndex()) {
+                    @case (0) { {{ formatEnrollmentDate(row.paidAt) }} }
+                    @case (2) {
+                      <div class="approve-cell">
+                        <span class="ds-chip" [ngClass]="levelChipClass(row.studentDanceLevel)">
+                          {{ formatLevel(row.studentDanceLevel) }}
+                        </span>
+                        <div class="approve-actions">
+                          <button mat-icon-button class="approve-button" aria-label="Approve enrollment"
+                                  matTooltip="Approve" (click)="onApprove(row.id)">
+                            <mat-icon>check_circle</mat-icon>
                           </button>
-                        }
+                          <button mat-icon-button class="reject-button" aria-label="Reject enrollment"
+                                  matTooltip="Reject" (click)="onReject(row.id)">
+                            <mat-icon>cancel</mat-icon>
+                          </button>
+                        </div>
+                      </div>
+                    }
+                    @case (3) {
+                      @if (row.approvedAt) {
+                        {{ formatEnrollmentDate(row.approvedAt) }}
+                      } @else {
+                        <button mat-stroked-button class="mark-paid-button" (click)="onMarkPaid(row.id)">
+                          Mark Paid
+                        </button>
                       }
                     }
-                  </td>
-                </ng-container>
+                  }
+                </td>
+              </ng-container>
 
-                <tr mat-header-row *matHeaderRowDef="enrollmentColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: enrollmentColumns;"></tr>
-              </table>
+              <!-- Empty state row, rendered when data source is empty -->
+              <tr class="mat-mdc-row empty-row" *matNoDataRow>
+                <td class="mat-mdc-cell empty-cell" [attr.colspan]="enrollmentColumns.length">
+                  @switch (activeTabIndex()) {
+                    @case (0) { No enrolled students yet }
+                    @case (1) { No students on the waitlist }
+                    @case (2) { No students pending approval }
+                    @case (3) { No students with open payments }
+                  }
+                </td>
+              </tr>
 
-              <div class="ds-table-footer">
-                Showing {{ activeTabData().length }} of {{ activeTabData().length }}
-              </div>
+              <tr mat-header-row *matHeaderRowDef="enrollmentColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: enrollmentColumns;"></tr>
+            </table>
+
+            <div class="ds-table-footer">
+              Showing {{ activeTabData().length }} of {{ activeTabData().length }}
             </div>
-          } @else {
-            <div class="enrollment-empty-state">
-              @switch (activeTabIndex()) {
-                @case (0) { No enrolled students yet }
-                @case (1) { No students on the waitlist }
-                @case (2) { No students pending approval }
-                @case (3) { No students with open payments }
-              }
-            </div>
-          }
+          </div>
         </mat-tab-nav-panel>
       </div>
     }

--- a/frontend/src/app/courses/overview/course-overview.scss
+++ b/frontend/src/app/courses/overview/course-overview.scss
@@ -74,10 +74,9 @@
 }
 
 .enrollment-table {
-  // Column widths matching Figma: Name 260, Phone 200, Role 120, Enrolled on 180, rest flexible
+  // Column widths matching Figma: Name 260, Phone 200, Role 120, Status 140, Enrolled on 180, rest flexible
   .mat-column-name {
     width: 260px;
-    font-weight: 600;
   }
 
   .mat-column-phone {
@@ -88,9 +87,26 @@
     width: 120px;
   }
 
+  .mat-column-status {
+    width: 170px;
+
+    .ds-chip {
+      white-space: nowrap;
+    }
+  }
+
   .mat-column-enrolledAt {
     width: 180px;
   }
+}
+
+.empty-row {
+  height: 56px;
+}
+
+.empty-cell {
+  text-align: center;
+  color: var(--mat-sys-on-surface-variant);
 }
 
 .mark-paid-button {
@@ -118,14 +134,3 @@
   color: var(--mat-sys-error);
 }
 
-.enrollment-empty-state {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--ds-spacing-12) var(--ds-spacing-6);
-  font: var(--mat-sys-body-large);
-  color: var(--mat-sys-on-surface-variant);
-  background: var(--mat-sys-surface);
-  border: 1px solid var(--mat-sys-outline-variant);
-  border-radius: var(--ds-radius-lg);
-}

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -12,7 +12,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { CourseDetail, CourseService } from '../course.service';
 import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summary';
 import { EnrollmentListItem, EnrollmentService } from '../enrollment.service';
-import { formatDate, formatDayFull, formatLevel, formatTime, levelChipClass, statusChipClass } from '../shared/format-utils';
+import { enrollmentStatusChipClass, formatDate, formatDayFull, formatEnrollmentStatus, formatLevel, formatTime, levelChipClass, statusChipClass } from '../shared/format-utils';
 import { extractErrorMessage } from '../../shared/error-utils';
 
 interface EnrollmentTab {
@@ -53,7 +53,7 @@ export class CourseOverviewComponent implements OnInit {
   protected activeTabIndex = signal(0);
 
   protected readonly tabs = ENROLLMENT_TABS;
-  protected readonly enrollmentColumns = ['name', 'phone', 'role', 'enrolledAt', 'lastColumn'];
+  protected readonly enrollmentColumns = ['name', 'phone', 'role', 'status', 'enrolledAt', 'lastColumn'];
 
   protected enrolledList = computed(() =>
     this.enrollments().filter(e => e.status === 'CONFIRMED'));
@@ -123,6 +123,8 @@ export class CourseOverviewComponent implements OnInit {
   protected statusChipClass = statusChipClass;
   protected levelChipClass = levelChipClass;
   protected formatLevel = formatLevel;
+  protected enrollmentStatusChipClass = enrollmentStatusChipClass;
+  protected formatEnrollmentStatus = formatEnrollmentStatus;
 
   protected selectTab(index: number): void {
     this.activeTabIndex.set(index);

--- a/frontend/src/app/courses/shared/format-utils.spec.ts
+++ b/frontend/src/app/courses/shared/format-utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatDayShort, formatDayFull, formatTime } from './format-utils';
+import { enrollmentStatusChipClass, formatDate, formatDayShort, formatDayFull, formatEnrollmentStatus, formatTime } from './format-utils';
 
 describe('formatDate', () => {
   it('formats ISO date to European format', () => {
@@ -34,5 +34,32 @@ describe('formatDayFull', () => {
 describe('formatTime', () => {
   it('strips seconds from time', () => {
     expect(formatTime('19:30:00')).toBe('19:30');
+  });
+});
+
+describe('enrollmentStatusChipClass', () => {
+  it('maps CONFIRMED to success', () => {
+    expect(enrollmentStatusChipClass('CONFIRMED')).toBe('ds-chip-success');
+  });
+
+  it('maps PENDING_PAYMENT to info', () => {
+    expect(enrollmentStatusChipClass('PENDING_PAYMENT')).toBe('ds-chip-info');
+  });
+
+  it('maps other statuses to default', () => {
+    expect(enrollmentStatusChipClass('WAITLISTED')).toBe('ds-chip-default');
+    expect(enrollmentStatusChipClass('PENDING_APPROVAL')).toBe('ds-chip-default');
+    expect(enrollmentStatusChipClass('REJECTED')).toBe('ds-chip-default');
+  });
+});
+
+describe('formatEnrollmentStatus', () => {
+  it('replaces underscores with spaces', () => {
+    expect(formatEnrollmentStatus('PENDING_PAYMENT')).toBe('PENDING PAYMENT');
+    expect(formatEnrollmentStatus('PENDING_APPROVAL')).toBe('PENDING APPROVAL');
+  });
+
+  it('leaves single-word statuses unchanged', () => {
+    expect(formatEnrollmentStatus('CONFIRMED')).toBe('CONFIRMED');
   });
 });

--- a/frontend/src/app/courses/shared/format-utils.ts
+++ b/frontend/src/app/courses/shared/format-utils.ts
@@ -53,3 +53,17 @@ export function formatLevel(level: string | null): string {
   if (!level) return 'No level';
   return level.charAt(0) + level.slice(1).toLowerCase();
 }
+
+/** Map an enrollment status to its chip class. */
+export function enrollmentStatusChipClass(status: string): string {
+  switch (status) {
+    case 'CONFIRMED': return 'ds-chip-success';
+    case 'PENDING_PAYMENT': return 'ds-chip-info';
+    default: return 'ds-chip-default';
+  }
+}
+
+/** Human-friendly label for an enrollment status (e.g. "PENDING_PAYMENT" → "PENDING PAYMENT"). */
+export function formatEnrollmentStatus(status: string): string {
+  return status.replace(/_/g, ' ');
+}

--- a/frontend/src/app/dev-tools/dev-tools.html
+++ b/frontend/src/app/dev-tools/dev-tools.html
@@ -86,9 +86,7 @@
           <ng-container matColumnDef="status">
             <th mat-header-cell *matHeaderCellDef>Status</th>
             <td mat-cell *matCellDef="let row">
-              <span class="ds-chip" [class.ds-chip-success]="row.status === 'CONFIRMED'"
-                    [class.ds-chip-info]="row.status === 'PENDING_PAYMENT'"
-                    [class.ds-chip-default]="row.status !== 'CONFIRMED' && row.status !== 'PENDING_PAYMENT'">
+              <span class="ds-chip" [ngClass]="enrollmentStatusChipClass(row.status)">
                 {{ formatStatus(row.status) }}
               </span>
             </td>

--- a/frontend/src/app/dev-tools/dev-tools.ts
+++ b/frontend/src/app/dev-tools/dev-tools.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HttpClient } from '@angular/common/http';
-import { LowerCasePipe } from '@angular/common';
+import { LowerCasePipe, NgClass } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -15,6 +15,7 @@ import { concat, EMPTY, Observable, of, switchMap, tap, toArray } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { CourseDetail, CourseListItem, CourseService } from '../courses/course.service';
 import { EnrollmentListItem, EnrollmentService, EnrollStudentRequest } from '../courses/enrollment.service';
+import { enrollmentStatusChipClass, formatEnrollmentStatus } from '../courses/shared/format-utils';
 
 const FIRST_NAMES = ['Anna', 'Marco', 'Laura', 'David', 'Sofia', 'Jan', 'Yuki', 'Elena', 'Thomas', 'Mia',
   'Lukas', 'Sarah', 'Alex', 'Nina', 'Felix', 'Julia', 'Max', 'Lena', 'Tobias', 'Clara'];
@@ -26,7 +27,7 @@ const slugify = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').repla
 @Component({
   selector: 'app-dev-tools',
   imports: [
-    LowerCasePipe, FormsModule, MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule,
+    LowerCasePipe, NgClass, FormsModule, MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule,
     MatSelectModule, MatTableModule, MatProgressSpinnerModule,
   ],
   templateUrl: './dev-tools.html',
@@ -186,9 +187,8 @@ export class DevToolsComponent implements OnInit {
     });
   }
 
-  protected formatStatus(status: string): string {
-    return status.replace(/_/g, ' ');
-  }
+  protected formatStatus = formatEnrollmentStatus;
+  protected enrollmentStatusChipClass = enrollmentStatusChipClass;
 
   protected formatRole(role: string | null): string {
     if (!role) return '—';


### PR DESCRIPTION
Closes #266.

## Summary
- Drop the bolder Name column override so cells match the shared `.ds-table-card` style (Courses list parity).
- Keep the table chrome and headers visible on empty tabs; render the empty message as a single `*matNoDataRow` row inside the tbody instead of a separate card.
- Add a Status column with the same chip the Dev Tools page uses. Extract `enrollmentStatusChipClass` + `formatEnrollmentStatus` helpers into `format-utils.ts` and reuse them in Dev Tools.

## Test plan
- [x] `ng build` passes
- [x] `npx ng test --browsers chromium --no-watch` — 80/80 pass (adds 5 helper assertions)
- [x] Visual verification across all 4 tabs (Enrolled populated, Waitlist/Approve empty, Open Payment populated) — Name column matches other cells, empty state renders as a table row, Status chip visible on every row
- [x] Dev Tools page still renders correctly after the helper refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)