### PR TITLE
Drop Course.enrolledStudents; derive from seat-holding enrollments (#272)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
@@ -80,6 +80,4 @@ public class Course {
     private BigDecimal price;
 
     private LocalDate publishedAt;
-
-    private int enrolledStudents;
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -26,10 +26,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CourseService {
 
-    private static final List<EnrollmentStatus> COMMITTED_STATUSES = List.of(
-            EnrollmentStatus.PENDING_PAYMENT,
-            EnrollmentStatus.CONFIRMED);
-
     private final CourseRepository courseRepository;
     private final EnrollmentRepository enrollmentRepository;
     private final SchoolService schoolService;
@@ -40,24 +36,38 @@ public class CourseService {
         School school = schoolService.findSchoolByMember(userId);
         List<Course> courses = fetchCourses(school.getId(), statusFilter);
         LocalDate today = LocalDate.now(clock);
-        Map<Long, RoleCounts> roleCounts = fetchRoleCounts(courses);
+        List<Long> courseIds = courses.stream().map(Course::getId).toList();
+        Map<Long, RoleCounts> roleCounts = fetchRoleCounts(courseIds);
+        Map<Long, Integer> committedCounts = fetchCommittedCounts(courseIds);
         return courses.stream()
-                .map(c -> toListDto(c, today, roleCounts.getOrDefault(c.getId(), RoleCounts.EMPTY)))
+                .map(c -> toListDto(c, today,
+                        committedCounts.getOrDefault(c.getId(), 0),
+                        roleCounts.getOrDefault(c.getId(), RoleCounts.EMPTY)))
                 .toList();
     }
 
-    private Map<Long, RoleCounts> fetchRoleCounts(List<Course> courses) {
-        List<Long> courseIds = courses.stream().map(Course::getId).toList();
+    private Map<Long, RoleCounts> fetchRoleCounts(List<Long> courseIds) {
         if (courseIds.isEmpty()) {
             return Map.of();
         }
         Map<Long, RoleCounts> result = new HashMap<>();
-        for (Object[] row : enrollmentRepository.countByRoleGroupedByCourse(courseIds, COMMITTED_STATUSES)) {
+        for (Object[] row : enrollmentRepository.countByRoleGroupedByCourse(courseIds, EnrollmentStatus.SEAT_HOLDING_STATI)) {
             Long courseId = (Long) row[0];
             DanceRole role = (DanceRole) row[1];
             int count = ((Number) row[2]).intValue();
             RoleCounts existing = result.getOrDefault(courseId, RoleCounts.EMPTY);
             result.put(courseId, existing.plus(role, count));
+        }
+        return result;
+    }
+
+    private Map<Long, Integer> fetchCommittedCounts(List<Long> courseIds) {
+        if (courseIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Integer> result = new HashMap<>();
+        for (Object[] row : enrollmentRepository.countGroupedByCourse(courseIds, EnrollmentStatus.SEAT_HOLDING_STATI)) {
+            result.put((Long) row[0], ((Number) row[1]).intValue());
         }
         return result;
     }
@@ -166,12 +176,11 @@ public class CourseService {
      * Seeds a course for dev/test data. Skips domain validation (seed data may have past dates).
      */
     @Transactional
-    public Course seedCourse(Long userId, CreateCourseDto dto, int enrolledStudents, LocalDate publishedAt) {
+    public Course seedCourse(Long userId, CreateCourseDto dto, LocalDate publishedAt) {
         School school = schoolService.findSchoolByMember(userId);
         Course course = new Course();
         course.setSchool(school);
         applyDto(course, dto);
-        course.setEnrolledStudents(enrolledStudents);
         course.setPublishedAt(publishedAt);
         return courseRepository.save(course);
     }
@@ -243,7 +252,7 @@ public class CourseService {
         return startDate.plusWeeks((long) (numberOfSessions - 1) * intervalWeeks);
     }
 
-    private CourseListDto toListDto(Course course, LocalDate today, RoleCounts roleCounts) {
+    private CourseListDto toListDto(Course course, LocalDate today, int enrolledStudents, RoleCounts roleCounts) {
         return new CourseListDto(
                 course.getId(),
                 course.getTitle(),
@@ -256,7 +265,7 @@ public class CourseService {
                 course.getNumberOfSessions(),
                 course.getStartDate(),
                 course.getEndDate(),
-                course.getEnrolledStudents(),
+                enrolledStudents,
                 roleCounts.leads(),
                 roleCounts.follows(),
                 course.getMaxParticipants(),
@@ -269,6 +278,8 @@ public class CourseService {
     }
 
     private CourseDetailDto toDetailDto(Course course, LocalDate today) {
+        int enrolledStudents = (int) enrollmentRepository.countByCourseIdAndStatusIn(
+                course.getId(), EnrollmentStatus.SEAT_HOLDING_STATI);
         return new CourseDetailDto(
                 course.getId(),
                 course.getTitle(),
@@ -293,7 +304,7 @@ public class CourseService {
                 CourseStatusDerivation.deriveStatus(
                         course.getPublishedAt(), course.getStartDate(), course.getEndDate(), today),
                 course.getPublishedAt(),
-                course.getEnrolledStudents(),
+                enrolledStudents,
                 CourseStatusDerivation.deriveCompletedSessions(
                         course.getStartDate(), course.getDayOfWeek(), course.getNumberOfSessions(), today)
         );

--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -97,7 +97,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.minusWeeks(1), RecurrenceType.WEEKLY,
                 6, LocalTime.of(19, 30), LocalTime.of(20, 45),
                 "Studio A", "Maria", 12, false, null,
-                PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 0, today.minusWeeks(2)));
+                PriceModel.FIXED_COURSE, new BigDecimal("166.50")), today.minusWeeks(2)));
 
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
                 "Bachata Intermediate", DanceStyle.BACHATA, CourseLevel.INTERMEDIATE,
@@ -105,7 +105,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.minusWeeks(2), RecurrenceType.WEEKLY,
                 8, LocalTime.of(19, 0), LocalTime.of(20, 0),
                 "Studio B", "Carlos", 15, true, 3,
-                PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 0, today.minusWeeks(3)));
+                PriceModel.FIXED_COURSE, new BigDecimal("220.00")), today.minusWeeks(3)));
 
         // --- OPEN courses (published, start in the future) ---
         Course salsaAdvanced = courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -114,7 +114,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.plusWeeks(4), RecurrenceType.WEEKLY,
                 10, LocalTime.of(20, 0), LocalTime.of(21, 15),
                 "Studio A", "Maria, Carlos", 10, true, 2,
-                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, today.minusDays(5));
+                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), today.minusDays(5));
         courses.add(salsaAdvanced);
 
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -123,7 +123,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.plusWeeks(5), RecurrenceType.WEEKLY,
                 6, LocalTime.of(18, 30), LocalTime.of(19, 45),
                 "Studio B", "Carlos", 16, true, null,
-                PriceModel.FIXED_COURSE, new BigDecimal("166.50")), 0, today.minusDays(3)));
+                PriceModel.FIXED_COURSE, new BigDecimal("166.50")), today.minusDays(3)));
 
         // --- DRAFT courses (not published) ---
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -132,7 +132,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.plusWeeks(8), RecurrenceType.WEEKLY,
                 8, LocalTime.of(19, 0), LocalTime.of(20, 0),
                 "Studio A", "Maria", 20, false, null,
