### PR TITLE
Add waitlist flow: capacity, role imbalance, FIFO positioning (#251)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
@@ -13,5 +13,11 @@ interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     long countByCourseIdAndStatusIn(Long courseId, List<EnrollmentStatus> statuses);
 
+    long countByCourseIdAndDanceRoleAndStatusIn(Long courseId, DanceRole danceRole, List<EnrollmentStatus> statuses);
+
+    long countByCourseIdAndStatus(Long courseId, EnrollmentStatus status);
+
+    long countByCourseIdAndStatusAndDanceRole(Long courseId, EnrollmentStatus status, DanceRole danceRole);
+
     boolean existsByStudentIdAndCourseIdAndStatusNot(Long studentId, Long courseId, EnrollmentStatus status);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -29,6 +29,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EnrollmentService {
 
+    private static final List<EnrollmentStatus> COMMITTED_STATUSES = List.of(
+            EnrollmentStatus.PENDING_PAYMENT,
+            EnrollmentStatus.CONFIRMED);
+
     private final EnrollmentRepository enrollmentRepository;
     private final SchoolService schoolService;
     private final CourseService courseService;
@@ -46,13 +50,6 @@ public class EnrollmentService {
         validateDanceRole(course, dto.danceRole());
         validateNoDuplicate(student.getId(), course.getId());
 
-        EnrollmentStatus status = resolveBookingStatus(course, student);
-        if (status == EnrollmentStatus.PENDING_PAYMENT) {
-            // Only the committed (direct-pay) path is capped by capacity at enroll time.
-            // PENDING_APPROVAL applicants queue up for owner review; approve-time rechecks capacity.
-            validateCapacity(course);
-        }
-
         SchoolMember enrolledBy = schoolMemberService.findByUserIdAndSchoolId(userId, school.getId())
                 .orElse(null);
 
@@ -60,12 +57,27 @@ public class EnrollmentService {
         enrollment.setStudent(student);
         enrollment.setCourse(course);
         enrollment.setDanceRole(dto.danceRole());
-        enrollment.setStatus(status);
         enrollment.setEnrolledAt(Instant.now(clock));
         enrollment.setEnrolledBy(enrolledBy);
 
+        EnrollmentStatus bookingStatus = resolveBookingStatus(course, student);
+        // PENDING_APPROVAL applicants queue for owner review — they don't reserve seats at enroll time,
+        // so capacity / role-balance only gate the committed (direct-pay) path. Approval re-checks capacity.
+        WaitlistDecision waitlist = (bookingStatus == EnrollmentStatus.PENDING_PAYMENT)
+                ? resolveWaitlist(course, dto.danceRole())
+                : null;
+        if (waitlist != null) {
+            enrollment.setStatus(EnrollmentStatus.WAITLISTED);
+            enrollment.setWaitlistReason(waitlist.reason());
+            enrollment.setWaitlistPosition(waitlist.position());
+        } else {
+            enrollment.setStatus(bookingStatus);
+        }
+
         enrollmentRepository.save(enrollment);
-        course.setEnrolledStudents(course.getEnrolledStudents() + 1);
+        if (enrollment.getStatus() != EnrollmentStatus.WAITLISTED) {
+            course.setEnrolledStudents(course.getEnrolledStudents() + 1);
+        }
         return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
     }
 
@@ -101,13 +113,13 @@ public class EnrollmentService {
         Course course = enrollment.getCourse();
         upsertStudentDanceLevel(enrollment.getStudent(), course.getDanceStyle(), course.getLevel());
 
-        // If the course is already full of committed enrollments, route the approval to the waitlist.
+        // If the course filled up between application and approval, route to the waitlist.
         long committedCount = enrollmentRepository.countByCourseIdAndStatusIn(
-                course.getId(),
-                List.of(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.CONFIRMED));
+                course.getId(), COMMITTED_STATUSES);
         if (committedCount >= course.getMaxParticipants()) {
             enrollment.setStatus(EnrollmentStatus.WAITLISTED);
             enrollment.setWaitlistReason(WaitlistReason.CAPACITY);
+            enrollment.setWaitlistPosition(nextPosition(course.getId(), enrollment.getDanceRole()));
         } else {
             enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
         }
@@ -169,15 +181,37 @@ public class EnrollmentService {
         }
     }
 
-    private void validateCapacity(Course course) {
-        // Only count committed seats. PENDING_APPROVAL applicants do not reserve capacity —
-        // the approve step re-checks and routes to WAITLISTED if the course has since filled.
-        long activeCount = enrollmentRepository.countByCourseIdAndStatusIn(
-                course.getId(),
-                List.of(EnrollmentStatus.PENDING_PAYMENT, EnrollmentStatus.CONFIRMED));
-        if (activeCount >= course.getMaxParticipants()) {
-            throw new DomainRuleViolationException("Course is at capacity");
+    private WaitlistDecision resolveWaitlist(Course course, DanceRole role) {
+        long committed = enrollmentRepository.countByCourseIdAndStatusIn(course.getId(), COMMITTED_STATUSES);
+        if (committed >= course.getMaxParticipants()) {
+            return new WaitlistDecision(WaitlistReason.CAPACITY, nextPosition(course.getId(), role));
         }
+
+        if (course.getCourseType() == CourseType.PARTNER
+                && course.isRoleBalancingEnabled()
+                && course.getRoleBalanceThreshold() != null
+                && role != null) {
+            DanceRole other = (role == DanceRole.LEAD) ? DanceRole.FOLLOW : DanceRole.LEAD;
+            long myCount = enrollmentRepository.countByCourseIdAndDanceRoleAndStatusIn(
+                    course.getId(), role, COMMITTED_STATUSES);
+            long otherCount = enrollmentRepository.countByCourseIdAndDanceRoleAndStatusIn(
+                    course.getId(), other, COMMITTED_STATUSES);
+            if ((myCount + 1) > otherCount + course.getRoleBalanceThreshold()) {
+                return new WaitlistDecision(WaitlistReason.ROLE_IMBALANCE, nextPosition(course.getId(), role));
+            }
+        }
+
+        return null;
+    }
+
+    private int nextPosition(Long courseId, DanceRole role) {
+        long existing = (role == null)
+                ? enrollmentRepository.countByCourseIdAndStatus(courseId, EnrollmentStatus.WAITLISTED)
+                : enrollmentRepository.countByCourseIdAndStatusAndDanceRole(courseId, EnrollmentStatus.WAITLISTED, role);
+        return (int) existing + 1;
+    }
+
+    private record WaitlistDecision(WaitlistReason reason, int position) {
     }
 
     private EnrollmentStatus resolveBookingStatus(Course course, Student student) {

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -146,12 +146,13 @@ class EnrollmentIntegrationTest {
     }
 
     @Test
-    void enrollStudent_atCapacity_returns409() throws Exception {
+    void enrollStudent_atCapacity_returnsWaitlisted_withCapacityReason_andFifoPosition() throws Exception {
         Course tinyCourse = createCourse(school, "Tiny Course", DanceStyle.SALSA,
                 CourseLevel.BEGINNER, CourseType.SOLO, 1, false, null);
         entityManager.flush();
 
         Student student2 = createStudent(school, "Marco Rossi", "marco@example.com", null);
+        Student student3 = createStudent(school, "Laura Weber", "laura@example.com", null);
         entityManager.flush();
 
         // Fill the one spot
@@ -161,16 +162,175 @@ class EnrollmentIntegrationTest {
                                 {"studentId": %d}
                                 """.formatted(student.getId()))
                         .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
+
+        // Second student goes to waitlist with CAPACITY reason and position 1
+        String resp2 = mockMvc.perform(post("/api/courses/{id}/enrollments", tinyCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student2.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("WAITLISTED"))
+                .andReturn().getResponse().getContentAsString();
+
+        Long waitlistedId = com.jayway.jsonpath.JsonPath.parse(resp2).read("$.enrollmentId", Long.class);
+        entityManager.flush();
+        entityManager.clear();
+        Enrollment waitlisted = entityManager.find(Enrollment.class, waitlistedId);
+        org.junit.jupiter.api.Assertions.assertEquals(WaitlistReason.CAPACITY, waitlisted.getWaitlistReason());
+        org.junit.jupiter.api.Assertions.assertEquals(1, waitlisted.getWaitlistPosition());
+
+        // Third student: waitlist position 2
+        String resp3 = mockMvc.perform(post("/api/courses/{id}/enrollments", tinyCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student3.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("WAITLISTED"))
+                .andReturn().getResponse().getContentAsString();
+
+        Long waitlistedId2 = com.jayway.jsonpath.JsonPath.parse(resp3).read("$.enrollmentId", Long.class);
+        entityManager.flush();
+        entityManager.clear();
+        Enrollment waitlisted2 = entityManager.find(Enrollment.class, waitlistedId2);
+        org.junit.jupiter.api.Assertions.assertEquals(2, waitlisted2.getWaitlistPosition());
+    }
+
+    @Test
+    void enrollStudent_atCapacity_doesNotIncrementEnrolledStudentsCounter() throws Exception {
+        Course tinyCourse = createCourse(school, "Tiny Course", DanceStyle.SALSA,
+                CourseLevel.BEGINNER, CourseType.SOLO, 1, false, null);
+        entityManager.flush();
+
+        Student student2 = createStudent(school, "Marco Rossi", "marco@example.com", null);
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/courses/{id}/enrollments", tinyCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
                 .andExpect(status().isCreated());
 
-        // Second student cannot enroll
         mockMvc.perform(post("/api/courses/{id}/enrollments", tinyCourse.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {"studentId": %d}
                                 """.formatted(student2.getId()))
                         .with(authentication(authToken(owner))))
-                .andExpect(status().isConflict());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("WAITLISTED"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Course refreshed = entityManager.find(Course.class, tinyCourse.getId());
+        org.junit.jupiter.api.Assertions.assertEquals(1, refreshed.getEnrolledStudents());
+    }
+
+    @Test
+    void enrollStudent_roleImbalance_returnsWaitlisted_withRoleImbalanceReason() throws Exception {
+        // threshold=1 → tolerate up to a 1-diff. With 1 LEAD + 0 FOLLOW (diff=1=threshold, fine),
+        // a second LEAD would make diff=2 > threshold → waitlist with ROLE_IMBALANCE.
+        Course balancedCourse = createCourse(school, "Kizomba Balanced", DanceStyle.KIZOMBA,
+                CourseLevel.BEGINNER, CourseType.PARTNER, 20, true, 1);
+        entityManager.flush();
+
+        Student leadA = createStudent(school, "Lead A", "leada@example.com", null);
+        Student leadB = createStudent(school, "Lead B", "leadb@example.com", null);
+        entityManager.flush();
+
+        enrollPartner(balancedCourse.getId(), leadA.getId(), "LEAD", "PENDING_PAYMENT");
+
+        String resp = enrollPartner(balancedCourse.getId(), leadB.getId(), "LEAD", "WAITLISTED");
+        Long id = com.jayway.jsonpath.JsonPath.parse(resp).read("$.enrollmentId", Long.class);
+        entityManager.flush();
+        entityManager.clear();
+        Enrollment waitlisted = entityManager.find(Enrollment.class, id);
+        org.junit.jupiter.api.Assertions.assertEquals(WaitlistReason.ROLE_IMBALANCE, waitlisted.getWaitlistReason());
+        org.junit.jupiter.api.Assertions.assertEquals(1, waitlisted.getWaitlistPosition());
+    }
+
+    @Test
+    void enrollStudent_roleImbalance_onlyCountsActiveStatuses() throws Exception {
+        // threshold=1, 1 LEAD (REJECTED — excluded) + 1 FOLLOW; next LEAD should NOT waitlist because
+        // rejected enrollments don't count. It's PENDING_PAYMENT.
+        Course advancedCourse = createCourse(school, "Salsa Advanced Gate", DanceStyle.SALSA,
+                CourseLevel.ADVANCED, CourseType.PARTNER, 20, true, 1);
+        entityManager.flush();
+
+        Student rejectedLead = createStudent(school, "Rejected Lead", "rejlead@example.com", null);
+        Student follow = createStudent(school, "Follow", "follow@example.com", null);
+        Student newLead = createStudent(school, "New Lead", "newlead@example.com", null);
+        addDanceLevel(follow, DanceStyle.SALSA, CourseLevel.ADVANCED);
+        addDanceLevel(newLead, DanceStyle.SALSA, CourseLevel.ADVANCED);
+        entityManager.flush();
+
+        String respRejected = enrollPartner(advancedCourse.getId(), rejectedLead.getId(), "LEAD", "PENDING_APPROVAL");
+        Long rejectedId = com.jayway.jsonpath.JsonPath.parse(respRejected).read("$.enrollmentId", Long.class);
+        mockMvc.perform(put("/api/enrollments/{id}/reject", rejectedId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk());
+
+        enrollPartner(advancedCourse.getId(), follow.getId(), "FOLLOW", "PENDING_PAYMENT");
+        // Rejected LEAD no longer counts; 0 active LEAD + 1 FOLLOW, adding 1 LEAD → 1 vs 1, diff 0, not waitlisted
+        enrollPartner(advancedCourse.getId(), newLead.getId(), "LEAD", "PENDING_PAYMENT");
+    }
+
+    @Test
+    void enrollStudent_waitlistPosition_perRoleFIFO() throws Exception {
+        // tinyCourse max=2: enroll 1 LEAD + 1 FOLLOW to fill capacity, then waitlist additional students.
+        // Positions should be assigned per role: LEAD #1, LEAD #2, FOLLOW #1.
+        Course tinyPartner = createCourse(school, "Kizomba Tiny", DanceStyle.KIZOMBA,
+                CourseLevel.BEGINNER, CourseType.PARTNER, 2, false, null);
+        entityManager.flush();
+
+        Student leadA = createStudent(school, "Lead A", "leada2@example.com", null);
+        Student followA = createStudent(school, "Follow A", "followa2@example.com", null);
+        Student leadB = createStudent(school, "Lead B", "leadb2@example.com", null);
+        Student leadC = createStudent(school, "Lead C", "leadc2@example.com", null);
+        Student followB = createStudent(school, "Follow B", "followb2@example.com", null);
+        entityManager.flush();
+
+        enrollPartner(tinyPartner.getId(), leadA.getId(), "LEAD", "PENDING_PAYMENT");
+        enrollPartner(tinyPartner.getId(), followA.getId(), "FOLLOW", "PENDING_PAYMENT");
+        // Now at capacity — remaining enrollments go to the waitlist with CAPACITY reason.
+
+        String respLeadB = enrollPartner(tinyPartner.getId(), leadB.getId(), "LEAD", "WAITLISTED");
+        String respLeadC = enrollPartner(tinyPartner.getId(), leadC.getId(), "LEAD", "WAITLISTED");
+        String respFollowB = enrollPartner(tinyPartner.getId(), followB.getId(), "FOLLOW", "WAITLISTED");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Enrollment lB = entityManager.find(Enrollment.class,
+                com.jayway.jsonpath.JsonPath.parse(respLeadB).read("$.enrollmentId", Long.class));
+        Enrollment lC = entityManager.find(Enrollment.class,
+                com.jayway.jsonpath.JsonPath.parse(respLeadC).read("$.enrollmentId", Long.class));
+        Enrollment fB = entityManager.find(Enrollment.class,
+                com.jayway.jsonpath.JsonPath.parse(respFollowB).read("$.enrollmentId", Long.class));
+
+        org.junit.jupiter.api.Assertions.assertEquals(1, lB.getWaitlistPosition());
+        org.junit.jupiter.api.Assertions.assertEquals(2, lC.getWaitlistPosition());
+        org.junit.jupiter.api.Assertions.assertEquals(1, fB.getWaitlistPosition());
+    }
+
+    private String enrollPartner(Long courseId, Long studentId, String role, String expectedStatus) throws Exception {
+        return mockMvc.perform(post("/api/courses/{id}/enrollments", courseId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "%s"}
+                                """.formatted(studentId, role))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(expectedStatus))
+                .andReturn().getResponse().getContentAsString();
     }
 
     @Test

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -80,6 +80,7 @@
                 <th mat-header-cell *matHeaderCellDef>
                   @switch (activeTabIndex()) {
                     @case (0) { Paid }
+                    @case (1) { Waitlist }
                     @case (2) { Level }
                     @case (3) { Approved on }
                     @default { }
@@ -88,6 +89,14 @@
                 <td mat-cell *matCellDef="let row">
                   @switch (activeTabIndex()) {
                     @case (0) { {{ formatEnrollmentDate(row.paidAt) }} }
+                    @case (1) {
+                      <div class="waitlist-cell">
+                        <span class="ds-chip ds-chip-default">#{{ row.waitlistPosition }}</span>
+                        <span class="ds-chip" [ngClass]="waitlistReasonChipClass(row.waitlistReason)">
+                          {{ formatWaitlistReason(row.waitlistReason) }}
+                        </span>
+                      </div>
+                    }
                     @case (2) {
                       <div class="approve-cell">
                         <span class="ds-chip" [ngClass]="levelChipClass(row.studentDanceLevel)">

--- a/frontend/src/app/courses/overview/course-overview.scss
+++ b/frontend/src/app/courses/overview/course-overview.scss
@@ -120,6 +120,12 @@
   gap: var(--ds-spacing-3);
 }
 
+.waitlist-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-2);
+}
+
 .approve-actions {
   display: flex;
   align-items: center;

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -230,4 +230,70 @@ describe('CourseOverviewComponent', () => {
       httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
     });
   });
+
+  describe('Waitlist tab', () => {
+    it('renders WAITLISTED rows with position and reason chips', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([
+        makeEnrollment({
+          id: 10, studentName: 'Lead A', status: 'WAITLISTED', danceRole: 'LEAD',
+          waitlistPosition: 2, waitlistReason: 'ROLE_IMBALANCE',
+        }),
+      ]);
+      fixture.detectChanges();
+
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[1] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const row = el.querySelector('tr[mat-row]');
+      expect(row).toBeTruthy();
+      expect(row?.textContent).toContain('Lead A');
+
+      const waitlistCell = row?.querySelector('.waitlist-cell');
+      expect(waitlistCell).toBeTruthy();
+
+      const chips = waitlistCell?.querySelectorAll('.ds-chip') ?? [];
+      expect(chips.length).toBe(2);
+      expect(chips[0].textContent?.trim()).toBe('#2');
+      expect(chips[1].textContent?.trim()).toBe('Role imbalance');
+      expect(chips[1].classList.contains('ds-chip-info')).toBe(true);
+    });
+
+    it('renders CAPACITY reason with default chip styling', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([
+        makeEnrollment({
+          status: 'WAITLISTED', waitlistPosition: 1, waitlistReason: 'CAPACITY',
+        }),
+      ]);
+      fixture.detectChanges();
+
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[1] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const chips = el.querySelectorAll('.waitlist-cell .ds-chip');
+      expect(chips[0].textContent?.trim()).toBe('#1');
+      expect(chips[1].textContent?.trim()).toBe('Capacity');
+      expect(chips[1].classList.contains('ds-chip-default')).toBe(true);
+    });
+
+    it('shows Waitlist as the last-column header on the waitlist tab', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([
+        makeEnrollment({
+          status: 'WAITLISTED', waitlistPosition: 1, waitlistReason: 'CAPACITY',
+        }),
+      ]);
+      fixture.detectChanges();
+
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[1] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const headers = Array.from(el.querySelectorAll('th[mat-header-cell]')).map(h => h.textContent?.trim());
+      expect(headers).toContain('Waitlist');
+    });
+  });
 });

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -12,7 +12,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { CourseDetail, CourseService } from '../course.service';
 import { CourseSummaryComponent, CourseSummaryData } from '../shared/course-summary';
 import { EnrollmentListItem, EnrollmentService } from '../enrollment.service';
-import { enrollmentStatusChipClass, formatDate, formatDayFull, formatEnrollmentStatus, formatLevel, formatTime, levelChipClass, statusChipClass } from '../shared/format-utils';
+import { enrollmentStatusChipClass, formatDate, formatDayFull, formatEnrollmentStatus, formatLevel, formatTime, formatWaitlistReason, levelChipClass, statusChipClass, waitlistReasonChipClass } from '../shared/format-utils';
 import { extractErrorMessage } from '../../shared/error-utils';
 
 interface EnrollmentTab {
@@ -125,6 +125,8 @@ export class CourseOverviewComponent implements OnInit {
   protected formatLevel = formatLevel;
   protected enrollmentStatusChipClass = enrollmentStatusChipClass;
   protected formatEnrollmentStatus = formatEnrollmentStatus;
+  protected waitlistReasonChipClass = waitlistReasonChipClass;
+  protected formatWaitlistReason = formatWaitlistReason;
 
   protected selectTab(index: number): void {
     this.activeTabIndex.set(index);

--- a/frontend/src/app/courses/shared/format-utils.ts
+++ b/frontend/src/app/courses/shared/format-utils.ts
@@ -67,3 +67,19 @@ export function enrollmentStatusChipClass(status: string): string {
 export function formatEnrollmentStatus(status: string): string {
   return status.replace(/_/g, ' ');
 }
+
+/** Map a waitlist reason to its chip class. */
+export function waitlistReasonChipClass(reason: string | null): string {
+  switch (reason) {
+    case 'ROLE_IMBALANCE': return 'ds-chip-info';
+    case 'CAPACITY':       return 'ds-chip-default';
+    default:               return 'ds-chip-default';
+  }
+}
+
+/** Display label for a waitlist reason. */
+export function formatWaitlistReason(reason: string | null): string {
+  if (reason === 'CAPACITY') return 'Capacity';
+  if (reason === 'ROLE_IMBALANCE') return 'Role imbalance';
+  return '—';
+}

--- a/frontend/src/app/dev-tools/dev-tools.html
+++ b/frontend/src/app/dev-tools/dev-tools.html
@@ -38,6 +38,15 @@
         Add Student
       </button>
 
+      @if (isPartnerCourse()) {
+        <button mat-stroked-button (click)="onCreateImbalance()" [disabled]="imbalancing()">
+          @if (imbalancing()) {
+            <mat-spinner diameter="18"></mat-spinner>
+          }
+          Create Imbalance
+        </button>
+      }
+
       <mat-form-field class="role-select">
         <mat-label>Role</mat-label>
         <mat-select [value]="danceRole()" (selectionChange)="danceRole.set($event.value)">
@@ -90,6 +99,11 @@
                 {{ formatStatus(row.status) }}
               </span>
             </td>
+          </ng-container>
+
+          <ng-container matColumnDef="waitlistInfo">
+            <th mat-header-cell *matHeaderCellDef>Waitlist</th>
+            <td mat-cell *matCellDef="let row">{{ formatWaitlistInfo(row) }}</td>
           </ng-container>
 
           <ng-container matColumnDef="enrolledAt">

--- a/frontend/src/app/dev-tools/dev-tools.ts
+++ b/frontend/src/app/dev-tools/dev-tools.ts
@@ -49,9 +49,10 @@ export class DevToolsComponent implements OnInit {
   protected filling = signal(false);
   protected adding = signal(false);
   protected paying = signal(false);
+  protected imbalancing = signal(false);
   protected danceRole = signal<'LEAD' | 'FOLLOW'>('LEAD');
 
-  protected readonly enrollmentColumns = ['name', 'phone', 'role', 'status', 'enrolledAt'];
+  protected readonly enrollmentColumns = ['name', 'phone', 'role', 'status', 'waitlistInfo', 'enrolledAt'];
 
   ngOnInit(): void {
     this.loadCourses();
@@ -157,6 +158,56 @@ export class DevToolsComponent implements OnInit {
     });
   }
 
+  protected onCreateImbalance(): void {
+    const courseId = this.selectedCourseId();
+    const course = this.courseDetail();
+    if (!courseId || !course || course.courseType !== 'PARTNER') return;
+
+    const threshold = course.roleBalanceThreshold ?? 3;
+    const role = this.danceRole();
+    const other = role === 'LEAD' ? 'FOLLOW' : 'LEAD';
+
+    const isActive = (s: string) => s === 'CONFIRMED' || s === 'PENDING_PAYMENT' || s === 'PENDING_APPROVAL';
+    const active = this.enrollments().filter(e => isActive(e.status));
+    const myCount = active.filter(e => e.danceRole === role).length;
+    const otherCount = active.filter(e => e.danceRole === other).length;
+
+    // One student to push past threshold + one extra so the waitlist row is visible.
+    const needed = Math.max(1, (otherCount + threshold) - myCount + 1);
+    const remainingCapacity = Math.max(0, course.maxParticipants - active.length);
+    // Don't over-enroll capacity-wise beyond what's needed to demonstrate imbalance.
+    const toEnroll = Math.max(1, Math.min(needed, remainingCapacity + 2));
+
+    this.imbalancing.set(true);
+
+    const operations: Observable<unknown>[] = [];
+    for (let i = 0; i < toEnroll; i++) {
+      operations.push(
+        this.createRandomStudent().pipe(
+          switchMap(result => this.enrollmentService.enrollStudent(courseId, { studentId: result.id, danceRole: role })),
+        ),
+      );
+    }
+
+    concat(...operations).pipe(
+      toArray(),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: () => {
+        this.snackBar.open(`Enrolled ${toEnroll} ${role}s to create imbalance`, 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        this.imbalancing.set(false);
+        this.loadCourses();
+        this.loadEnrollments(courseId);
+      },
+      error: () => {
+        this.snackBar.open('Some enrollments failed', 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+        this.imbalancing.set(false);
+        this.loadCourses();
+        this.loadEnrollments(courseId);
+      },
+    });
+  }
+
   protected onSimulatePayment(): void {
     const courseId = this.selectedCourseId();
     if (!courseId) return;
@@ -189,6 +240,14 @@ export class DevToolsComponent implements OnInit {
 
   protected formatStatus = formatEnrollmentStatus;
   protected enrollmentStatusChipClass = enrollmentStatusChipClass;
+
+  protected formatWaitlistInfo(row: EnrollmentListItem): string {
+    if (row.status !== 'WAITLISTED' || row.waitlistPosition == null) return '—';
+    const reason = row.waitlistReason === 'ROLE_IMBALANCE' ? 'role imbalance'
+                 : row.waitlistReason === 'CAPACITY' ? 'capacity'
+                 : 'unknown';
+    return `#${row.waitlistPosition} · ${reason}`;
+  }
 
   protected formatRole(role: string | null): string {
     if (!role) return '—';


### PR DESCRIPTION
## Summary

- Enrollment now routes to `WAITLISTED` instead of erroring when the course is at capacity (reason `CAPACITY`) or when a partner course with role-balancing would tip past its threshold (reason `ROLE_IMBALANCE`). Approval-time waitlisting (already landed in #268) now also assigns a position.
- `waitlistPosition` is FIFO per-role for partner courses, and global for solo — counting only existing `WAITLISTED` rows in the same course.
- Waitlist tab on the course detail page renders a 5-column table (Name, Phone, Role, Enrolled on, Position + Reason chip). Dev Tools adds a Create Imbalance button for partner courses and a Waitlist column in its enrollment table.

Closes #251.

## Test plan

- [x] `./mvnw test -Dtest=EnrollmentIntegrationTest` — 30 tests pass, including 4 new waitlist tests (capacity + position, counter-stays-put, role-imbalance with reason, per-role FIFO, active-statuses-only for role count)
- [x] `npx ng test --browsers chromium --no-watch` — 83 tests pass, including 3 new Waitlist-tab tests
- [x] Visual verification via Playwright:
  - Dev Tools → Bachata Intermediate (PARTNER) → Create Imbalance (LEAD) → course detail → Waitlist tab shows `#1` + orange "Role imbalance" chip
  - Dev Tools → Salsa Solo (SOLO) → Fill Course → Add Student → Waitlist tab shows `#1` + gray "Capacity" chip
  - `course.enrolledStudents` counter stays at maxParticipants (not incremented for waitlisted rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)