### PR TITLE
Courses list + enrollments: cut requests on init and kill N+1 (#276)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 interface CourseRepository extends JpaRepository<Course, Long> {
 
-    List<Course> findAllBySchoolId(Long schoolId);
-
     boolean existsBySchoolId(Long schoolId);
 
     Optional<Course> findByIdAndSchoolId(Long id, Long schoolId);
@@ -26,4 +24,7 @@ interface CourseRepository extends JpaRepository<Course, Long> {
 
     @Query("SELECT c FROM Course c WHERE c.school.id = :schoolId AND c.endDate < :today")
     List<Course> findFinishedBySchoolId(Long schoolId, LocalDate today);
+
+    @Query("SELECT c FROM Course c WHERE c.school.id = :schoolId AND (c.publishedAt IS NULL OR c.endDate >= :today)")
+    List<Course> findActiveBySchoolId(Long schoolId, LocalDate today);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -198,10 +198,11 @@ public class CourseService {
     }
 
     private List<Course> fetchCourses(Long schoolId, CourseLifecycleStatus statusFilter) {
-        if (statusFilter == null) {
-            return courseRepository.findAllBySchoolId(schoolId);
-        }
         LocalDate today = LocalDate.now(clock);
+        if (statusFilter == null) {
+            // FINISHED grows unbounded; fetched explicitly when the client requests them.
+            return courseRepository.findActiveBySchoolId(schoolId, today);
+        }
         return switch (statusFilter) {
             case DRAFT -> courseRepository.findDraftBySchoolId(schoolId);
             case OPEN -> courseRepository.findOpenBySchoolId(schoolId, today);

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseStatusDerivation.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseStatusDerivation.java
@@ -25,7 +25,9 @@ import java.time.temporal.TemporalAdjusters;
  *
  * <h3>Where the rules live (important!)</h3>
  * These same rules are duplicated in {@link CourseRepository} as JPQL queries for
- * database-level filtering ({@code findDraftBySchoolId}, {@code findOpenBySchoolId}, etc.).
+ * database-level filtering ({@code findDraftBySchoolId}, {@code findOpenBySchoolId},
+ * {@code findRunningBySchoolId}, {@code findFinishedBySchoolId}, and the
+ * {@code findActiveBySchoolId} union used as the default no-filter view).
  * If you change the derivation logic here, you <b>must</b> update the corresponding repository
  * queries and their integration tests in {@code CourseFilterIntegrationTest}.
  *

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.enrollment;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,10 @@ import java.util.Optional;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
+    // Kills the 1 + 2N lazy loads in EnrollmentService.toListDto (student fields,
+    // student.danceLevels, course.danceStyle). "course" is sufficient because its
+    // basic columns (including danceStyle) are eager once the entity is loaded.
+    @EntityGraph(attributePaths = {"student", "student.danceLevels", "course"})
     List<Enrollment> findAllByCourseId(Long courseId);
 
     Optional<Enrollment> findByIdAndCourseSchoolId(Long id, Long schoolId);

--- a/backend/src/main/java/ch/ruppen/danceschool/student/Student.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/Student.java
@@ -16,8 +16,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -46,5 +46,5 @@ public class Student {
     private String phoneNumber;
 
     @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<StudentDanceLevel> danceLevels = new ArrayList<>();
+    private Set<StudentDanceLevel> danceLevels = new LinkedHashSet<>();
 }

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseFilterIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseFilterIntegrationTest.java
@@ -78,11 +78,12 @@ class CourseFilterIntegrationTest {
     }
 
     @Test
-    void noFilter_returnsAllCourses() throws Exception {
+    void noFilter_returnsActiveCoursesExcludingFinished() throws Exception {
         mockMvc.perform(get("/api/courses/me")
                         .with(authentication(authToken(ownerA))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(4));
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[?(@.status=='FINISHED')]").isEmpty());
     }
 
     @Test

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
@@ -1,0 +1,183 @@
+package ch.ruppen.danceschool.enrollment;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.course.PriceModel;
+import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.student.Student;
+import ch.ruppen.danceschool.student.StudentDanceLevel;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Proves the enrollment list query does not scale with N via Hibernate statistics.
+ * Fixes the N+1 that was lazy-loading {@code student}, {@code student.danceLevels},
+ * and {@code course} per row when building the list DTOs.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class EnrollmentListSqlBudgetTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private AppUser owner;
+    private School school;
+    private Course course;
+
+    @BeforeEach
+    void setUp() {
+        owner = createUser("owner@example.com", "Owner", "firebase-owner");
+        school = createSchoolWithOwner("Test School", owner);
+
+        course = createCourse(school);
+        entityManager.flush();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 5, 20})
+    void listEnrollments_sqlCountDoesNotScaleWithN(int n) throws Exception {
+        for (int i = 0; i < n; i++) {
+            Student s = createStudent(school, "Student " + i, "s" + i + "@example.com");
+            addDanceLevel(s, DanceStyle.BACHATA, CourseLevel.INTERMEDIATE);
+            addDanceLevel(s, DanceStyle.SALSA, CourseLevel.BEGINNER);
+            createEnrollment(course, s);
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        Statistics stats = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        mockMvc.perform(get("/api/courses/{id}/enrollments", course.getId())
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk());
+
+        assertThat(stats.getPrepareStatementCount())
+                .as("SQL budget for /enrollments with N=%d", n)
+                .isLessThanOrEqualTo(3);
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser ownerUser) {
+        School s = new School();
+        s.setName(name);
+        entityManager.persist(s);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(ownerUser);
+        member.setSchool(s);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return s;
+    }
+
+    private Course createCourse(School s) {
+        Course c = new Course();
+        c.setSchool(s);
+        c.setTitle("Bachata Intermediate");
+        c.setDanceStyle(DanceStyle.BACHATA);
+        c.setLevel(CourseLevel.INTERMEDIATE);
+        c.setCourseType(CourseType.PARTNER);
+        c.setMaxParticipants(50);
+        c.setRoleBalancingEnabled(false);
+        c.setStartDate(LocalDate.now().plusWeeks(2));
+        c.setEndDate(LocalDate.now().plusWeeks(10));
+        c.setLocation("Studio A");
+        c.setTeachers("Test Teacher");
+        c.setStartTime(LocalTime.of(19, 0));
+        c.setEndTime(LocalTime.of(20, 0));
+        c.setDayOfWeek(DayOfWeek.MONDAY);
+        c.setRecurrenceType(RecurrenceType.WEEKLY);
+        c.setNumberOfSessions(8);
+        c.setPriceModel(PriceModel.FIXED_COURSE);
+        c.setPrice(new BigDecimal("200.00"));
+        c.setPublishedAt(LocalDate.now().minusDays(1));
+        entityManager.persist(c);
+        return c;
+    }
+
+    private Student createStudent(School s, String name, String email) {
+        Student st = new Student();
+        st.setSchool(s);
+        st.setName(name);
+        st.setEmail(email);
+        entityManager.persist(st);
+        return st;
+    }
+
+    private void addDanceLevel(Student st, DanceStyle style, CourseLevel level) {
+        StudentDanceLevel dl = new StudentDanceLevel();
+        dl.setStudent(st);
+        dl.setDanceStyle(style);
+        dl.setLevel(level);
+        st.getDanceLevels().add(dl);
+        entityManager.persist(dl);
+    }
+
+    private void createEnrollment(Course c, Student s) {
+        Enrollment e = new Enrollment();
+        e.setCourse(c);
+        e.setStudent(s);
+        e.setDanceRole(DanceRole.LEAD);
+        e.setStatus(EnrollmentStatus.CONFIRMED);
+        e.setEnrolledAt(Instant.now());
+        entityManager.persist(e);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -56,6 +56,10 @@ export interface CourseDetail {
 export class CourseService {
   private http = inject(HttpClient);
 
+  getCourses(): Observable<CourseListItem[]> {
+    return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`);
+  }
+
   getCoursesByStatus(status: string): Observable<CourseListItem[]> {
     return this.http.get<CourseListItem[]>(`${environment.apiUrl}/api/courses/me`, {
       params: { status },

--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -29,6 +29,9 @@
     </div>
 
     <mat-tab-nav-panel #coursesTabPanel>
+      @if (activeTabIndex() === 4 && finishedError()) {
+        <p class="error-text">Could not load finished courses. Select the tab again to retry.</p>
+      }
       <div class="ds-table-card courses-table">
         <table mat-table [dataSource]="activeDataSource()" matSort>
           <ng-container matColumnDef="status">

--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -53,89 +53,145 @@ describe('CoursesComponent', () => {
     httpTesting.verify();
   });
 
-  function flushAllTabs(data: {
-    running?: CourseListItem[];
-    open?: CourseListItem[];
-    draft?: CourseListItem[];
-    finished?: CourseListItem[];
-  } = {}): void {
+  /**
+   * Flushes the single init request (GET /api/courses/me without status) with `courses`.
+   * The backend excludes FINISHED from this response; the component lazy-loads FINISHED
+   * on first activation.
+   */
+  function flushInit(courses: CourseListItem[] = []): void {
     fixture.detectChanges();
-    const reqs = httpTesting.match(req => req.url.includes('/api/courses/me'));
-    reqs.forEach(req => {
-      const status = req.request.params.get('status');
-      switch (status) {
-        case 'RUNNING': req.flush(data.running ?? []); break;
-        case 'OPEN': req.flush(data.open ?? []); break;
-        case 'DRAFT': req.flush(data.draft ?? []); break;
-        case 'FINISHED': req.flush(data.finished ?? []); break;
-        default: req.flush([]);
-      }
-    });
+    const reqs = httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && !req.params.has('status'));
+    expect(reqs.length).toBe(1);
+    reqs[0].flush(courses);
     fixture.detectChanges();
   }
+
+  it('fires exactly one GET /api/courses/me (no status) on init', () => {
+    fixture.detectChanges();
+    const noStatus = httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && !req.params.has('status'));
+    const withStatus = httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && req.params.has('status'));
+    expect(noStatus.length).toBe(1);
+    expect(withStatus.length).toBe(0);
+    noStatus[0].flush([]);
+  });
+
+  it('surfaces an error and allows retry when FINISHED fetch fails', () => {
+    flushInit([makeCourse({ id: 1, status: 'RUNNING' })]);
+
+    const component = fixture.componentInstance as any;
+    component.selectTab(4);
+    fixture.detectChanges();
+
+    const failed = httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && req.params.get('status') === 'FINISHED');
+    expect(failed.length).toBe(1);
+    failed[0].error(new ProgressEvent('error'));
+    fixture.detectChanges();
+
+    expect(el.querySelector('.error-text')).toBeTruthy();
+    expect(component.finishedError()).toBe(true);
+
+    // Re-activating the tab retries the fetch
+    component.selectTab(4);
+    fixture.detectChanges();
+    const retried = httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && req.params.get('status') === 'FINISHED');
+    expect(retried.length).toBe(1);
+    retried[0].flush([]);
+  });
+
+  it('loads FINISHED lazily on first Finished tab activation and caches it', () => {
+    flushInit([makeCourse({ id: 1, status: 'RUNNING' })]);
+
+    // No FINISHED request before the tab is activated
+    expect(httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && req.params.get('status') === 'FINISHED').length).toBe(0);
+
+    const component = fixture.componentInstance as any;
+    component.selectTab(4);
+    fixture.detectChanges();
+
+    const finishedReqs = httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && req.params.get('status') === 'FINISHED');
+    expect(finishedReqs.length).toBe(1);
+    finishedReqs[0].flush([makeCourse({ id: 9, status: 'FINISHED' })]);
+    fixture.detectChanges();
+
+    // Switch away and back: no refetch
+    component.selectTab(0);
+    fixture.detectChanges();
+    component.selectTab(4);
+    fixture.detectChanges();
+    expect(httpTesting.match(req =>
+      req.url.includes('/api/courses/me') && req.params.get('status') === 'FINISHED').length).toBe(0);
+  });
 
   it('should display loading state initially', () => {
     fixture.detectChanges();
     expect(el.querySelector('.loading')).toBeTruthy();
 
-    flushAllTabs();
+    flushInit();
   });
 
-  it('should display empty state when no courses in any tab', () => {
-    flushAllTabs();
+  it('should display empty state when no active courses', () => {
+    flushInit([]);
     expect(el.querySelector('.empty-state')).toBeTruthy();
     expect(el.querySelector('.empty-state-title')?.textContent?.trim()).toBe('No courses yet');
   });
 
-  it('should render 5 tabs with labels and counts (All + 4 statuses)', () => {
-    flushAllTabs({
-      running: [makeCourse({ id: 1 }), makeCourse({ id: 2 })],
-      open: [makeCourse({ id: 3, status: 'OPEN' })],
-      draft: [],
-      finished: [makeCourse({ id: 4, status: 'FINISHED' })],
-    });
+  it('should render 5 tabs (Active + 4 statuses) with labels and counts', () => {
+    flushInit([
+      makeCourse({ id: 1, status: 'RUNNING' }),
+      makeCourse({ id: 2, status: 'RUNNING' }),
+      makeCourse({ id: 3, status: 'OPEN' }),
+      makeCourse({ id: 4, status: 'DRAFT' }),
+    ]);
 
     const tabs = el.querySelectorAll('a[mat-tab-link]');
     expect(tabs.length).toBe(5);
 
     const labels = Array.from(tabs).map(t => t.querySelector('.ds-tab-label')?.textContent?.trim());
     const counts = Array.from(tabs).map(t => t.querySelector('.ds-tab-count')?.textContent?.trim());
-    expect(labels).toEqual(['All', 'Draft', 'Open', 'Running', 'Finished']);
-    expect(counts).toEqual(['4', '0', '1', '2', '1']);
+    expect(labels).toEqual(['Active', 'Draft', 'Open', 'Running', 'Finished']);
+    // Active = DRAFT + OPEN + RUNNING; Finished is 0 until lazy-loaded
+    expect(counts).toEqual(['4', '1', '1', '2', '0']);
   });
 
-  it('should show unified column set across tabs', () => {
-    flushAllTabs({ running: [makeCourse()] });
+  it('shows unified column set across tabs', () => {
+    flushInit([makeCourse()]);
 
     const headers = Array.from(el.querySelectorAll('th')).map(th => th.textContent?.trim());
     expect(headers).toEqual(['Status', 'Course Name', 'Type', 'Level', 'Start / End', 'Enrollment']);
   });
 
-  it('should display enrollment for non-draft courses', () => {
-    flushAllTabs({ running: [makeCourse({ enrolledStudents: 12, maxParticipants: 20 })] });
+  it('displays enrollment for non-draft courses', () => {
+    flushInit([makeCourse({ enrolledStudents: 12, maxParticipants: 20 })]);
 
     const cells = Array.from(el.querySelectorAll('td')).map(td => td.textContent?.trim());
     expect(cells.some(c => c?.includes('12 / 20'))).toBe(true);
   });
 
-  it('should show leads/follows sub-line for PARTNER courses', () => {
-    flushAllTabs({ running: [makeCourse({ courseType: 'PARTNER', leadCount: 5, followCount: 7 })] });
+  it('shows leads/follows sub-line for PARTNER courses', () => {
+    flushInit([makeCourse({ courseType: 'PARTNER', leadCount: 5, followCount: 7 })]);
 
     const cell = el.querySelector('td.mat-column-enrollment');
     expect(cell?.querySelector('.ds-cell-primary')?.textContent?.trim()).toBe('12 / 20');
     expect(cell?.querySelector('.ds-cell-secondary')?.textContent?.trim()).toBe('5L / 7F');
   });
 
-  it('should NOT show leads/follows sub-line for SOLO courses', () => {
-    flushAllTabs({ running: [makeCourse({ courseType: 'SOLO', leadCount: 0, followCount: 0 })] });
+  it('does NOT show leads/follows sub-line for SOLO courses', () => {
+    flushInit([makeCourse({ courseType: 'SOLO', leadCount: 0, followCount: 0 })]);
 
     const cell = el.querySelector('td.mat-column-enrollment');
     expect(cell?.querySelector('.ds-cell-primary')?.textContent?.trim()).toBe('12 / 20');
     expect(cell?.querySelector('.ds-cell-secondary')).toBeNull();
   });
 
-  it('should leave enrollment blank for draft courses', () => {
-    flushAllTabs({ draft: [makeCourse({ status: 'DRAFT', enrolledStudents: 0, maxParticipants: 20 })] });
+  it('leaves enrollment blank for draft courses', () => {
+    flushInit([makeCourse({ status: 'DRAFT', enrolledStudents: 0, maxParticipants: 20 })]);
     // Switch to Draft tab (index 1)
     const component = fixture.componentInstance as any;
     component.selectTab(1);
@@ -146,42 +202,40 @@ describe('CoursesComponent', () => {
     expect(enrollmentCells[0].textContent?.trim()).toBe('');
   });
 
-  it('should display status chip with dot indicator', () => {
-    flushAllTabs({ running: [makeCourse()] });
+  it('displays status chip with dot indicator', () => {
+    flushInit([makeCourse()]);
 
     const chip = el.querySelector('.ds-chip');
     expect(chip?.querySelector('.ds-chip__dot')).toBeTruthy();
     expect(chip?.textContent?.trim()).toContain('Running');
   });
 
-  it('should show correct count in table footer', () => {
-    flushAllTabs({ running: [makeCourse({ id: 1 }), makeCourse({ id: 2 })] });
+  it('shows correct count in table footer', () => {
+    flushInit([makeCourse({ id: 1 }), makeCourse({ id: 2 })]);
     const footer = el.querySelector('.ds-table-footer')?.textContent?.trim();
-    // All tab is default and aggregates all statuses
+    // Active tab is default and contains all non-FINISHED courses from the init response
     expect(footer).toContain('2 of 2');
   });
 
-  it('should aggregate all statuses into the All tab', () => {
-    flushAllTabs({
-      running: [makeCourse({ id: 1 }), makeCourse({ id: 2 })],
-      open: [makeCourse({ id: 3, status: 'OPEN' })],
-      draft: [makeCourse({ id: 4, status: 'DRAFT' })],
-      finished: [makeCourse({ id: 5, status: 'FINISHED' }), makeCourse({ id: 6, status: 'FINISHED' })],
-    });
+  it('aggregates non-FINISHED statuses into the Active tab', () => {
+    flushInit([
+      makeCourse({ id: 1, status: 'RUNNING' }),
+      makeCourse({ id: 2, status: 'RUNNING' }),
+      makeCourse({ id: 3, status: 'OPEN' }),
+      makeCourse({ id: 4, status: 'DRAFT' }),
+    ]);
 
     const component = fixture.componentInstance as any;
-    expect(component.tabCounts()[0]).toBe(6);
-    expect(component.tabData[0].data.map((c: CourseListItem) => c.id).sort()).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(component.tabCounts()[0]).toBe(4);
+    expect(component.tabData[0].data.map((c: CourseListItem) => c.id).sort()).toEqual([1, 2, 3, 4]);
   });
 
   describe('search filter', () => {
     it('matches title case-insensitively', () => {
-      flushAllTabs({
-        running: [
-          makeCourse({ id: 1, title: 'Bachata Fundamentals', danceStyle: 'BACHATA' }),
-          makeCourse({ id: 2, title: 'Salsa Intermediate', danceStyle: 'SALSA' }),
-        ],
-      });
+      flushInit([
+        makeCourse({ id: 1, title: 'Bachata Fundamentals', danceStyle: 'BACHATA' }),
+        makeCourse({ id: 2, title: 'Salsa Intermediate', danceStyle: 'SALSA' }),
+      ]);
       const component = fixture.componentInstance as any;
       component.searchText = 'fundamentals';
       component.applyFilter();
@@ -190,12 +244,10 @@ describe('CoursesComponent', () => {
     });
 
     it('matches dance style, level, and day of week', () => {
-      flushAllTabs({
-        running: [
-          makeCourse({ id: 1, danceStyle: 'BACHATA', level: 'BEGINNER', dayOfWeek: 'FRIDAY' }),
-          makeCourse({ id: 2, danceStyle: 'SALSA', level: 'ADVANCED', dayOfWeek: 'MONDAY' }),
-        ],
-      });
+      flushInit([
+        makeCourse({ id: 1, danceStyle: 'BACHATA', level: 'BEGINNER', dayOfWeek: 'FRIDAY' }),
+        makeCourse({ id: 2, danceStyle: 'SALSA', level: 'ADVANCED', dayOfWeek: 'MONDAY' }),
+      ]);
       const component = fixture.componentInstance as any;
 
       component.searchText = 'salsa';
@@ -212,7 +264,7 @@ describe('CoursesComponent', () => {
     });
   });
 
-  it('should display error state', () => {
+  it('displays error state', () => {
     fixture.detectChanges();
     const reqs = httpTesting.match(req => req.url.includes('/api/courses/me'));
     if (reqs.length > 0) {
@@ -224,7 +276,7 @@ describe('CoursesComponent', () => {
   });
 
   describe('helper methods', () => {
-    it('should return correct status chip class', () => {
+    it('returns correct status chip class', () => {
       const component = fixture.componentInstance as any;
       expect(component.statusChipClass('OPEN')).toBe('ds-chip-success');
       expect(component.statusChipClass('RUNNING')).toBe('ds-chip-primary');
@@ -232,13 +284,13 @@ describe('CoursesComponent', () => {
       expect(component.statusChipClass('FINISHED')).toBe('ds-chip-default');
     });
 
-    it('should calculate session duration in minutes', () => {
+    it('calculates session duration in minutes', () => {
       const component = fixture.componentInstance as any;
       expect(component.sessionDuration('19:30:00', '20:45:00')).toBe(75);
       expect(component.sessionDuration('18:00:00', '19:00:00')).toBe(60);
     });
 
-    it('should format date range with short month and year on end', () => {
+    it('formats date range with short month and year on end', () => {
       const component = fixture.componentInstance as any;
       const result: string = component.formatDateRange('2026-05-15', '2026-07-03');
       expect(result).toContain('May');
@@ -247,7 +299,7 @@ describe('CoursesComponent', () => {
       expect(result).toContain('–');
     });
 
-    it('should return correct dance style chip class', () => {
+    it('returns correct dance style chip class', () => {
       const component = fixture.componentInstance as any;
       expect(component.danceStyleChipClass('BACHATA')).toBe('ds-chip-primary');
       expect(component.danceStyleChipClass('SALSA')).toBe('ds-chip-info');

--- a/frontend/src/app/courses/courses.ts
+++ b/frontend/src/app/courses/courses.ts
@@ -10,7 +10,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatTabsModule } from '@angular/material/tabs';
-import { forkJoin } from 'rxjs';
 import { CourseListItem, CourseService } from './course.service';
 import { statusChipClass } from './shared/format-utils';
 
@@ -22,14 +21,20 @@ interface TabConfig {
 const COLUMNS = ['status', 'title', 'danceStyle', 'level', 'dateRange', 'enrollment'];
 
 const TAB_CONFIGS: TabConfig[] = [
-  { status: 'ALL', label: 'All' },
+  { status: 'ACTIVE', label: 'Active' },
   { status: 'DRAFT', label: 'Draft' },
   { status: 'OPEN', label: 'Open' },
   { status: 'RUNNING', label: 'Running' },
   { status: 'FINISHED', label: 'Finished' },
 ];
 
-const DEFAULT_TAB_INDEX = 0; // All tab
+const ACTIVE_TAB_INDEX = 0;
+const DRAFT_TAB_INDEX = 1;
+const OPEN_TAB_INDEX = 2;
+const RUNNING_TAB_INDEX = 3;
+const FINISHED_TAB_INDEX = 4;
+
+const DEFAULT_TAB_INDEX = ACTIVE_TAB_INDEX;
 
 const DAY_ORDER: Record<string, number> = {
   MONDAY: 1, TUESDAY: 2, WEDNESDAY: 3,
@@ -55,6 +60,7 @@ export class CoursesComponent implements OnInit {
   protected activeTabIndex = signal(DEFAULT_TAB_INDEX);
   protected loaded = signal(false);
   protected error = signal(false);
+  protected finishedError = signal(false);
   protected hasAnyCourses = signal(false);
 
   // Per-tab data
@@ -66,6 +72,8 @@ export class CoursesComponent implements OnInit {
   protected columns = COLUMNS;
   protected activeDataSource = computed(() => this.tabData[this.activeTabIndex()]);
   protected activeTab = computed(() => TAB_CONFIGS[this.activeTabIndex()]);
+
+  private finishedLoaded = false;
 
   @ViewChild(MatSort) set sort(sort: MatSort) {
     if (sort) {
@@ -83,22 +91,10 @@ export class CoursesComponent implements OnInit {
       };
     });
 
-    const statusTabs = TAB_CONFIGS.slice(1);
-    forkJoin(
-      statusTabs.map(tab => this.courseService.getCoursesByStatus(tab.status))
-    ).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (results) => {
-        const counts: number[] = [0];
-        const all: CourseListItem[] = [];
-        results.forEach((courses, i) => {
-          this.tabData[i + 1].data = courses;
-          counts.push(courses.length);
-          all.push(...courses);
-        });
-        counts[0] = all.length;
-        this.tabData[0].data = all;
-        this.tabCounts.set(counts);
-        this.hasAnyCourses.set(all.length > 0);
+    this.courseService.getCourses().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (courses) => {
+        this.partitionActiveCourses(courses);
+        this.hasAnyCourses.set(courses.length > 0);
         this.loaded.set(true);
       },
       error: () => {
@@ -110,6 +106,50 @@ export class CoursesComponent implements OnInit {
 
   protected selectTab(index: number): void {
     this.activeTabIndex.set(index);
+    if (index === FINISHED_TAB_INDEX && !this.finishedLoaded) {
+      this.finishedError.set(false);
+      this.loadFinishedCourses();
+    }
+  }
+
+  private partitionActiveCourses(courses: CourseListItem[]): void {
+    const draft: CourseListItem[] = [];
+    const open: CourseListItem[] = [];
+    const running: CourseListItem[] = [];
+    for (const c of courses) {
+      if (c.status === 'DRAFT') draft.push(c);
+      else if (c.status === 'OPEN') open.push(c);
+      else if (c.status === 'RUNNING') running.push(c);
+    }
+    this.tabData[ACTIVE_TAB_INDEX].data = courses;
+    this.tabData[DRAFT_TAB_INDEX].data = draft;
+    this.tabData[OPEN_TAB_INDEX].data = open;
+    this.tabData[RUNNING_TAB_INDEX].data = running;
+
+    const counts = this.tabCounts().slice();
+    counts[ACTIVE_TAB_INDEX] = courses.length;
+    counts[DRAFT_TAB_INDEX] = draft.length;
+    counts[OPEN_TAB_INDEX] = open.length;
+    counts[RUNNING_TAB_INDEX] = running.length;
+    this.tabCounts.set(counts);
+  }
+
+  private loadFinishedCourses(): void {
+    this.finishedLoaded = true;
+    this.courseService.getCoursesByStatus('FINISHED').pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (courses) => {
+        this.tabData[FINISHED_TAB_INDEX].data = courses;
+        const counts = this.tabCounts().slice();
+        counts[FINISHED_TAB_INDEX] = courses.length;
+        this.tabCounts.set(counts);
+        if (courses.length > 0) this.hasAnyCourses.set(true);
+      },
+      error: () => {
+        // Allow retry on next tab activation
+        this.finishedLoaded = false;
+        this.finishedError.set(true);
+      },
+    });
   }
 
   protected applyFilter(): void {


### PR DESCRIPTION
## Summary

- Courses list now fires **1** `GET /api/courses/me` on init instead of 4 (forkJoin). Results partition client-side; the renamed **Active** tab excludes FINISHED, and **Finished** lazy-loads on first activation (cached for the session, with a retry-on-reselect on error).
- Enrollments N+1 killed: `EnrollmentRepository.findAllByCourseId` now uses `@EntityGraph` to fetch `student`, `student.danceLevels`, and `course` in one query. `Student.danceLevels` switched to `LinkedHashSet` to avoid Cartesian duplication while keeping response order stable.
- Default (no filter) courses endpoint now returns non-FINISHED via `CourseRepository.findActiveBySchoolId`, matching the new Active tab semantics.

Closes #276

## Test plan

- [x] Backend: `EnrollmentListSqlBudgetTest` proves `prepareStatementCount <= 3` regardless of N (parameterized over 1, 5, 20)
- [x] Backend: full suite green (148 tests); `CourseFilterIntegrationTest.noFilter_*` updated for new semantic
- [x] Frontend: `courses.spec.ts` asserts exactly one no-status GET on init, one FINISHED GET on first activation only, and the error-retry path
- [x] Frontend: full suite green (88 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)