-                PriceModel.FIXED_COURSE, new BigDecimal("220.00")), 0, null));
+                PriceModel.FIXED_COURSE, new BigDecimal("220.00")), null));
 
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
                 "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
@@ -140,7 +140,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.plusWeeks(10), RecurrenceType.WEEKLY,
                 6, LocalTime.of(14, 0), LocalTime.of(15, 30),
                 "Studio B", "Carlos, Ana", 12, true, null,
-                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), 0, null));
+                PriceModel.FIXED_COURSE, new BigDecimal("310.00")), null));
 
         // --- FINISHED course (end date in the past) ---
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -149,7 +149,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.minusWeeks(12), RecurrenceType.WEEKLY,
                 8, LocalTime.of(20, 0), LocalTime.of(21, 0),
                 "Studio A", "Luis", 14, true, null,
-                PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 0, today.minusWeeks(14)));
+                PriceModel.FIXED_COURSE, new BigDecimal("180.00")), today.minusWeeks(14)));
 
         return courses;
     }
@@ -169,7 +169,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.minusWeeks(1), RecurrenceType.WEEKLY,
                 8, LocalTime.of(18, 0), LocalTime.of(19, 0),
                 "Main Hall", "Ana", 20, true, null,
-                PriceModel.FIXED_COURSE, new BigDecimal("180.00")), 0, today.minusWeeks(2)));
+                PriceModel.FIXED_COURSE, new BigDecimal("180.00")), today.minusWeeks(2)));
 
         courses.add(courseService.seedCourse(owner2.getId(), new CreateCourseDto(
                 "Bachata Sensual", DanceStyle.BACHATA, CourseLevel.ADVANCED,
@@ -177,7 +177,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 today.plusWeeks(3), RecurrenceType.WEEKLY,
                 6, LocalTime.of(14, 0), LocalTime.of(15, 30),
                 "Main Hall", "Ana, Luis", 12, true, null,
-                PriceModel.FIXED_COURSE, new BigDecimal("200.00")), 0, today.minusDays(2)));
+                PriceModel.FIXED_COURSE, new BigDecimal("200.00")), today.minusDays(2)));
 
         return courses;
     }
