### PR TITLE
Default role balance threshold to 3 in course form

### DIFF
--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -23,7 +23,7 @@ export class CourseFormService {
     registration: new FormGroup({
       maxParticipants: new FormControl<number | null>(null, { validators: [Validators.required, Validators.min(1)] }),
       roleBalancingEnabled: new FormControl(false, { nonNullable: true }),
-      roleBalanceThreshold: new FormControl<number | null>(null),
+      roleBalanceThreshold: new FormControl<number | null>(3),
     }),
     pricing: new FormGroup({
       priceModel: new FormControl('FIXED_COURSE', { nonNullable: true, validators: [Validators.required] }),


### PR DESCRIPTION
## Summary
- Initialize the Max Imbalance field with a sensible default of `3` instead of blank when creating a new course.

Closes #261

## Test plan
- [x] Frontend unit tests pass (`npx ng test --browsers chromium --no-watch`)
- [x] Frontend build passes (`npx ng build`)
- [x] Visual verification: new course → Registration step shows Max Imbalance = 3 when Role Balancing toggles on

🤖 Generated with [Claude Code](https://claude.com/claude-code)