### PR TITLE
Apply role-imbalance check to approval flow (#292)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -56,19 +56,7 @@ public class EnrollmentService {
         enrollment.setEnrolledAt(Instant.now(clock));
         enrollment.setEnrolledBy(enrolledBy);
 
-        EnrollmentStatus bookingStatus = resolveBookingStatus(course, student);
-        // PENDING_APPROVAL applicants queue for owner review — they don't reserve seats at enroll time,
-        // so capacity / role-balance only gate the committed (direct-pay) path. Approval re-checks capacity.
-        WaitlistDecision waitlist = (bookingStatus == EnrollmentStatus.PENDING_PAYMENT)
-                ? resolveWaitlist(course, dto.danceRole())
-                : null;
-        if (waitlist != null) {
-            enrollment.setStatus(EnrollmentStatus.WAITLISTED);
-            enrollment.setWaitlistReason(waitlist.reason());
-            enrollment.setWaitlistPosition(waitlist.position());
-        } else {
-            enrollment.setStatus(bookingStatus);
-        }
+        applyBookingDecision(enrollment);
 
         enrollmentRepository.save(enrollment);
         return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
@@ -106,19 +94,9 @@ public class EnrollmentService {
         Course course = enrollment.getCourse();
         upsertStudentDanceLevel(enrollment.getStudent(), course.getDanceStyle(), course.getLevel());
 
-        // If the course filled up between application and approval, route to the waitlist.
-        long committedCount = enrollmentRepository.countByCourseIdAndStatusIn(
-                course.getId(), EnrollmentStatus.SEAT_HOLDING_STATI);
-        if (committedCount >= course.getMaxParticipants()) {
-            // Compute position BEFORE flipping to WAITLISTED so Hibernate's auto-flush
-            // doesn't count this enrollment against itself.
-            int position = nextPosition(course.getId(), enrollment.getDanceRole());
-            enrollment.setStatus(EnrollmentStatus.WAITLISTED);
-            enrollment.setWaitlistReason(WaitlistReason.CAPACITY);
-            enrollment.setWaitlistPosition(position);
-        } else {
-            enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
-        }
+        // Order matters: upsert first so the level gate now passes, then apply the same
+        // capacity + role-balance checks the direct-pay path runs.
+        applyBookingDecision(enrollment);
 
         return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
     }
@@ -174,6 +152,23 @@ public class EnrollmentService {
         if (enrollmentRepository.existsByStudentIdAndCourseIdAndStatusNot(
                 studentId, courseId, EnrollmentStatus.REJECTED)) {
             throw new DomainRuleViolationException("Student is already enrolled in this course");
+        }
+    }
+
+    private void applyBookingDecision(Enrollment enrollment) {
+        Course course = enrollment.getCourse();
+        EnrollmentStatus bookingStatus = resolveBookingStatus(course, enrollment.getStudent());
+        // PENDING_APPROVAL doesn't reserve a seat, so skip capacity/role-balance until approval
+        // promotes it to a committed status.
+        WaitlistDecision waitlist = (bookingStatus == EnrollmentStatus.PENDING_PAYMENT)
+                ? resolveWaitlist(course, enrollment.getDanceRole())
+                : null;
+        if (waitlist != null) {
+            enrollment.setStatus(EnrollmentStatus.WAITLISTED);
+            enrollment.setWaitlistReason(waitlist.reason());
+            enrollment.setWaitlistPosition(waitlist.position());
+        } else {
+            enrollment.setStatus(bookingStatus);
         }
     }
 

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -601,6 +601,55 @@ class EnrollmentIntegrationTest {
     }
 
     @Test
+    void approve_whenRoleImbalanceExceeded_routesToWaitlistWithImbalanceReason() throws Exception {
+        // Capacity well above demand, but role-balance threshold of 2: the approval path must apply
+        // the same imbalance check as the enroll-time path. Under-leveled LEAD applies first, then
+        // qualified LEADs fill the lead side; approving the applicant would push the lead/follow
+        // diff past the threshold.
+        Course advancedCourse = createCourse(school, "Salsa Advanced Imbalance", DanceStyle.SALSA,
+                CourseLevel.ADVANCED, CourseType.PARTNER, 10, 2);
+        entityManager.flush();
+
+        // Under-leveled LEAD applies → PENDING_APPROVAL, no seat reserved.
+        String pendingResponse = mockMvc.perform(post("/api/courses/{id}/enrollments", advancedCourse.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"studentId": %d, "danceRole": "LEAD"}
+                                """.formatted(student.getId()))
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING_APPROVAL"))
+                .andReturn().getResponse().getContentAsString();
+        Long pendingId = com.jayway.jsonpath.JsonPath.parse(pendingResponse).read("$.enrollmentId", Long.class);
+
+        // Two qualified LEADs sign up directly: 0→1 and 1→2, both within the +2 threshold vs zero FOLLOWs.
+        Student qualifiedLead1 = createStudent(school, "Q Lead 1", "qlead1@example.com", null);
+        addDanceLevel(qualifiedLead1, DanceStyle.SALSA, CourseLevel.ADVANCED);
+        Student qualifiedLead2 = createStudent(school, "Q Lead 2", "qlead2@example.com", null);
+        addDanceLevel(qualifiedLead2, DanceStyle.SALSA, CourseLevel.ADVANCED);
+        entityManager.flush();
+
+        enrollPartner(advancedCourse.getId(), qualifiedLead1.getId(), "LEAD", "PENDING_PAYMENT");
+        enrollPartner(advancedCourse.getId(), qualifiedLead2.getId(), "LEAD", "PENDING_PAYMENT");
+
+        // Approve: 2 LEADs vs 0 FOLLOWs, +1 would make diff = 3 > threshold 2 → ROLE_IMBALANCE.
+        mockMvc.perform(put("/api/enrollments/{id}/approve", pendingId)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("WAITLISTED"));
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Enrollment updated = entityManager.find(Enrollment.class, pendingId);
+        org.junit.jupiter.api.Assertions.assertEquals(EnrollmentStatus.WAITLISTED, updated.getStatus());
+        org.junit.jupiter.api.Assertions.assertEquals(WaitlistReason.ROLE_IMBALANCE, updated.getWaitlistReason());
+        org.junit.jupiter.api.Assertions.assertEquals(1, updated.getWaitlistPosition());
+        // approvedAt is still set — approval decision is separate from slot outcome.
+        org.junit.jupiter.api.Assertions.assertNotNull(updated.getApprovedAt());
+    }
+
+    @Test
     void approve_toWaitlist_assignsPositionFifoPerRole_acrossEnrollAndApprovePaths() throws Exception {
         // Capacity 2 ADVANCED partner course: qualified students fill seats, under-leveled students
         // queue for approval. Interleave enroll-time waitlisting with approve-time routing to verify


### PR DESCRIPTION
Closes #292.

## Summary
- Approval previously only re-checked capacity. An applicant in `PENDING_APPROVAL` could land in `PENDING_PAYMENT` even after committed enrollments had pushed the course past the role-balance threshold — a direct-pay path would have routed the same applicant to `WAITLISTED(ROLE_IMBALANCE)`.
- Extract the post-validation booking decision (resolveBookingStatus + resolveWaitlist) into a private `applyBookingDecision` helper, reused by both `enrollStudent` and `approveEnrollment`.
- Approve now upserts the student's level first (so the level gate passes), then runs the same capacity + role-balance pipeline as enroll.

## Test plan
- [x] `./mvnw test` — 151 passing, including new `approve_whenRoleImbalanceExceeded_routesToWaitlistWithImbalanceReason` (capacity 10, threshold 2: applicant LEAD applies under-leveled, two qualified LEADs join, approve → WAITLISTED + ROLE_IMBALANCE + position 1 + approvedAt set)
- [x] Existing `approve_whenCourseFull_routesToWaitlistWithCapacityReason` and FIFO-ordering test still pass — capacity branch behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)