@@ -256,7 +256,6 @@ public class DevDataSeeder implements ApplicationRunner {
                 EnrollmentStatus.PENDING_PAYMENT, now.minus(3, ChronoUnit.DAYS), null);
         enrollmentService.seedEnrollment(soloCourse, students.get(6), null,
                 EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
-        soloCourse.setEnrolledStudents(6);
 
         // courses[1] = "Bachata Intermediate" (PARTNER, INTERMEDIATE, max 15, roleBalancing=true, threshold=3)
         // Enroll 5 students with LEAD/FOLLOW roles, mix of CONFIRMED and PENDING_PAYMENT
@@ -271,7 +270,6 @@ public class DevDataSeeder implements ApplicationRunner {
                 EnrollmentStatus.CONFIRMED, now.minus(9, ChronoUnit.DAYS), now.minus(7, ChronoUnit.DAYS));
         enrollmentService.seedEnrollment(partnerCourse, students.get(4), DanceRole.FOLLOW,
                 EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
-        partnerCourse.setEnrolledStudents(5);
 
         // courses[2] = "Salsa Advanced" (PARTNER, ADVANCED)
         // Seed two PENDING_APPROVAL rows so the Approve tab has visible content.
@@ -283,6 +281,5 @@ public class DevDataSeeder implements ApplicationRunner {
                 EnrollmentStatus.PENDING_APPROVAL, now.minus(1, ChronoUnit.DAYS), null);
         enrollmentService.seedEnrollment(salsaAdvanced, students.get(5), DanceRole.LEAD,
                 EnrollmentStatus.PENDING_APPROVAL, now.minus(12, ChronoUnit.HOURS), null);
-        salsaAdvanced.setEnrolledStudents(2);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
@@ -28,4 +28,10 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             "GROUP BY e.course.id, e.danceRole")
     List<Object[]> countByRoleGroupedByCourse(@Param("courseIds") List<Long> courseIds,
                                               @Param("statuses") List<EnrollmentStatus> statuses);
+
+    @Query("SELECT e.course.id, COUNT(e) FROM Enrollment e " +
+            "WHERE e.course.id IN :courseIds AND e.status IN :statuses " +
+            "GROUP BY e.course.id")
+    List<Object[]> countGroupedByCourse(@Param("courseIds") List<Long> courseIds,
+                                        @Param("statuses") List<EnrollmentStatus> statuses);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -29,10 +29,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EnrollmentService {
 
-    private static final List<EnrollmentStatus> COMMITTED_STATUSES = List.of(
-            EnrollmentStatus.PENDING_PAYMENT,
-            EnrollmentStatus.CONFIRMED);
-
     private final EnrollmentRepository enrollmentRepository;
     private final SchoolService schoolService;
     private final CourseService courseService;
@@ -75,9 +71,6 @@ public class EnrollmentService {
         }
 
         enrollmentRepository.save(enrollment);
-        if (enrollment.getStatus() != EnrollmentStatus.WAITLISTED) {
-            course.setEnrolledStudents(course.getEnrolledStudents() + 1);
-        }
         return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
     }
 
@@ -115,7 +108,7 @@ public class EnrollmentService {
 
         // If the course filled up between application and approval, route to the waitlist.
         long committedCount = enrollmentRepository.countByCourseIdAndStatusIn(
-                course.getId(), COMMITTED_STATUSES);
+                course.getId(), EnrollmentStatus.SEAT_HOLDING_STATI);
         if (committedCount >= course.getMaxParticipants()) {
             // Compute position BEFORE flipping to WAITLISTED so Hibernate's auto-flush
             // doesn't count this enrollment against itself.
@@ -185,7 +178,7 @@ public class EnrollmentService {
     }
 
     private WaitlistDecision resolveWaitlist(Course course, DanceRole role) {
-        long committed = enrollmentRepository.countByCourseIdAndStatusIn(course.getId(), COMMITTED_STATUSES);
+        long committed = enrollmentRepository.countByCourseIdAndStatusIn(course.getId(), EnrollmentStatus.SEAT_HOLDING_STATI);
         if (committed >= course.getMaxParticipants()) {
             return new WaitlistDecision(WaitlistReason.CAPACITY, nextPosition(course.getId(), role));
         }
@@ -196,9 +189,9 @@ public class EnrollmentService {
                 && role != null) {
             DanceRole other = (role == DanceRole.LEAD) ? DanceRole.FOLLOW : DanceRole.LEAD;
             long myCount = enrollmentRepository.countByCourseIdAndDanceRoleAndStatusIn(
-                    course.getId(), role, COMMITTED_STATUSES);
+                    course.getId(), role, EnrollmentStatus.SEAT_HOLDING_STATI);
             long otherCount = enrollmentRepository.countByCourseIdAndDanceRoleAndStatusIn(
-                    course.getId(), other, COMMITTED_STATUSES);
+                    course.getId(), other, EnrollmentStatus.SEAT_HOLDING_STATI);
             if ((myCount + 1) > otherCount + course.getRoleBalanceThreshold()) {
                 return new WaitlistDecision(WaitlistReason.ROLE_IMBALANCE, nextPosition(course.getId(), role));
             }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentStatus.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentStatus.java
@@ -1,9 +1,18 @@
 package ch.ruppen.danceschool.enrollment;
 
+import java.util.List;
+
 public enum EnrollmentStatus {
     PENDING_APPROVAL,
     PENDING_PAYMENT,
     CONFIRMED,
     WAITLISTED,
-    REJECTED
+    REJECTED;
+
+    /**
+     * Enrollments in these statuses hold a seat — they count toward the course's capacity,
+     * role-balance check, and the `enrolledStudents` total exposed in DTOs.
+     * PENDING_APPROVAL does not reserve a seat until approved; WAITLISTED / REJECTED never do.
+     */
+    public static final List<EnrollmentStatus> SEAT_HOLDING_STATI = List.of(PENDING_PAYMENT, CONFIRMED);
 }

--- a/backend/src/main/resources/db/changelog/020-drop-enrolled-students-from-course.yaml
+++ b/backend/src/main/resources/db/changelog/020-drop-enrolled-students-from-course.yaml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - changeSet:
+      id: 020-drop-enrolled-students-from-course
+      author: claude
+      changes:
+        - dropColumn:
+            tableName: course
+            columnName: enrolled_students

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -37,3 +37,5 @@ databaseChangeLog:
       file: db/changelog/018-add-requires-approval-to-course.yaml
   - include:
       file: db/changelog/019-drop-requires-approval-from-course.yaml
+  - include:
+      file: db/changelog/020-drop-enrolled-students-from-course.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
@@ -57,9 +57,18 @@ class CourseControllerIntegrationTest {
 
     @Test
     void getMe_returnsCourses_whenUserHasCourses() throws Exception {
-        createCourse(school, "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
+        Course course = createCourse(school, "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
                 DayOfWeek.MONDAY, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                8, 5, 15, new BigDecimal("180.00"), LocalDate.now());
+                8, 15, new BigDecimal("180.00"), LocalDate.now());
+        // Committed enrollments (PENDING_PAYMENT + CONFIRMED) count as enrolledStudents.
+        // WAITLISTED / PENDING_APPROVAL must not be counted.
+        createEnrollment(course, createStudent(school, "S1", "s1@example.com"), null, EnrollmentStatus.CONFIRMED);
+        createEnrollment(course, createStudent(school, "S2", "s2@example.com"), null, EnrollmentStatus.CONFIRMED);
+        createEnrollment(course, createStudent(school, "S3", "s3@example.com"), null, EnrollmentStatus.CONFIRMED);
+        createEnrollment(course, createStudent(school, "S4", "s4@example.com"), null, EnrollmentStatus.PENDING_PAYMENT);
+        createEnrollment(course, createStudent(school, "S5", "s5@example.com"), null, EnrollmentStatus.PENDING_PAYMENT);
+        createEnrollment(course, createStudent(school, "S6", "s6@example.com"), null, EnrollmentStatus.WAITLISTED);
+        createEnrollment(course, createStudent(school, "S7", "s7@example.com"), null, EnrollmentStatus.PENDING_APPROVAL);
         entityManager.flush();
 
         mockMvc.perform(get("/api/courses/me")
@@ -96,10 +105,10 @@ class CourseControllerIntegrationTest {
     void getMe_returnsMultipleCourses() throws Exception {
         createCourse(school, "Salsa Beginners", DanceStyle.SALSA, CourseLevel.BEGINNER,
                 DayOfWeek.MONDAY, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                8, 5, 15, new BigDecimal("180.00"), LocalDate.now());
+                8, 15, new BigDecimal("180.00"), LocalDate.now());
         createCourse(school, "Bachata Advanced", DanceStyle.BACHATA, CourseLevel.ADVANCED,
                 DayOfWeek.WEDNESDAY, LocalTime.of(20, 0), LocalTime.of(21, 15),
-                10, 10, 10, new BigDecimal("310.00"), LocalDate.now());
+                10, 10, new BigDecimal("310.00"), LocalDate.now());
         entityManager.flush();
 
         mockMvc.perform(get("/api/courses/me")
@@ -113,11 +122,11 @@ class CourseControllerIntegrationTest {
         Course partnerCourse = createCourseEntity(school, "Bachata Intermediate", DanceStyle.BACHATA,
                 CourseLevel.INTERMEDIATE, CourseType.PARTNER,
                 DayOfWeek.MONDAY, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                8, 0, 20, new BigDecimal("200.00"), LocalDate.now());
+                8, 20, new BigDecimal("200.00"), LocalDate.now());
         Course soloCourse = createCourseEntity(school, "Salsa Solo", DanceStyle.SALSA,
                 CourseLevel.BEGINNER, CourseType.SOLO,
                 DayOfWeek.TUESDAY, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                8, 0, 20, new BigDecimal("180.00"), LocalDate.now());
+                8, 20, new BigDecimal("180.00"), LocalDate.now());
 
         Student s1 = createStudent(school, "Anna", "anna@example.com");
         Student s2 = createStudent(school, "Ben", "ben@example.com");
@@ -186,17 +195,17 @@ class CourseControllerIntegrationTest {
         return s;
     }
 
-    private void createCourse(School s, String title, DanceStyle danceStyle, CourseLevel level,
-                              DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime,
-                              int sessions, int enrolled, int max, BigDecimal price,
-                              LocalDate publishedAt) {
-        createCourseEntity(s, title, danceStyle, level, CourseType.PARTNER,
-                dayOfWeek, startTime, endTime, sessions, enrolled, max, price, publishedAt);
+    private Course createCourse(School s, String title, DanceStyle danceStyle, CourseLevel level,
+                                DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime,
+                                int sessions, int max, BigDecimal price,
+                                LocalDate publishedAt) {
+        return createCourseEntity(s, title, danceStyle, level, CourseType.PARTNER,
+                dayOfWeek, startTime, endTime, sessions, max, price, publishedAt);
     }
 
     private Course createCourseEntity(School s, String title, DanceStyle danceStyle, CourseLevel level,
                                       CourseType courseType, DayOfWeek dayOfWeek, LocalTime startTime,
-                                      LocalTime endTime, int sessions, int enrolled, int max,
+                                      LocalTime endTime, int sessions, int max,
                                       BigDecimal price, LocalDate publishedAt) {
         LocalDate startDate = LocalDate.now().plusDays(30);
         Course course = new Course();
@@ -214,7 +223,6 @@ class CourseControllerIntegrationTest {
         course.setEndTime(endTime);
         course.setLocation("Studio A");
         course.setMaxParticipants(max);
-        course.setEnrolledStudents(enrolled);
         course.setPriceModel(PriceModel.FIXED_COURSE);
         course.setPrice(price);
         course.setPublishedAt(publishedAt);

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -202,7 +202,7 @@ class EnrollmentIntegrationTest {
     }
 
     @Test
-    void enrollStudent_atCapacity_doesNotIncrementEnrolledStudentsCounter() throws Exception {
+    void enrollStudent_atCapacity_waitlistedDoesNotCountAsCommitted() throws Exception {
         Course tinyCourse = createCourse(school, "Tiny Course", DanceStyle.SALSA,
                 CourseLevel.BEGINNER, CourseType.SOLO, 1, false, null);
         entityManager.flush();
@@ -227,11 +227,10 @@ class EnrollmentIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.status").value("WAITLISTED"));
 
-        entityManager.flush();
-        entityManager.clear();
-
-        Course refreshed = entityManager.find(Course.class, tinyCourse.getId());
-        org.junit.jupiter.api.Assertions.assertEquals(1, refreshed.getEnrolledStudents());
+        mockMvc.perform(get("/api/courses/{id}", tinyCourse.getId())
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enrolledStudents").value(1));
     }
 
     @Test

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -6,7 +6,6 @@
 ## Course Domain
 
 - **Teachers field** — `Course.teachers` is a plain String (e.g. "Maria, Carlos"). Needs to become a `@ManyToMany` relation to `SchoolMember` (role=TEACHER) when teacher signup/invite flow is built.
-- **Enrollment counts** — `Course.enrolledStudents` is a stored integer, seeded with sample data. Needs to be computed from actual enrollment records when student enrollment is built.
 - **Server-side pagination** — all table endpoints currently return the full list. Payments table will need backend `Pageable` support as transaction volume grows (rule of thumb: >500 rows).
 - **Mobile table layout** — tables are desktop-only. Needs a design decision (horizontal scroll, card layout, or hidden columns) before mobile support.
 


### PR DESCRIPTION
## Summary

Closes #272.

- Removes `Course.enrolledStudents` stored counter + `enrolled_students` column (Liquibase `020-drop-enrolled-students-from-course.yaml`).
- `CourseListDto.enrolledStudents` / `CourseDetailDto.enrolledStudents` now populated from an aggregate count over enrollments whose status holds a seat (`PENDING_PAYMENT` + `CONFIRMED`). List endpoint uses a single `GROUP BY course_id` query — no N+1.
- `EnrollmentService.enrollStudent` no longer mutates `Course` — fixes the package-by-feature leak.
- Consolidates the seat-holding status list onto `EnrollmentStatus.SEAT_HOLDING_STATI` (previously duplicated in `CourseService` and `EnrollmentService`).
- Refactors the obsolete `enrollStudent_atCapacity_doesNotIncrementEnrolledStudentsCounter` test to assert against the derived detail endpoint instead of the deleted getter.

### Behavior change

`Salsa Advanced` (seeded with 2 `PENDING_APPROVAL` enrollments) now correctly shows `0/10` instead of `2/10`. Seats aren't reserved until approval.

## Test plan

- [x] `./mvnw test` — 145 tests pass
- [x] Visual: courses list shows derived counts (Bachata Intermediate 5/15 with 2L/3F, Salsa Advanced 0/10)
- [x] Visual: course detail page count matches list (4 CONFIRMED + 1 PENDING_PAYMENT = 5)
- [x] Liquibase migration runs cleanly on fresh H2

🤖 Generated with [Claude Code](https://claude.com/claude-code)