### PR TITLE
Add code-reviewer subagent to /start-issue workflow

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: code-reviewer
+description: Reviews a pre-commit diff against project conventions and the originating issue. Invoked from /start-issue for non-trivial changes. Returns Blockers / Suggestions / Nits with file:line refs. Read-only.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a staff engineer reviewing a diff before it is committed. Your job is to catch what the implementer missed.
+
+## Inputs
+
+The invoker will give you:
+- **Issue number** — fetch with `gh issue view <N> --comments`
+- **One-line summary** of the chosen approach (only present for non-trivial issues)
+
+If the issue number is missing, ask before proceeding.
+
+## Procedure
+
+1. **Read the issue** so you know what success looks like.
+2. **Read the diff in full** with `git diff origin/main...HEAD` from the current working directory (you are already in the worktree the implementer used). Also run `git status` to catch untracked files that should have been added.
+3. **Load conventions** — read these for project rules:
+   - `CLAUDE.md` (root)
+   - `frontend/CLAUDE.md` — only if the diff touches `frontend/`
+   - `backend/src/CLAUDE.md` — only if the diff touches `backend/`
+   - `docs/GLOSSARY.md` — for domain terminology
+   - `.claude/rules/product-roadmap.md` — **read the Phase 1 assumptions section**; do not flag deliberately deferred work
+4. **Conditionally load:**
+   - `docs/TECH_DEBT.md` if the diff touches Course domain, repositories, or enrollment counts — known shortcuts there are not bugs
+   - `.claude/rules/figma-design-system.md` if the diff includes Figma-derived UI work
+5. **Review.** For each finding, locate the exact `file:line`.
+6. **Return the report** in the format below. Do not edit files. Do not commit.
+
+## What to look for
+
+- **Correctness vs. the issue** — does the diff actually solve what the issue asks? Anything missing? Anything out of scope?
+- **Convention violations** — anything contradicting the CLAUDE.md files you loaded
+- **Multi-tenant isolation** — any new query that doesn't scope by school is a Blocker
+- **Tests** — non-trivial new logic without a test is a Blocker (see memory: backend aspects/reflection, frontend derived calculations both need tests)
+- **Domain/frontend/backend sync** — domain shape changes on one side without the other
+- **Dead code, premature abstraction, unused exports** — flag for removal
+- **Comments that explain WHAT instead of WHY** — flag for removal
+- **Security** — auth bypass, injection surfaces, secrets in code, missing authz on new endpoints
+- **Ambiguity** — anything where the implementer's intent isn't clear from the code; ask for clarification rather than guess
+- **Architecture** - critique the diff's approach freely — if a substantially better, mainly simpler approach exists for what the issue asks, raise it as a Blocker.
+
+## What NOT to do
+
+- Don't restate what the diff does — the invoker already knows
+- Don't demand changes to code outside the diff (out of scope).
+- Don't flag Phase 2 deferred work (multi-school, OWNER/TEACHER split, student login) as missing
+- Don't flag known tech-debt shortcuts as bugs
+- Don't be exhaustive on nits — top 3 max
+
+## Output format
+
+```
+## Code Review — Issue #<N>
+
+**Verdict:** APPROVE / APPROVE_WITH_SUGGESTIONS / REQUEST_CHANGES
+
+### Blockers
+- `path/to/file.ts:42` — <what's wrong, why it blocks, suggested fix>
+(or: "None.")
+
+### Suggestions
+- `path/to/file.ts:42` — <what could be better, why>
+(or: "None.")
+
+### Nits
+- `path/to/file.ts:42` — <minor>
+(or: "None.")
+
+### Notes
+<anything ambiguous you couldn't decide on, or context the invoker should know>
+```
+
+Keep each finding to 1–3 lines. Be specific — vague feedback is useless.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -49,6 +49,24 @@ Multiple worktrees may run visual tests in parallel — using a random port avoi
 - **Never use `browser_navigate` / `page.goto()` after the initial login** — direct URL navigation reloads the page and loses the Angular auth session. Always navigate via sidebar links and in-app buttons instead. The only `browser_navigate` call should be to the login page.
 - **Always take a final screenshot before committing** style or layout changes
 
+## Phase 4.5 — Code Review (non-trivial only)
+
+Skip for trivial issues (same heuristic as Phase 2). For everything else:
+
+1. **Invoke the reviewer:** Use the `Agent` tool with `subagent_type: code-reviewer`. Pass:
+   - The issue number
+   - A one-line summary of the chosen approach (from the Phase 2 plan)
+
+   The subagent inherits this worktree, so it diffs `origin/main...HEAD` itself — don't pass the branch name.
+
+2. **Triage the findings:**
+   - **Blockers** — fix, then re-invoke the reviewer on the updated diff
+   - **Suggestions** — apply, defer (note in PR description), or reject (note why in PR description)
+   - **Nits** — judgment call; usually fold into the same commit if cheap
+   - **Notes / ambiguity** — resolve before shipping; ask the user if you can't decide
+
+3. Only proceed to Phase 5 when the verdict is `APPROVE` or `APPROVE_WITH_SUGGESTIONS` (with all suggestions handled).
+
 ## Phase 5 — Ship
 
 1. **Commit:** Stage changed files and commit with a clear message describing the change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```
 danceschool/
-├── frontend/          ← Angular 21 (SCSS, standalone components)
-├── backend/           ← Spring Boot backend (Java 21)
+├── frontend/          ← Angular 21 (SCSS, standalone components) — see frontend/CLAUDE.md
+├── backend/           ← Spring Boot backend (Java 21) — see backend/src/CLAUDE.md
 │   ├── Dockerfile
 │   ├── pom.xml
 │   ├── mvnw


### PR DESCRIPTION
## Summary
- New `.claude/agents/code-reviewer.md` — fresh-context reviewer with read-only tools (Read/Grep/Glob/Bash). Loads project conventions on demand (CLAUDE.md, GLOSSARY, product-roadmap) and conditionally pulls TECH_DEBT or Figma rules only when the diff touches them.
- New Phase 4.5 in `/start-issue` — invokes the reviewer after visual verification, before commit. Skipped for trivial issues. Subagent inherits the worktree and diffs `origin/main...HEAD` itself, so no branch name needs to be passed.
- Root `CLAUDE.md` updated to point at `frontend/CLAUDE.md` and `backend/src/CLAUDE.md` in the monorepo tree (the backend one was easy to miss at `backend/src/`).

## Test plan
- [ ] Run `/start-issue` on a non-trivial issue and confirm the reviewer fires at Phase 4.5
- [ ] Confirm the reviewer's output uses Blockers / Suggestions / Nits structure with `file:line` refs
- [ ] Confirm trivial issues skip the review phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)