### PR TITLE
Collapse roleBalancingEnabled + roleBalanceThreshold into one field (#285)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/Course.java
@@ -70,8 +70,6 @@ public class Course {
 
     private int maxParticipants;
 
-    private boolean roleBalancingEnabled;
-
     private Integer roleBalanceThreshold;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
@@ -22,7 +22,6 @@ public record CourseDetailDto(
         String location,
         String teachers,
         int maxParticipants,
-        boolean roleBalancingEnabled,
         Integer roleBalanceThreshold,
         PriceModel priceModel,
         BigDecimal price,

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -218,10 +218,6 @@ public class CourseService {
         if (isCreate && !dto.startDate().isAfter(LocalDate.now(clock))) {
             throw new DomainRuleViolationException("Start date must be in the future");
         }
-        if (!dto.roleBalancingEnabled() && dto.roleBalanceThreshold() != null) {
-            throw new DomainRuleViolationException(
-                    "Role balance threshold requires role balancing to be enabled");
-        }
     }
 
     private void applyDto(Course course, CreateCourseDto dto) {
@@ -240,7 +236,6 @@ public class CourseService {
         course.setLocation(dto.location());
         course.setTeachers(dto.teachers());
         course.setMaxParticipants(dto.maxParticipants());
-        course.setRoleBalancingEnabled(dto.roleBalancingEnabled());
         course.setRoleBalanceThreshold(dto.roleBalanceThreshold());
         course.setPriceModel(dto.priceModel());
         course.setPrice(dto.price());
@@ -298,7 +293,6 @@ public class CourseService {
                 course.getLocation(),
                 course.getTeachers(),
                 course.getMaxParticipants(),
-                course.isRoleBalancingEnabled(),
                 course.getRoleBalanceThreshold(),
                 course.getPriceModel(),
                 course.getPrice(),

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CreateCourseDto.java
@@ -24,8 +24,7 @@ public record CreateCourseDto(
         @NotBlank @Size(max = 255) String location,
         @Size(max = 255) String teachers,
         @Min(1) int maxParticipants,
-        boolean roleBalancingEnabled,
-        Integer roleBalanceThreshold,
+        @Min(0) Integer roleBalanceThreshold,
         @NotNull PriceModel priceModel,
         @NotNull @DecimalMin("0") BigDecimal price
 ) {

--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -96,7 +96,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.SOLO, "Learn the basics of Salsa, Merengue, and Bachata in solo style.",
                 today.minusWeeks(1), RecurrenceType.WEEKLY,
                 6, LocalTime.of(19, 30), LocalTime.of(20, 45),
-                "Studio A", "Maria", 12, false, null,
+                "Studio A", "Maria", 12, null,
                 PriceModel.FIXED_COURSE, new BigDecimal("166.50")), today.minusWeeks(2)));
 
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -104,7 +104,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Take your Bachata to the next level with partner work and musicality.",
                 today.minusWeeks(2), RecurrenceType.WEEKLY,
                 8, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                "Studio B", "Carlos", 15, true, 3,
+                "Studio B", "Carlos", 15, 3,
                 PriceModel.FIXED_COURSE, new BigDecimal("220.00")), today.minusWeeks(3)));
 
         // --- OPEN courses (published, start in the future) ---
@@ -113,7 +113,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Advanced Salsa patterns, styling, and performance preparation.",
                 today.plusWeeks(4), RecurrenceType.WEEKLY,
                 10, LocalTime.of(20, 0), LocalTime.of(21, 15),
-                "Studio A", "Maria, Carlos", 10, true, 2,
+                "Studio A", "Maria, Carlos", 10, 2,
                 PriceModel.FIXED_COURSE, new BigDecimal("310.00")), today.minusDays(5));
         courses.add(salsaAdvanced);
 
@@ -122,7 +122,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Start your Bachata journey with the fundamentals of partner dancing.",
                 today.plusWeeks(5), RecurrenceType.WEEKLY,
                 6, LocalTime.of(18, 30), LocalTime.of(19, 45),
-                "Studio B", "Carlos", 16, true, null,
+                "Studio B", "Carlos", 16, 3,
                 PriceModel.FIXED_COURSE, new BigDecimal("166.50")), today.minusDays(3)));
 
         // --- DRAFT courses (not published) ---
@@ -131,7 +131,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Social dancing techniques and floor craft.",
                 today.plusWeeks(8), RecurrenceType.WEEKLY,
                 8, LocalTime.of(19, 0), LocalTime.of(20, 0),
-                "Studio A", "Maria", 20, false, null,
+                "Studio A", "Maria", 20, null,
                 PriceModel.FIXED_COURSE, new BigDecimal("220.00")), null));
 
         courses.add(courseService.seedCourse(owner.getId(), new CreateCourseDto(
@@ -139,7 +139,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
                 today.plusWeeks(10), RecurrenceType.WEEKLY,
                 6, LocalTime.of(14, 0), LocalTime.of(15, 30),
-                "Studio B", "Carlos, Ana", 12, true, null,
+                "Studio B", "Carlos, Ana", 12, 3,
                 PriceModel.FIXED_COURSE, new BigDecimal("310.00")), null));
 
         // --- FINISHED course (end date in the past) ---
