### PR TITLE
Hide enrollment seat-holding internals behind EnrollmentService (#291)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseRepository.java
@@ -7,7 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-interface CourseRepository extends JpaRepository<Course, Long> {
+public interface CourseRepository extends JpaRepository<Course, Long> {
 
     boolean existsBySchoolId(Long schoolId);
 

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -1,8 +1,7 @@
 package ch.ruppen.danceschool.course;
 
-import ch.ruppen.danceschool.enrollment.DanceRole;
-import ch.ruppen.danceschool.enrollment.EnrollmentRepository;
-import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
+import ch.ruppen.danceschool.enrollment.EnrollmentService;
+import ch.ruppen.danceschool.enrollment.RoleCounts;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +25,7 @@ import java.util.Map;
 public class CourseService {
 
     private final CourseRepository courseRepository;
-    private final EnrollmentRepository enrollmentRepository;
+    private final EnrollmentService enrollmentService;
     private final SchoolService schoolService;
     private final Clock clock;
 
@@ -37,49 +35,13 @@ public class CourseService {
         List<Course> courses = fetchCourses(school.getId(), statusFilter);
         LocalDate today = LocalDate.now(clock);
         List<Long> courseIds = courses.stream().map(Course::getId).toList();
-        Map<Long, RoleCounts> roleCounts = fetchRoleCounts(courseIds);
-        Map<Long, Integer> committedCounts = fetchCommittedCounts(courseIds);
+        Map<Long, RoleCounts> roleCounts = enrollmentService.countSeatHoldersByRoleGroupedByCourse(courseIds);
+        Map<Long, Integer> committedCounts = enrollmentService.countSeatHoldersGroupedByCourse(courseIds);
         return courses.stream()
                 .map(c -> toListDto(c, today,
                         committedCounts.getOrDefault(c.getId(), 0),
                         roleCounts.getOrDefault(c.getId(), RoleCounts.EMPTY)))
                 .toList();
-    }
-
-    private Map<Long, RoleCounts> fetchRoleCounts(List<Long> courseIds) {
-        if (courseIds.isEmpty()) {
-            return Map.of();
-        }
-        Map<Long, RoleCounts> result = new HashMap<>();
-        for (Object[] row : enrollmentRepository.countByRoleGroupedByCourse(courseIds, EnrollmentStatus.SEAT_HOLDING_STATI)) {
-            Long courseId = (Long) row[0];
-            DanceRole role = (DanceRole) row[1];
-            int count = ((Number) row[2]).intValue();
-            RoleCounts existing = result.getOrDefault(courseId, RoleCounts.EMPTY);
-            result.put(courseId, existing.plus(role, count));
-        }
-        return result;
-    }
-
-    private Map<Long, Integer> fetchCommittedCounts(List<Long> courseIds) {
-        if (courseIds.isEmpty()) {
-            return Map.of();
-        }
-        Map<Long, Integer> result = new HashMap<>();
-        for (Object[] row : enrollmentRepository.countGroupedByCourse(courseIds, EnrollmentStatus.SEAT_HOLDING_STATI)) {
-            result.put((Long) row[0], ((Number) row[1]).intValue());
-        }
-        return result;
-    }
-
-    private record RoleCounts(int leads, int follows) {
-        static final RoleCounts EMPTY = new RoleCounts(0, 0);
-
-        RoleCounts plus(DanceRole role, int count) {
-            if (role == DanceRole.LEAD) return new RoleCounts(leads + count, follows);
-            if (role == DanceRole.FOLLOW) return new RoleCounts(leads, follows + count);
-            return this;
-        }
     }
 
     @Transactional
@@ -186,12 +148,6 @@ public class CourseService {
     }
 
     @Transactional(readOnly = true)
-    public Course findCourseByIdAndSchool(Long courseId, School school) {
-        return courseRepository.findByIdAndSchoolId(courseId, school.getId())
-                .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
-    }
-
-    @Transactional(readOnly = true)
     public boolean hasCoursesForMember(Long userId) {
         School school = schoolService.findSchoolByMember(userId);
         return courseRepository.existsBySchoolId(school.getId());
@@ -274,8 +230,7 @@ public class CourseService {
     }
 
     private CourseDetailDto toDetailDto(Course course, LocalDate today) {
-        int enrolledStudents = (int) enrollmentRepository.countByCourseIdAndStatusIn(
-                course.getId(), EnrollmentStatus.SEAT_HOLDING_STATI);
+        int enrolledStudents = enrollmentService.countSeatHoldersByCourse(course.getId());
         return new CourseDetailDto(
                 course.getId(),
                 course.getTitle(),

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     // Kills the 1 + 2N lazy loads in EnrollmentService.toListDto (student fields,
     // student.danceLevels, course.danceStyle). "course" is sufficient because its

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -2,7 +2,7 @@ package ch.ruppen.danceschool.enrollment;
 
 import ch.ruppen.danceschool.course.Course;
 import ch.ruppen.danceschool.course.CourseLevel;
-import ch.ruppen.danceschool.course.CourseService;
+import ch.ruppen.danceschool.course.CourseRepository;
 import ch.ruppen.danceschool.course.CourseType;
 import ch.ruppen.danceschool.course.DanceStyle;
 import ch.ruppen.danceschool.school.School;
@@ -22,7 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -31,7 +33,7 @@ public class EnrollmentService {
 
     private final EnrollmentRepository enrollmentRepository;
     private final SchoolService schoolService;
-    private final CourseService courseService;
+    private final CourseRepository courseRepository;
     private final StudentService studentService;
     private final SchoolMemberService schoolMemberService;
     private final Clock clock;
@@ -40,7 +42,7 @@ public class EnrollmentService {
     @BusinessOperation(event = "StudentEnrolled")
     public EnrollmentResponseDto enrollStudent(Long userId, Long courseId, EnrollStudentDto dto) {
         School school = schoolService.findSchoolByMember(userId);
-        Course course = courseService.findCourseByIdAndSchool(courseId, school);
+        Course course = loadCourseInSchool(courseId, school);
         Student student = studentService.findStudentByIdAndSchool(dto.studentId(), school);
 
         validateDanceRole(course, dto.danceRole());
@@ -139,9 +141,48 @@ public class EnrollmentService {
     }
 
     @Transactional(readOnly = true)
+    public Map<Long, RoleCounts> countSeatHoldersByRoleGroupedByCourse(List<Long> courseIds) {
+        if (courseIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, RoleCounts> result = new HashMap<>();
+        for (Object[] row : enrollmentRepository.countByRoleGroupedByCourse(courseIds, EnrollmentStatus.SEAT_HOLDING_STATI)) {
+            Long courseId = (Long) row[0];
+            DanceRole role = (DanceRole) row[1];
+            int count = ((Number) row[2]).intValue();
+            RoleCounts existing = result.getOrDefault(courseId, RoleCounts.EMPTY);
+            result.put(courseId, existing.plus(role, count));
+        }
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Integer> countSeatHoldersGroupedByCourse(List<Long> courseIds) {
+        if (courseIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Integer> result = new HashMap<>();
+        for (Object[] row : enrollmentRepository.countGroupedByCourse(courseIds, EnrollmentStatus.SEAT_HOLDING_STATI)) {
+            result.put((Long) row[0], ((Number) row[1]).intValue());
+        }
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public int countSeatHoldersByCourse(Long courseId) {
+        return (int) enrollmentRepository.countByCourseIdAndStatusIn(
+                courseId, EnrollmentStatus.SEAT_HOLDING_STATI);
+    }
+
+    private Course loadCourseInSchool(Long courseId, School school) {
+        return courseRepository.findByIdAndSchoolId(courseId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
+    }
+
+    @Transactional(readOnly = true)
     public List<EnrollmentListDto> getEnrollments(Long userId, Long courseId) {
         School school = schoolService.findSchoolByMember(userId);
-        courseService.findCourseByIdAndSchool(courseId, school);
+        loadCourseInSchool(courseId, school);
 
         return enrollmentRepository.findAllByCourseId(courseId).stream()
                 .map(this::toListDto)

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/RoleCounts.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/RoleCounts.java
@@ -1,0 +1,12 @@
+package ch.ruppen.danceschool.enrollment;
+
+public record RoleCounts(int leads, int follows) {
+
+    public static final RoleCounts EMPTY = new RoleCounts(0, 0);
+
+    RoleCounts plus(DanceRole role, int count) {
+        if (role == DanceRole.LEAD) return new RoleCounts(leads + count, follows);
+        if (role == DanceRole.FOLLOW) return new RoleCounts(leads, follows + count);
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary

- Move seat-holder counting out of `CourseService` into three new `EnrollmentService` methods (`countSeatHoldersByRoleGroupedByCourse`, `countSeatHoldersGroupedByCourse`, `countSeatHoldersByCourse`); `CourseService` no longer imports `EnrollmentRepository` or `EnrollmentStatus`.
- Relocate the `RoleCounts` record to the `enrollment` package as a shared value object.
- Break the resulting `CourseService` ↔ `EnrollmentService` cycle by having `EnrollmentService` inject `CourseRepository` directly for its tenant-scoped course lookup. `CourseRepository` is now public (cross-slice repo injection is explicitly allowed per `CLAUDE.md`); the unused `CourseService.findCourseByIdAndSchool` helper is removed. `EnrollmentRepository` returns to package-private.

Closes #291.

## Test plan

- [x] `./mvnw test` — 150/150 pass
- [x] Visual verification at 1440x900: courses list renders role counts (`2L / 3F`) and committed counts; course detail page shows correct seat-holding count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)