### PR TITLE
Remove Course.requiresApproval (#275)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
@@ -82,6 +82,4 @@ public class Course {
     private LocalDate publishedAt;
 
     private int enrolledStudents;
-
-    private boolean requiresApproval;
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -115,7 +115,6 @@ public class DevDataSeeder implements ApplicationRunner {
                 10, LocalTime.of(20, 0), LocalTime.of(21, 15),
                 "Studio A", "Maria, Carlos", 10, true, 2,
                 PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, today.minusDays(5));
-        salsaAdvanced.setRequiresApproval(true);
         courses.add(salsaAdvanced);
 
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -274,8 +273,9 @@ public class DevDataSeeder implements ApplicationRunner {
                 EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
         partnerCourse.setEnrolledStudents(5);
 
-        // courses[2] = "Salsa Advanced" (PARTNER, ADVANCED, requiresApproval=true)
+        // courses[2] = "Salsa Advanced" (PARTNER, ADVANCED)
         // Seed two PENDING_APPROVAL rows so the Approve tab has visible content.
+        // Both route via level mismatch against ADVANCED salsa.
         // students[0] Anna: INTERMEDIATE salsa (under-level)
         // students[5] Jan de Vries: no salsa level at all
         Course salsaAdvanced = courses.get(2);

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -220,10 +220,6 @@ public class EnrollmentService {
             return EnrollmentStatus.PENDING_PAYMENT;
         }
 
-        if (course.isRequiresApproval()) {
-            return EnrollmentStatus.PENDING_APPROVAL;
-        }
-
         CourseLevel studentLevel = findStudentLevel(student, course.getDanceStyle());
         if (studentLevel == null || studentLevel.ordinal() < course.getLevel().ordinal()) {
             return EnrollmentStatus.PENDING_APPROVAL;

--- a/backend/src/main/resources/db/changelog/019-drop-requires-approval-from-course.yaml
+++ b/backend/src/main/resources/db/changelog/019-drop-requires-approval-from-course.yaml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - changeSet:
+      id: 019-drop-requires-approval-from-course
+      author: claude
+      changes:
+        - dropColumn:
+            tableName: course
+            columnName: requires_approval

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -35,3 +35,5 @@ databaseChangeLog:
       file: db/changelog/017-create-enrollment.yaml
   - include:
       file: db/changelog/018-add-requires-approval-to-course.yaml
+  - include:
+      file: db/changelog/019-drop-requires-approval-from-course.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -368,40 +368,6 @@ class EnrollmentIntegrationTest {
     }
 
     @Test
-    void enrollStudent_requiresApprovalFlag_returnsPendingApproval_evenWithMatchingLevel() throws Exception {
-        Course approvalCourse = createCourseWithApproval(school, "Bachata Approval", DanceStyle.BACHATA,
-                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 10, true);
-        entityManager.flush();
-
-        // Student has INTERMEDIATE bachata (matches course level), but requiresApproval=true
-        mockMvc.perform(post("/api/courses/{id}/enrollments", approvalCourse.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"studentId": %d, "danceRole": "LEAD"}
-                                """.formatted(student.getId()))
-                        .with(authentication(authToken(owner))))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"));
-    }
-
-    @Test
-    void enrollStudent_beginnerCourseWithRequiresApproval_bypassesApproval() throws Exception {
-        // Even with requiresApproval=true, BEGINNER courses skip approval
-        Course approvalBeginner = createCourseWithApproval(school, "Kizomba Beginner Approval",
-                DanceStyle.KIZOMBA, CourseLevel.BEGINNER, CourseType.PARTNER, 10, true);
-        entityManager.flush();
-
-        mockMvc.perform(post("/api/courses/{id}/enrollments", approvalBeginner.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"studentId": %d, "danceRole": "FOLLOW"}
-                                """.formatted(student.getId()))
-                        .with(authentication(authToken(owner))))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.status").value("PENDING_PAYMENT"));
-    }
-
-    @Test
     void enrollStudent_beginnerCourse_alwaysAllowed() throws Exception {
         // Student with no Kizomba level can still enroll in BEGINNER Kizomba
         Course beginnerKizomba = createCourse(school, "Kizomba Beginner", DanceStyle.KIZOMBA,
@@ -499,7 +465,7 @@ class EnrollmentIntegrationTest {
 
     @Test
     void enroll_withPendingApprovalApplicants_doesNotBlockCommittedEnrollment() throws Exception {
-        // Course with capacity 2, no requiresApproval, ADVANCED level.
+        // Course with capacity 2, ADVANCED level.
         Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
                 CourseLevel.ADVANCED, CourseType.PARTNER, 2, true, 1);
         entityManager.flush();
@@ -612,42 +578,6 @@ class EnrollmentIntegrationTest {
                 .findFirst()
                 .orElse(null);
         org.junit.jupiter.api.Assertions.assertEquals(CourseLevel.ADVANCED, salsaLevel);
-    }
-
-    @Test
-    void approve_doesNotDowngradeExistingHigherDanceLevel() throws Exception {
-        // Course is INTERMEDIATE bachata with requiresApproval=true; student has INTERMEDIATE bachata
-        // But to trigger PENDING_APPROVAL we need requiresApproval; and to test non-downgrade we use ADVANCED student
-        Student advancedStudent = createStudent(school, "Laura Advanced", "laura@example.com", null);
-        addDanceLevel(advancedStudent, DanceStyle.BACHATA, CourseLevel.ADVANCED);
-        Course approvalCourse = createCourseWithApproval(school, "Bachata Approval", DanceStyle.BACHATA,
-                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 10, true);
-        entityManager.flush();
-
-        String response = mockMvc.perform(post("/api/courses/{id}/enrollments", approvalCourse.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"studentId": %d, "danceRole": "LEAD"}
-                                """.formatted(advancedStudent.getId()))
-                        .with(authentication(authToken(owner))))
-                .andExpect(status().isCreated())
-                .andReturn().getResponse().getContentAsString();
-        Long enrollmentId = com.jayway.jsonpath.JsonPath.parse(response).read("$.enrollmentId", Long.class);
-
-        mockMvc.perform(put("/api/enrollments/{id}/approve", enrollmentId)
-                        .with(authentication(authToken(owner))))
-                .andExpect(status().isOk());
-
-        entityManager.flush();
-        entityManager.clear();
-
-        Student refreshed = entityManager.find(Student.class, advancedStudent.getId());
-        CourseLevel bachataLevel = refreshed.getDanceLevels().stream()
-                .filter(dl -> dl.getDanceStyle() == DanceStyle.BACHATA)
-                .map(StudentDanceLevel::getLevel)
-                .findFirst()
-                .orElse(null);
-        org.junit.jupiter.api.Assertions.assertEquals(CourseLevel.ADVANCED, bachataLevel);
     }
 
     @Test
@@ -817,13 +747,6 @@ class EnrollmentIntegrationTest {
         entityManager.persist(member);
 
         return s;
-    }
-
-    private Course createCourseWithApproval(School s, String title, DanceStyle danceStyle, CourseLevel level,
-                                            CourseType courseType, int maxParticipants, boolean requiresApproval) {
-        Course c = createCourse(s, title, danceStyle, level, courseType, maxParticipants, false, null);
-        c.setRequiresApproval(requiresApproval);
-        return c;
     }
 
     private Long createPendingApprovalForInsufficientLevel() throws Exception {


### PR DESCRIPTION
## Summary
- Drops `Course.requiresApproval` end-to-end: entity, `EnrollmentService.resolveBookingStatus` flag branch, `DevDataSeeder`, and flag-specific integration tests
- New Liquibase migration `019-drop-requires-approval-from-course.yaml` mirrors `018`
- Booking status now only branches on course level + student level — matches the narrower Phase 1 scope described in #275

## Coverage check
Deleted: `enrollStudent_requiresApprovalFlag_returnsPendingApproval_evenWithMatchingLevel`, `enrollStudent_beginnerCourseWithRequiresApproval_bypassesApproval`, `approve_doesNotDowngradeExistingHigherDanceLevel`, and the `createCourseWithApproval` helper.

All branches of the new `resolveBookingStatus` remain covered by existing tests:
- BEGINNER → PENDING_PAYMENT: `enrollStudent_beginnerCourse_alwaysAllowed`
- Matching/higher level → PENDING_PAYMENT: `enrollStudent_partnerCourse_returnsCreatedWithPendingPayment`
- Under-level / missing level → PENDING_APPROVAL: `enrollStudent_insufficientLevel_returnsPendingApproval`, `enrollStudent_noLevelForStyle_returnsPendingApproval`

The approve-side level upgrade invariant stays covered by `approve_transitionsToPendingPayment_setsApprovedAt_andUpgradesStudentLevel`.

## Test plan
- [x] `./mvnw test` — 143 tests, all green
- [x] DevDataSeeder still produces 2 PENDING_APPROVAL rows for Salsa Advanced (via level-mismatch path)
- No frontend changes — flag never leaked to the frontend

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)