@@ -148,7 +148,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Introduction to Kizomba connection and movement.",
                 today.minusWeeks(12), RecurrenceType.WEEKLY,
                 8, LocalTime.of(20, 0), LocalTime.of(21, 0),
-                "Studio A", "Luis", 14, true, null,
+                "Studio A", "Luis", 14, 3,
                 PriceModel.FIXED_COURSE, new BigDecimal("180.00")), today.minusWeeks(14)));
 
         return courses;
@@ -168,7 +168,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Introduction to Salsa for complete beginners.",
                 today.minusWeeks(1), RecurrenceType.WEEKLY,
                 8, LocalTime.of(18, 0), LocalTime.of(19, 0),
-                "Main Hall", "Ana", 20, true, null,
+                "Main Hall", "Ana", 20, 3,
                 PriceModel.FIXED_COURSE, new BigDecimal("180.00")), today.minusWeeks(2)));
 
         courses.add(courseService.seedCourse(owner2.getId(), new CreateCourseDto(
@@ -176,7 +176,7 @@ public class DevDataSeeder implements ApplicationRunner {
                 CourseType.PARTNER, "Explore Bachata Sensual technique and musicality.",
                 today.plusWeeks(3), RecurrenceType.WEEKLY,
                 6, LocalTime.of(14, 0), LocalTime.of(15, 30),
-                "Main Hall", "Ana, Luis", 12, true, null,
+                "Main Hall", "Ana, Luis", 12, 3,
                 PriceModel.FIXED_COURSE, new BigDecimal("200.00")), today.minusDays(2)));
 
         return courses;
@@ -257,7 +257,7 @@ public class DevDataSeeder implements ApplicationRunner {
         enrollmentService.seedEnrollment(soloCourse, students.get(6), null,
                 EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
 
-        // courses[1] = "Bachata Intermediate" (PARTNER, INTERMEDIATE, max 15, roleBalancing=true, threshold=3)
+        // courses[1] = "Bachata Intermediate" (PARTNER, INTERMEDIATE, max 15, threshold=3)
         // Enroll 5 students with LEAD/FOLLOW roles, mix of CONFIRMED and PENDING_PAYMENT
         Course partnerCourse = courses.get(1);
         enrollmentService.seedEnrollment(partnerCourse, students.get(0), DanceRole.FOLLOW,

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -184,7 +184,6 @@ public class EnrollmentService {
         }
 
         if (course.getCourseType() == CourseType.PARTNER
-                && course.isRoleBalancingEnabled()
                 && course.getRoleBalanceThreshold() != null
                 && role != null) {
             DanceRole other = (role == DanceRole.LEAD) ? DanceRole.FOLLOW : DanceRole.LEAD;

--- a/backend/src/main/resources/db/changelog/021-drop-role-balancing-enabled.yaml
+++ b/backend/src/main/resources/db/changelog/021-drop-role-balancing-enabled.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 021-drop-role-balancing-enabled
+      author: claude
+      changes:
+        - sql:
+            sql: >-
+              UPDATE course SET role_balance_threshold = 3
+              WHERE role_balancing_enabled = TRUE AND role_balance_threshold IS NULL
+        - dropColumn:
+            tableName: course
+            columnName: role_balancing_enabled

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -39,3 +39,5 @@ databaseChangeLog:
       file: db/changelog/019-drop-requires-approval-from-course.yaml
   - include:
       file: db/changelog/020-drop-enrolled-students-from-course.yaml
+  - include:
+      file: db/changelog/021-drop-role-balancing-enabled.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
@@ -6,7 +6,6 @@ import ch.ruppen.danceschool.schoolmember.MemberRole;
 import ch.ruppen.danceschool.schoolmember.SchoolMember;
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import ch.ruppen.danceschool.user.AppUser;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -45,9 +44,6 @@ class CourseCrudIntegrationTest {
     @Autowired
     private EntityManager entityManager;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     private AppUser ownerA;
     private AppUser ownerB;
     private School schoolA;
@@ -78,7 +74,6 @@ class CourseCrudIntegrationTest {
                   "location": "Studio A",
                   "teachers": "Maria",
                   "maxParticipants": 15,
-                  "roleBalancingEnabled": false,
                   "priceModel": "FIXED_COURSE",
                   "price": 180.00
                 }
@@ -190,7 +185,7 @@ class CourseCrudIntegrationTest {
                     .andExpect(jsonPath("$.endTime").value("21:15:00"))
                     .andExpect(jsonPath("$.location").value("Studio A"))
                     .andExpect(jsonPath("$.maxParticipants").value(12))
-                    .andExpect(jsonPath("$.roleBalancingEnabled").value(false))
+                    .andExpect(jsonPath("$.roleBalanceThreshold").doesNotExist())
                     .andExpect(jsonPath("$.priceModel").value("FIXED_COURSE"))
                     .andExpect(jsonPath("$.price").value(310.00))
                     .andExpect(jsonPath("$.status").value("OPEN"))
@@ -294,24 +289,22 @@ class CourseCrudIntegrationTest {
         }
 
         @Test
-        void rejects_whenThresholdSetWithoutBalancingEnabled() throws Exception {
+        void rejects_whenRoleBalanceThresholdIsNegative() throws Exception {
             String json = validCourseJson()
-                    .replace("\"priceModel\"", "\"roleBalanceThreshold\": 3, \"priceModel\"");
+                    .replace("\"priceModel\"", "\"roleBalanceThreshold\": -1, \"priceModel\"");
 
             mockMvc.perform(post("/api/courses")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(json)
                             .with(authentication(authToken(ownerA))))
-                    .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.detail").value(
-                            "Role balance threshold requires role balancing to be enabled"));
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.roleBalanceThreshold").exists());
         }
 
         @Test
-        void accepts_partnerCourseWithRoleBalancingEnabled() throws Exception {
+        void accepts_partnerCourseWithRoleBalanceThreshold() throws Exception {
             String json = validCourseJson()
-                    .replace("\"roleBalancingEnabled\": false",
-                            "\"roleBalancingEnabled\": true, \"roleBalanceThreshold\": 3");
+                    .replace("\"priceModel\"", "\"roleBalanceThreshold\": 3, \"priceModel\"");
 
             mockMvc.perform(post("/api/courses")
                             .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -63,10 +63,10 @@ class EnrollmentIntegrationTest {
         school = createSchoolWithOwner("Test School", owner);
 
         partnerCourse = createCourse(school, "Bachata Intermediate", DanceStyle.BACHATA,
-                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 15, true, 3);
+                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 15, 3);
 
         soloCourse = createCourse(school, "Salsa Solo Beginner", DanceStyle.SALSA,
-                CourseLevel.BEGINNER, CourseType.SOLO, 12, false, null);
+                CourseLevel.BEGINNER, CourseType.SOLO, 12, null);
 
         student = createStudent(school, "Anna Mueller", "anna@example.com", "+41 79 100 0001");
         addDanceLevel(student, DanceStyle.BACHATA, CourseLevel.INTERMEDIATE);
@@ -148,7 +148,7 @@ class EnrollmentIntegrationTest {
     @Test
     void enrollStudent_atCapacity_returnsWaitlisted_withCapacityReason_andFifoPosition() throws Exception {
         Course tinyCourse = createCourse(school, "Tiny Course", DanceStyle.SALSA,
-                CourseLevel.BEGINNER, CourseType.SOLO, 1, false, null);
+                CourseLevel.BEGINNER, CourseType.SOLO, 1, null);
         entityManager.flush();
 
         Student student2 = createStudent(school, "Marco Rossi", "marco@example.com", null);
@@ -204,7 +204,7 @@ class EnrollmentIntegrationTest {
     @Test
     void enrollStudent_atCapacity_waitlistedDoesNotCountAsCommitted() throws Exception {
         Course tinyCourse = createCourse(school, "Tiny Course", DanceStyle.SALSA,
-                CourseLevel.BEGINNER, CourseType.SOLO, 1, false, null);
+                CourseLevel.BEGINNER, CourseType.SOLO, 1, null);
         entityManager.flush();
 
         Student student2 = createStudent(school, "Marco Rossi", "marco@example.com", null);
@@ -234,11 +234,56 @@ class EnrollmentIntegrationTest {
     }
 
     @Test
+    void enrollStudent_partnerCourseWithNullThreshold_doesNotWaitlistOnImbalance() throws Exception {
+        // null threshold = balancing off. Even a large LEAD-vs-FOLLOW gap must not waitlist.
+        Course course = createCourse(school, "Bachata Unbalanced", DanceStyle.BACHATA,
+                CourseLevel.BEGINNER, CourseType.PARTNER, 20, null);
+        entityManager.flush();
+
+        Student leadA = createStudent(school, "Lead A", "leadnull-a@example.com", null);
+        Student leadB = createStudent(school, "Lead B", "leadnull-b@example.com", null);
+        Student leadC = createStudent(school, "Lead C", "leadnull-c@example.com", null);
+        Student leadD = createStudent(school, "Lead D", "leadnull-d@example.com", null);
+        entityManager.flush();
+
+        enrollPartner(course.getId(), leadA.getId(), "LEAD", "PENDING_PAYMENT");
+        enrollPartner(course.getId(), leadB.getId(), "LEAD", "PENDING_PAYMENT");
+        enrollPartner(course.getId(), leadC.getId(), "LEAD", "PENDING_PAYMENT");
+        enrollPartner(course.getId(), leadD.getId(), "LEAD", "PENDING_PAYMENT");
+    }
+
+    @Test
+    void enrollStudent_partnerCourseWithThreshold3_waitlistsWhenExceedsThreshold() throws Exception {
+        // threshold=3 → tolerate up to a 3-diff. After 4 LEADs vs 0 FOLLOWS (diff=4 > 3),
+        // the 4th LEAD must waitlist with ROLE_IMBALANCE.
+        Course course = createCourse(school, "Bachata Threshold3", DanceStyle.BACHATA,
+                CourseLevel.BEGINNER, CourseType.PARTNER, 20, 3);
+        entityManager.flush();
+
+        Student leadA = createStudent(school, "Lead A", "lead3-a@example.com", null);
+        Student leadB = createStudent(school, "Lead B", "lead3-b@example.com", null);
+        Student leadC = createStudent(school, "Lead C", "lead3-c@example.com", null);
+        Student leadD = createStudent(school, "Lead D", "lead3-d@example.com", null);
+        entityManager.flush();
+
+        enrollPartner(course.getId(), leadA.getId(), "LEAD", "PENDING_PAYMENT");
+        enrollPartner(course.getId(), leadB.getId(), "LEAD", "PENDING_PAYMENT");
+        enrollPartner(course.getId(), leadC.getId(), "LEAD", "PENDING_PAYMENT");
+
+        String resp = enrollPartner(course.getId(), leadD.getId(), "LEAD", "WAITLISTED");
+        Long id = com.jayway.jsonpath.JsonPath.parse(resp).read("$.enrollmentId", Long.class);
+        entityManager.flush();
+        entityManager.clear();
+        Enrollment waitlisted = entityManager.find(Enrollment.class, id);
+        org.junit.jupiter.api.Assertions.assertEquals(WaitlistReason.ROLE_IMBALANCE, waitlisted.getWaitlistReason());
+    }
+
+    @Test
     void enrollStudent_roleImbalance_returnsWaitlisted_withRoleImbalanceReason() throws Exception {
         // threshold=1 → tolerate up to a 1-diff. With 1 LEAD + 0 FOLLOW (diff=1=threshold, fine),
         // a second LEAD would make diff=2 > threshold → waitlist with ROLE_IMBALANCE.
         Course balancedCourse = createCourse(school, "Kizomba Balanced", DanceStyle.KIZOMBA,
-                CourseLevel.BEGINNER, CourseType.PARTNER, 20, true, 1);
+                CourseLevel.BEGINNER, CourseType.PARTNER, 20, 1);
         entityManager.flush();
 
         Student leadA = createStudent(school, "Lead A", "leada@example.com", null);
@@ -261,7 +306,7 @@ class EnrollmentIntegrationTest {
         // threshold=1, 1 LEAD (REJECTED — excluded) + 1 FOLLOW; next LEAD should NOT waitlist because
         // rejected enrollments don't count. It's PENDING_PAYMENT.
         Course advancedCourse = createCourse(school, "Salsa Advanced Gate", DanceStyle.SALSA,
-                CourseLevel.ADVANCED, CourseType.PARTNER, 20, true, 1);
+                CourseLevel.ADVANCED, CourseType.PARTNER, 20, 1);
         entityManager.flush();
 
         Student rejectedLead = createStudent(school, "Rejected Lead", "rejlead@example.com", null);
@@ -287,7 +332,7 @@ class EnrollmentIntegrationTest {
         // tinyCourse max=2: enroll 1 LEAD + 1 FOLLOW to fill capacity, then waitlist additional students.
         // Positions should be assigned per role: LEAD #1, LEAD #2, FOLLOW #1.
         Course tinyPartner = createCourse(school, "Kizomba Tiny", DanceStyle.KIZOMBA,
-                CourseLevel.BEGINNER, CourseType.PARTNER, 2, false, null);
+                CourseLevel.BEGINNER, CourseType.PARTNER, 2, null);
         entityManager.flush();
 
         Student leadA = createStudent(school, "Lead A", "leada2@example.com", null);
@@ -335,7 +380,7 @@ class EnrollmentIntegrationTest {
     @Test
     void enrollStudent_insufficientLevel_returnsPendingApproval() throws Exception {
         Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
-                CourseLevel.ADVANCED, CourseType.PARTNER, 10, true, 2);
+                CourseLevel.ADVANCED, CourseType.PARTNER, 10, 2);
         entityManager.flush();
 
         // Student has BEGINNER salsa level, course requires ADVANCED → needs approval
@@ -352,7 +397,7 @@ class EnrollmentIntegrationTest {
     @Test
     void enrollStudent_noLevelForStyle_returnsPendingApproval() throws Exception {
         Course intermediateZouk = createCourse(school, "Zouk Intermediate", DanceStyle.ZOUK,
-                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 10, false, null);
+                CourseLevel.INTERMEDIATE, CourseType.PARTNER, 10, null);
         entityManager.flush();
 
         // Student has no ZOUK level at all → needs approval
@@ -370,7 +415,7 @@ class EnrollmentIntegrationTest {
     void enrollStudent_beginnerCourse_alwaysAllowed() throws Exception {
         // Student with no Kizomba level can still enroll in BEGINNER Kizomba
         Course beginnerKizomba = createCourse(school, "Kizomba Beginner", DanceStyle.KIZOMBA,
-                CourseLevel.BEGINNER, CourseType.PARTNER, 10, false, null);
+                CourseLevel.BEGINNER, CourseType.PARTNER, 10, null);
         entityManager.flush();
 
         mockMvc.perform(post("/api/courses/{id}/enrollments", beginnerKizomba.getId())
@@ -466,7 +511,7 @@ class EnrollmentIntegrationTest {
     void enroll_withPendingApprovalApplicants_doesNotBlockCommittedEnrollment() throws Exception {
         // Course with capacity 2, ADVANCED level.
         Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
-                CourseLevel.ADVANCED, CourseType.PARTNER, 2, true, 1);
+                CourseLevel.ADVANCED, CourseType.PARTNER, 2, 1);
         entityManager.flush();
 
         // student (BEGINNER salsa) → PENDING_APPROVAL; should NOT reserve a seat.
@@ -509,7 +554,7 @@ class EnrollmentIntegrationTest {
     void approve_whenCourseFull_routesToWaitlistWithCapacityReason() throws Exception {
         // Course capacity 1, ADVANCED salsa.
         Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
-                CourseLevel.ADVANCED, CourseType.PARTNER, 1, true, 1);
+                CourseLevel.ADVANCED, CourseType.PARTNER, 1, 1);
         entityManager.flush();
 
         // Fill the one seat with a qualified direct-pay student.
@@ -561,7 +606,7 @@ class EnrollmentIntegrationTest {
         // queue for approval. Interleave enroll-time waitlisting with approve-time routing to verify
         // the per-role FIFO counter is shared between both entry points.
         Course advancedCourse = createCourse(school, "Salsa Advanced FIFO", DanceStyle.SALSA,
-                CourseLevel.ADVANCED, CourseType.PARTNER, 2, false, null);
+                CourseLevel.ADVANCED, CourseType.PARTNER, 2, null);
         entityManager.flush();
 
         Student qualifiedLead = createStudent(school, "Q Lead", "qlead@example.com", null);
@@ -688,7 +733,7 @@ class EnrollmentIntegrationTest {
     @Test
     void rejectedEnrollment_excludedFromCapacity_allowsReenrollment() throws Exception {
         Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
-                CourseLevel.ADVANCED, CourseType.PARTNER, 10, true, 2);
+                CourseLevel.ADVANCED, CourseType.PARTNER, 10, 2);
         entityManager.flush();
 
         String response = mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
@@ -811,7 +856,7 @@ class EnrollmentIntegrationTest {
 
     private Long createPendingApprovalForInsufficientLevel() throws Exception {
         Course advancedCourse = createCourse(school, "Salsa Advanced", DanceStyle.SALSA,
-                CourseLevel.ADVANCED, CourseType.PARTNER, 10, true, 2);
+                CourseLevel.ADVANCED, CourseType.PARTNER, 10, 2);
         entityManager.flush();
 
         String response = mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
@@ -827,7 +872,7 @@ class EnrollmentIntegrationTest {
 
     private Course createCourse(School s, String title, DanceStyle danceStyle, CourseLevel level,
                                 CourseType courseType, int maxParticipants,
-                                boolean roleBalancing, Integer roleBalanceThreshold) {
+                                Integer roleBalanceThreshold) {
         Course c = new Course();
         c.setSchool(s);
         c.setTitle(title);
@@ -835,7 +880,6 @@ class EnrollmentIntegrationTest {
         c.setLevel(level);
         c.setCourseType(courseType);
         c.setMaxParticipants(maxParticipants);
-        c.setRoleBalancingEnabled(roleBalancing);
         c.setRoleBalanceThreshold(roleBalanceThreshold);
         c.setStartDate(LocalDate.now().plusWeeks(2));
         c.setEndDate(LocalDate.now().plusWeeks(10));

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
@@ -130,7 +130,6 @@ class EnrollmentListSqlBudgetTest {
         c.setLevel(CourseLevel.INTERMEDIATE);
         c.setCourseType(CourseType.PARTNER);
         c.setMaxParticipants(50);
-        c.setRoleBalancingEnabled(false);
         c.setStartDate(LocalDate.now().plusWeeks(2));
         c.setEndDate(LocalDate.now().plusWeeks(10));
         c.setLocation("Studio A");

--- a/docs/TESTING_WORKFLOWS.md
+++ b/docs/TESTING_WORKFLOWS.md
@@ -99,11 +99,11 @@ Seed content (courses, students, enrollments, statuses) is defined in [`backend/
 
 ### Waitlist by role imbalance
 
-**How it triggers:** Only for PARTNER courses with `roleBalancingEnabled = true`. If adding another `LEAD` would push `leads - follows > threshold`, the new LEAD enrollment is waitlisted with reason `ROLE_IMBALANCE`. Default threshold is 3.
+**How it triggers:** Only for PARTNER courses with a non-null `roleBalanceThreshold`. If adding another `LEAD` would push `leads - follows > threshold`, the new LEAD enrollment is waitlisted with reason `ROLE_IMBALANCE`. Default threshold when enabling balancing on a new course is 3. A `null` threshold means balancing is off (no imbalance check).
 
 **How to test:**
-1. Dev Tools → pick a PARTNER BEGINNER course (e.g., "Bachata Beginners"; if its threshold is null, pick one with a threshold or enable role balancing first — Bachata Intermediate has threshold 3 but can't be Dev-Tools-filled due to level gating)
-2. Pick a role (e.g., Leader) → click "Create Imbalance" (button appears only for PARTNER courses)
+1. Dev Tools → pick a PARTNER BEGINNER course with balancing enabled (e.g., "Bachata Beginners" — threshold 3)
+2. Pick a role (e.g., Leader) → click "Create Imbalance" (button appears only for PARTNER courses with a non-null threshold)
 3. The UI enrolls enough LEADs to exceed `threshold + 1`
 4. Overflow LEADs appear in **Waitlist** tab with reason chip "Role imbalance" and a position number
 

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -42,7 +42,6 @@ export interface CourseDetail {
   location: string;
   teachers: string | null;
   maxParticipants: number;
-  roleBalancingEnabled: boolean;
   roleBalanceThreshold: number | null;
   priceModel: string;
   price: number;

--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -188,12 +188,14 @@
           @if (isPartnerCourse) {
             <div class="role-balancing-section">
               <div class="toggle-field">
-                <mat-slide-toggle formControlName="roleBalancingEnabled">
+                <mat-slide-toggle
+                  [checked]="roleBalancingEnabled"
+                  (change)="onRoleBalancingToggle($event.checked)">
                   Require Role Balancing
                 </mat-slide-toggle>
               </div>
 
-              @if (registrationGroup.controls.roleBalancingEnabled.value) {
+              @if (roleBalancingEnabled) {
                 <p class="field-hint">
                   Keeps leaders and followers roughly balanced — extras of the bigger role go on the waiting list.
                 </p>

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -107,7 +107,6 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
       location: this.scheduleGroup.controls.location.value,
       teachers: this.scheduleGroup.controls.teachers.value || null,
       maxParticipants: this.registrationGroup.controls.maxParticipants.value ?? 0,
-      roleBalancingEnabled: this.registrationGroup.controls.roleBalancingEnabled.value,
       roleBalanceThreshold: this.registrationGroup.controls.roleBalanceThreshold.value,
       priceModel: this.pricingGroup.controls.priceModel.value,
       price: this.pricingGroup.controls.price.value ?? 0,
@@ -152,9 +151,17 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(type => {
         if (!this.isEditMode) {
-          this.registrationGroup.controls.roleBalancingEnabled.setValue(type === 'PARTNER');
+          this.formService.setRoleBalancingEnabled(type === 'PARTNER');
         }
       });
+  }
+
+  protected get roleBalancingEnabled(): boolean {
+    return this.formService.roleBalancingEnabled;
+  }
+
+  protected onRoleBalancingToggle(enabled: boolean): void {
+    this.formService.setRoleBalancingEnabled(enabled);
   }
 
   protected label(items: { value: string; label: string }[], value: string): string {

--- a/frontend/src/app/courses/create/course-form.service.spec.ts
+++ b/frontend/src/app/courses/create/course-form.service.spec.ts
@@ -38,7 +38,6 @@ describe('CourseFormService.populate', () => {
       location: 'Studio A',
       teachers: '',
       maxParticipants: 20,
-      roleBalancingEnabled: false,
       roleBalanceThreshold: null,
       priceModel: 'FIXED_COURSE',
       price: 100,
@@ -46,5 +45,79 @@ describe('CourseFormService.populate', () => {
 
     expect(service.form.controls.schedule.controls.startTime.value).toBe('19:30');
     expect(service.form.controls.schedule.controls.endTime.value).toBe('21:00');
+  });
+});
+
+describe('CourseFormService.toDto', () => {
+  let service: CourseFormService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [CourseFormService] });
+    service = TestBed.inject(CourseFormService);
+  });
+
+  function fillRequired(): void {
+    service.form.patchValue({
+      details: { title: 'T', danceStyle: 'BACHATA', level: 'BEGINNER', courseType: 'PARTNER' },
+      schedule: {
+        startDate: '2030-01-01', recurrenceType: 'WEEKLY', numberOfSessions: 8,
+        startTime: '19:30', endTime: '20:45', location: 'Studio A',
+      },
+      registration: { maxParticipants: 20 },
+      pricing: { priceModel: 'FIXED_COURSE', price: 100 },
+    });
+  }
+
+  it('submits only roleBalanceThreshold — no roleBalancingEnabled field', () => {
+    fillRequired();
+    service.form.controls.registration.controls.roleBalanceThreshold.setValue(3);
+
+    const dto = service.toDto();
+
+    expect(dto).not.toHaveProperty('roleBalancingEnabled');
+    expect(dto['roleBalanceThreshold']).toBe(3);
+  });
+
+  it('submits roleBalanceThreshold as null when balancing is off', () => {
+    fillRequired();
+    service.form.controls.registration.controls.roleBalanceThreshold.setValue(null);
+
+    const dto = service.toDto();
+
+    expect(dto['roleBalanceThreshold']).toBeNull();
+    expect(dto).not.toHaveProperty('roleBalancingEnabled');
+  });
+});
+
+describe('CourseFormService role-balancing toggle', () => {
+  let service: CourseFormService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [CourseFormService] });
+    service = TestBed.inject(CourseFormService);
+  });
+
+  it('derives roleBalancingEnabled from the threshold value', () => {
+    const control = service.form.controls.registration.controls.roleBalanceThreshold;
+
+    control.setValue(null);
+    expect(service.roleBalancingEnabled).toBe(false);
+
+    control.setValue(3);
+    expect(service.roleBalancingEnabled).toBe(true);
+  });
+
+  it('toggling on sets threshold to the default (3)', () => {
+    service.form.controls.registration.controls.roleBalanceThreshold.setValue(null);
+    service.setRoleBalancingEnabled(true);
+    expect(service.form.controls.registration.controls.roleBalanceThreshold.value).toBe(3);
+    expect(service.roleBalancingEnabled).toBe(true);
+  });
+
+  it('toggling off clears threshold to null', () => {
+    service.form.controls.registration.controls.roleBalanceThreshold.setValue(5);
+    service.setRoleBalancingEnabled(false);
+    expect(service.form.controls.registration.controls.roleBalanceThreshold.value).toBeNull();
+    expect(service.roleBalancingEnabled).toBe(false);
   });
 });

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
 
+export const DEFAULT_ROLE_BALANCE_THRESHOLD = 3;
+
 @Injectable()
 export class CourseFormService {
   readonly form = new FormGroup({
@@ -22,8 +24,7 @@ export class CourseFormService {
     }),
     registration: new FormGroup({
       maxParticipants: new FormControl<number | null>(null, { validators: [Validators.required, Validators.min(1)] }),
-      roleBalancingEnabled: new FormControl(false, { nonNullable: true }),
-      roleBalanceThreshold: new FormControl<number | null>(3),
+      roleBalanceThreshold: new FormControl<number | null>(null),
     }),
     pricing: new FormGroup({
       priceModel: new FormControl('FIXED_COURSE', { nonNullable: true, validators: [Validators.required] }),
@@ -72,7 +73,6 @@ export class CourseFormService {
       },
       registration: {
         maxParticipants: data['maxParticipants'] as number,
-        roleBalancingEnabled: data['roleBalancingEnabled'] as boolean,
         roleBalanceThreshold: data['roleBalanceThreshold'] as number | null,
       },
       pricing: {
@@ -84,13 +84,22 @@ export class CourseFormService {
     this.form.markAsPristine();
   }
 
+  get roleBalancingEnabled(): boolean {
+    return this.form.controls.registration.controls.roleBalanceThreshold.value !== null;
+  }
+
+  setRoleBalancingEnabled(enabled: boolean): void {
+    const control = this.form.controls.registration.controls.roleBalanceThreshold;
+    control.setValue(enabled ? DEFAULT_ROLE_BALANCE_THRESHOLD : null);
+    control.markAsDirty();
+  }
+
   toDto(): Record<string, unknown> {
     const v = this.form.getRawValue();
     return {
       ...v.details,
       ...v.schedule,
       ...v.registration,
-      roleBalanceThreshold: v.registration.roleBalancingEnabled ? v.registration.roleBalanceThreshold : null,
       priceModel: v.pricing.priceModel,
       price: v.pricing.price,
     };

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -25,7 +25,6 @@ function makeCourseDetail(overrides: Partial<CourseDetail> = {}): CourseDetail {
     location: 'Studio A',
     teachers: null,
     maxParticipants: 20,
-    roleBalancingEnabled: true,
     roleBalanceThreshold: 2,
     priceModel: 'FIXED_COURSE',
     price: 166.5,

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -113,7 +113,6 @@ export class CourseOverviewComponent implements OnInit {
       location: c.location,
       teachers: c.teachers,
       maxParticipants: c.maxParticipants,
-      roleBalancingEnabled: c.roleBalancingEnabled,
       roleBalanceThreshold: c.roleBalanceThreshold,
       priceModel: c.priceModel,
       price: c.price,

--- a/frontend/src/app/courses/shared/course-summary.html
+++ b/frontend/src/app/courses/shared/course-summary.html
@@ -127,9 +127,9 @@
       @if (d.courseType === 'PARTNER') {
         <div class="summary-field">
           <span class="summary-label">Role Balancing</span>
-          <span class="summary-value">{{ d.roleBalancingEnabled ? 'Enabled' : 'Disabled' }}</span>
+          <span class="summary-value">{{ d.roleBalanceThreshold !== null ? 'Enabled' : 'Disabled' }}</span>
         </div>
-        @if (d.roleBalancingEnabled && d.roleBalanceThreshold) {
+        @if (d.roleBalanceThreshold !== null) {
           <div class="summary-field">
             <span class="summary-label">Max Imbalance</span>
             <span class="summary-value">{{ d.roleBalanceThreshold }}</span>

--- a/frontend/src/app/courses/shared/course-summary.spec.ts
+++ b/frontend/src/app/courses/shared/course-summary.spec.ts
@@ -18,7 +18,6 @@ function makeSummaryData(overrides: Partial<CourseSummaryData> = {}): CourseSumm
     location: 'Studio A',
     teachers: null,
     maxParticipants: 20,
-    roleBalancingEnabled: true,
     roleBalanceThreshold: 2,
     priceModel: 'FIXED_COURSE',
     price: 166.5,
@@ -116,11 +115,23 @@ describe('CourseSummaryComponent', () => {
     expect(labels).not.toContain('Description');
   });
 
-  it('should show role balancing fields for partner courses', () => {
-    setup(makeSummaryData({ courseType: 'PARTNER', roleBalancingEnabled: true, roleBalanceThreshold: 3 }));
+  it('should show role balancing fields for partner courses with a threshold', () => {
+    setup(makeSummaryData({ courseType: 'PARTNER', roleBalanceThreshold: 3 }));
     const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
     expect(labels).toContain('Role Balancing');
     expect(labels).toContain('Max Imbalance');
+    const values = Array.from(el.querySelectorAll('.summary-value')).map(e => e.textContent?.trim());
+    expect(values).toContain('Enabled');
+    expect(values).toContain('3');
+  });
+
+  it('should show Role Balancing disabled (no Max Imbalance) for partner courses with null threshold', () => {
+    setup(makeSummaryData({ courseType: 'PARTNER', roleBalanceThreshold: null }));
+    const labels = Array.from(el.querySelectorAll('.summary-label')).map(e => e.textContent?.trim());
+    expect(labels).toContain('Role Balancing');
+    expect(labels).not.toContain('Max Imbalance');
+    const values = Array.from(el.querySelectorAll('.summary-value')).map(e => e.textContent?.trim());
+    expect(values).toContain('Disabled');
   });
 
   it('should hide role balancing fields for solo courses', () => {

--- a/frontend/src/app/courses/shared/course-summary.ts
+++ b/frontend/src/app/courses/shared/course-summary.ts
@@ -24,8 +24,7 @@ export interface CourseSummaryData {
   location: string;
   teachers?: string | null;
   maxParticipants: number;
-  roleBalancingEnabled: boolean;
-  roleBalanceThreshold?: number | null;
+  roleBalanceThreshold: number | null;
   priceModel: string;
   price: number;
 }

--- a/frontend/src/app/dev-tools/dev-tools.html
+++ b/frontend/src/app/dev-tools/dev-tools.html
@@ -38,7 +38,7 @@
         Add Student
       </button>
 
-      @if (isPartnerCourse()) {
+      @if (hasRoleBalancing()) {
         <button mat-stroked-button (click)="onCreateImbalance()" [disabled]="imbalancing()">
           @if (imbalancing()) {
             <mat-spinner diameter="18"></mat-spinner>

--- a/frontend/src/app/dev-tools/dev-tools.ts
+++ b/frontend/src/app/dev-tools/dev-tools.ts
@@ -72,6 +72,10 @@ export class DevToolsComponent implements OnInit {
     return this.courseDetail()?.courseType === 'PARTNER';
   }
 
+  protected hasRoleBalancing(): boolean {
+    return this.isPartnerCourse() && this.courseDetail()?.roleBalanceThreshold != null;
+  }
+
   protected onFillCourse(): void {
     const courseId = this.selectedCourseId();
     if (!courseId) return;
@@ -161,9 +165,9 @@ export class DevToolsComponent implements OnInit {
   protected onCreateImbalance(): void {
     const courseId = this.selectedCourseId();
     const course = this.courseDetail();
-    if (!courseId || !course || course.courseType !== 'PARTNER') return;
+    if (!courseId || !course || course.courseType !== 'PARTNER' || course.roleBalanceThreshold == null) return;
 
-    const threshold = course.roleBalanceThreshold ?? 3;
+    const threshold = course.roleBalanceThreshold;
     const role = this.danceRole();
     const other = role === 'LEAD' ? 'FOLLOW' : 'LEAD';
 


### PR DESCRIPTION
## Summary

- Drops `Course.roleBalancingEnabled` (boolean). `roleBalanceThreshold: Integer` is now the single source of truth: `null` = balancing off, non-null = on. Tolerate up to `n` excess of one role over the other.
- Adds `@Min(0)` to reject negative thresholds (400).
- Liquibase migration `021` backfills `threshold = 3` for rows where `enabled=true AND threshold IS NULL` before dropping the column. Three of five seeded PARTNER courses were in that state — the imbalance check was being silently bypassed on them.
- Frontend UX unchanged. The toggle is now a view-layer widget derived from `threshold !== null`, flipping between `3` (default) and `null`. Only `roleBalanceThreshold` is submitted to the API.
- `DevDataSeeder` updated: Bachata Beginners now seeds with `threshold=3`, so Dev Tools → **Create Imbalance** actually produces a `WAITLISTED (ROLE_IMBALANCE)` row (the original repro from the issue).

Closes #285

## Test plan

- [x] `./mvnw test` — 150 passed
- [x] `npx ng test --browsers chromium --no-watch` — 91 passed
- [x] New backend tests: null threshold does not waitlist on imbalance; threshold=3 waitlists the 4th LEAD with `ROLE_IMBALANCE`; negative threshold returns 400
- [x] New frontend tests: toggle derives from threshold; toggle-on → 3, toggle-off → null; `toDto` emits only `roleBalanceThreshold`
- [x] Visual: Bachata Beginners course overview shows "Role Balancing: Enabled, Max Imbalance: 3"
- [x] Visual: Dev Tools → Create Imbalance on Bachata Beginners enrolls 3 LEADs as `PENDING_PAYMENT` + 1 LEAD as `WAITLISTED (role imbalance)`
- [x] Visual: Course edit → Registration toggle off hides Max Imbalance; toggle back on restores default 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)