### PR TITLE
Payments admin page: Open / Completed tabs + Mark Paid (#296)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/dev/DevDataSeeder.java
@@ -75,10 +75,14 @@ public class DevDataSeeder implements ApplicationRunner {
 
         List<Course> courses1 = seedCourses(owner);
         List<Course> courses2 = seedCoursesForOwner2(owner2);
-        List<Student> students1 = seedStudents(owner, owner2);
-        seedEnrollments(owner, courses1, students1);
+        SeededStudents students = seedStudents(owner, owner2);
+        seedEnrollments(courses1, students.school1());
+        seedEnrollmentsForOwner2(courses2, students.school2());
 
         log.info("Dev data seeded: owner@test.com (School 1), owner2@test.com (School 2)");
+    }
+
+    private record SeededStudents(List<Student> school1, List<Student> school2) {
     }
 
     private List<Course> seedCourses(AppUser owner) {
@@ -182,15 +186,16 @@ public class DevDataSeeder implements ApplicationRunner {
         return courses;
     }
 
-    private List<Student> seedStudents(AppUser owner, AppUser owner2) {
+    private SeededStudents seedStudents(AppUser owner, AppUser owner2) {
         if (studentService.hasStudentsForSchool(owner.getId())) {
-            return List.of();
+            return new SeededStudents(List.of(), List.of());
         }
 
         School school1 = schoolService.findSchoolByMember(owner.getId());
         School school2 = schoolService.findSchoolByMember(owner2.getId());
 
         List<Student> students = new ArrayList<>();
+        List<Student> students2 = new ArrayList<>();
 
         // School 1: 7 students with varied dance levels
         students.add(studentService.seedStudent(school1, "Anna Mueller", "anna.mueller@example.com", "+41 79 100 0001",
@@ -220,21 +225,31 @@ public class DevDataSeeder implements ApplicationRunner {
                         new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.INTERMEDIATE),
                         new CreateStudentDto.DanceLevelEntry(DanceStyle.ZOUK, CourseLevel.BEGINNER))));
 
-        // School 2: 3 students
-        studentService.seedStudent(school2, "Elena Fischer", "elena.fischer@example.com", "+41 79 200 0001",
-                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.BEGINNER)));
+        // School 2: 6 students
+        students2.add(studentService.seedStudent(school2, "Elena Fischer", "elena.fischer@example.com", "+41 79 200 0001",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.BEGINNER))));
 
-        studentService.seedStudent(school2, "Thomas Bauer", "thomas.bauer@example.com", "+41 79 200 0002",
+        students2.add(studentService.seedStudent(school2, "Thomas Bauer", "thomas.bauer@example.com", "+41 79 200 0002",
                 List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.INTERMEDIATE),
-                        new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE)));
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE))));
 
-        studentService.seedStudent(school2, "Mia Schmidt", "mia.schmidt@example.com", null,
-                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.STARTER)));
+        students2.add(studentService.seedStudent(school2, "Mia Schmidt", "mia.schmidt@example.com", null,
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.STARTER))));
 
-        return students;
+        students2.add(studentService.seedStudent(school2, "Lukas Huber", "lukas.huber@example.com", "+41 79 200 0004",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.BEGINNER),
+                        new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.STARTER))));
+
+        students2.add(studentService.seedStudent(school2, "Clara Meier", "clara.meier@example.com", "+41 79 200 0005",
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.BACHATA, CourseLevel.ADVANCED))));
+
+        students2.add(studentService.seedStudent(school2, "Pedro Alvarez", "pedro.alvarez@example.com", null,
+                List.of(new CreateStudentDto.DanceLevelEntry(DanceStyle.SALSA, CourseLevel.INTERMEDIATE))));
+
+        return new SeededStudents(students, students2);
     }
 
-    private void seedEnrollments(AppUser owner, List<Course> courses, List<Student> students) {
+    private void seedEnrollments(List<Course> courses, List<Student> students) {
         if (courses.isEmpty() || students.isEmpty()) {
             return;
         }
@@ -281,5 +296,54 @@ public class DevDataSeeder implements ApplicationRunner {
                 EnrollmentStatus.PENDING_APPROVAL, now.minus(1, ChronoUnit.DAYS), null);
         enrollmentService.seedEnrollment(salsaAdvanced, students.get(5), DanceRole.LEAD,
                 EnrollmentStatus.PENDING_APPROVAL, now.minus(12, ChronoUnit.HOURS), null);
+
+        // courses[3] = "Bachata Beginners" (PARTNER, BEGINNER)
+        // Mix of CONFIRMED-with-paidAt and PENDING_PAYMENT so the Payments page has
+        // ≥5 of each status to demo Open / Completed tabs meaningfully.
+        Course bachataBeginners = courses.get(3);
+        enrollmentService.seedEnrollment(bachataBeginners, students.get(2), DanceRole.FOLLOW,
+                EnrollmentStatus.CONFIRMED, now.minus(6, ChronoUnit.DAYS), now.minus(4, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(bachataBeginners, students.get(3), DanceRole.LEAD,
+                EnrollmentStatus.CONFIRMED, now.minus(5, ChronoUnit.DAYS), now.minus(3, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(bachataBeginners, students.get(0), DanceRole.FOLLOW,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(4, ChronoUnit.DAYS), null);
+        enrollmentService.seedEnrollment(bachataBeginners, students.get(1), DanceRole.LEAD,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(1, ChronoUnit.DAYS), null);
+        enrollmentService.seedEnrollment(bachataBeginners, students.get(5), DanceRole.LEAD,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(6, ChronoUnit.HOURS), null);
+    }
+
+    private void seedEnrollmentsForOwner2(List<Course> courses, List<Student> students) {
+        if (courses.isEmpty() || students.isEmpty()) {
+            return;
+        }
+
+        Instant now = Instant.now();
+
+        // courses[0] = "Salsa Beginners" (PARTNER, BEGINNER, max 20)
+        Course salsaBeginners = courses.get(0);
+        enrollmentService.seedEnrollment(salsaBeginners, students.get(0), DanceRole.FOLLOW,
+                EnrollmentStatus.CONFIRMED, now.minus(9, ChronoUnit.DAYS), now.minus(7, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(salsaBeginners, students.get(1), DanceRole.LEAD,
+                EnrollmentStatus.CONFIRMED, now.minus(8, ChronoUnit.DAYS), now.minus(6, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(salsaBeginners, students.get(2), DanceRole.FOLLOW,
+                EnrollmentStatus.CONFIRMED, now.minus(7, ChronoUnit.DAYS), now.minus(5, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(salsaBeginners, students.get(3), DanceRole.LEAD,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(5, ChronoUnit.DAYS), null);
+        enrollmentService.seedEnrollment(salsaBeginners, students.get(5), DanceRole.LEAD,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(3, ChronoUnit.DAYS), null);
+        enrollmentService.seedEnrollment(salsaBeginners, students.get(4), DanceRole.FOLLOW,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(2, ChronoUnit.DAYS), null);
+
+        // courses[1] = "Bachata Sensual" (PARTNER, ADVANCED, max 12) — for owner2
+        Course bachataSensual = courses.get(1);
+        enrollmentService.seedEnrollment(bachataSensual, students.get(4), DanceRole.FOLLOW,
+                EnrollmentStatus.CONFIRMED, now.minus(11, ChronoUnit.DAYS), now.minus(8, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(bachataSensual, students.get(1), DanceRole.LEAD,
+                EnrollmentStatus.CONFIRMED, now.minus(10, ChronoUnit.DAYS), now.minus(6, ChronoUnit.DAYS));
+        enrollmentService.seedEnrollment(bachataSensual, students.get(0), DanceRole.FOLLOW,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(4, ChronoUnit.DAYS), null);
+        enrollmentService.seedEnrollment(bachataSensual, students.get(2), DanceRole.LEAD,
+                EnrollmentStatus.PENDING_PAYMENT, now.minus(1, ChronoUnit.DAYS), null);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.enrollment;
 
+import ch.ruppen.danceschool.payment.PaymentDto;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     // Kills the 1 + 2N lazy loads in EnrollmentService.toListDto (student fields,
     // student.danceLevels, course.danceStyle). "course" is sufficient because its
@@ -41,4 +42,31 @@ interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
             "GROUP BY e.course.id")
     List<Object[]> countGroupedByCourse(@Param("courseIds") List<Long> courseIds,
                                         @Param("statuses") List<EnrollmentStatus> statuses);
+
+    /**
+     * Returns enrollments that represent a payment row — either pending payment
+     * (OPEN) or already paid (COMPLETED, identified by paidAt being set). Mirrors
+     * the per-course OPEN_PAYMENTS semantics from the course-detail enrollments
+     * view; if that derivation changes, update both.
+     */
+    @Query("""
+            SELECT new ch.ruppen.danceschool.payment.PaymentDto(
+                e.id,
+                s.name,
+                s.email,
+                c.title,
+                c.price,
+                CASE WHEN e.paidAt IS NOT NULL THEN ch.ruppen.danceschool.payment.PaymentStatus.COMPLETED
+                     ELSE ch.ruppen.danceschool.payment.PaymentStatus.OPEN END,
+                COALESCE(e.paidAt, e.enrolledAt)
+            )
+            FROM Enrollment e
+            JOIN e.student s
+            JOIN e.course c
+            WHERE c.school.id = :schoolId
+              AND (e.status = ch.ruppen.danceschool.enrollment.EnrollmentStatus.PENDING_PAYMENT
+                   OR e.paidAt IS NOT NULL)
+            ORDER BY COALESCE(e.paidAt, e.enrolledAt) DESC
+            """)
+    List<PaymentDto> findPaymentsBySchoolId(@Param("schoolId") Long schoolId);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
@@ -1,0 +1,23 @@
+package ch.ruppen.danceschool.payment;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/me/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @GetMapping
+    public List<PaymentDto> list(@AuthenticationPrincipal AuthenticatedUser principal) {
+        return paymentService.listForCurrentUser(principal.userId());
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentDto.java
@@ -1,0 +1,15 @@
+package ch.ruppen.danceschool.payment;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record PaymentDto(
+        Long enrollmentId,
+        String studentName,
+        String studentEmail,
+        String courseTitle,
+        BigDecimal amount,
+        PaymentStatus status,
+        Instant billingDate
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentService.java
@@ -1,0 +1,24 @@
+package ch.ruppen.danceschool.payment;
+
+import ch.ruppen.danceschool.enrollment.EnrollmentRepository;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.school.SchoolService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final SchoolService schoolService;
+
+    @Transactional(readOnly = true)
+    public List<PaymentDto> listForCurrentUser(Long userId) {
+        School school = schoolService.findSchoolByMember(userId);
+        return enrollmentRepository.findPaymentsBySchoolId(school.getId());
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentStatus.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentStatus.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.payment;
+
+public enum PaymentStatus {
+    OPEN,
+    COMPLETED
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentIntegrationTest.java
@@ -1,0 +1,272 @@
+package ch.ruppen.danceschool.payment;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.course.PriceModel;
+import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.enrollment.DanceRole;
+import ch.ruppen.danceschool.enrollment.Enrollment;
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.student.Student;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class PaymentIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private AppUser owner;
+    private AppUser owner2;
+    private School school;
+    private School school2;
+    private Course course;
+    private Student student;
+
+    @BeforeEach
+    void setUp() {
+        owner = createUser("owner@example.com", "Owner", "firebase-owner");
+        owner2 = createUser("owner2@example.com", "Owner 2", "firebase-owner-2");
+        school = createSchoolWithOwner("Test School", owner);
+        school2 = createSchoolWithOwner("Other School", owner2);
+
+        course = createCourse(school, "Bachata Beginners", new BigDecimal("166.50"));
+        student = createStudent(school, "Anna Mueller", "anna@example.com");
+
+        entityManager.flush();
+    }
+
+    @Test
+    void list_returnsOpenAndCompletedRows_partitionedByPaidAt() throws Exception {
+        Instant t1 = Instant.now().minus(5, ChronoUnit.DAYS);
+        Instant t2 = Instant.now().minus(3, ChronoUnit.DAYS);
+
+        Long openId = createEnrollment(course, student, EnrollmentStatus.PENDING_PAYMENT, t1, null);
+        Long paidId = createEnrollment(course, createStudent(school, "Marco", "marco@example.com"),
+                EnrollmentStatus.CONFIRMED, t1, t2);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                // Default order: billingDate DESC → paid (t2) before open (t1)
+                .andExpect(jsonPath("$[0].enrollmentId").value(paidId))
+                .andExpect(jsonPath("$[0].status").value("COMPLETED"))
+                .andExpect(jsonPath("$[0].studentName").value("Marco"))
+                .andExpect(jsonPath("$[0].studentEmail").value("marco@example.com"))
+                .andExpect(jsonPath("$[0].courseTitle").value("Bachata Beginners"))
+                .andExpect(jsonPath("$[0].amount").value(166.50))
+                .andExpect(jsonPath("$[1].enrollmentId").value(openId))
+                .andExpect(jsonPath("$[1].status").value("OPEN"));
+    }
+
+    @Test
+    void list_billingDateResolvesToPaidAtWhenSet_elseEnrolledAt() throws Exception {
+        Instant enrolled = Instant.parse("2026-04-01T10:00:00Z");
+        Instant paid = Instant.parse("2026-04-10T10:00:00Z");
+
+        createEnrollment(course, student, EnrollmentStatus.PENDING_PAYMENT, enrolled, null);
+        createEnrollment(course, createStudent(school, "Marco", "marco@example.com"),
+                EnrollmentStatus.CONFIRMED, enrolled, paid);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                // First row (paid, sorted by billingDate=paid DESC)
+                .andExpect(jsonPath("$[0].billingDate").value(paid.toString()))
+                // Second row (open, billingDate=enrolledAt)
+                .andExpect(jsonPath("$[1].billingDate").value(enrolled.toString()));
+    }
+
+    @Test
+    void list_excludesPendingApprovalWaitlistedAndRejectedWithoutPaidAt() throws Exception {
+        Instant now = Instant.now();
+        Student s2 = createStudent(school, "S2", "s2@example.com");
+        Student s3 = createStudent(school, "S3", "s3@example.com");
+        Student s4 = createStudent(school, "S4", "s4@example.com");
+
+        createEnrollment(course, student, EnrollmentStatus.PENDING_APPROVAL, now, null);
+        createEnrollment(course, s2, EnrollmentStatus.WAITLISTED, now, null);
+        createEnrollment(course, s3, EnrollmentStatus.REJECTED, now, null);
+        // PENDING_PAYMENT row should be the only one returned
+        Long openId = createEnrollment(course, s4, EnrollmentStatus.PENDING_PAYMENT, now, null);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].enrollmentId").value(openId))
+                .andExpect(jsonPath("$[0].status").value("OPEN"));
+    }
+
+    @Test
+    void list_includesRejectedWithPaidAt_asCompleted() throws Exception {
+        // Edge case: any row with paidAt set is COMPLETED, regardless of status — matches the
+        // per-course OPEN_PAYMENTS view's semantics. Refunds aren't modeled in v1.
+        Instant t = Instant.now();
+        Long id = createEnrollment(course, student, EnrollmentStatus.REJECTED, t.minusSeconds(60), t);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].enrollmentId").value(id))
+                .andExpect(jsonPath("$[0].status").value("COMPLETED"));
+    }
+
+    @Test
+    void list_orderedByBillingDateDesc() throws Exception {
+        Instant base = Instant.now();
+        Student s2 = createStudent(school, "S2", "s2@example.com");
+        Student s3 = createStudent(school, "S3", "s3@example.com");
+
+        Long oldest = createEnrollment(course, student, EnrollmentStatus.PENDING_PAYMENT,
+                base.minus(10, ChronoUnit.DAYS), null);
+        Long middle = createEnrollment(course, s2, EnrollmentStatus.CONFIRMED,
+                base.minus(8, ChronoUnit.DAYS), base.minus(5, ChronoUnit.DAYS));
+        Long newest = createEnrollment(course, s3, EnrollmentStatus.PENDING_PAYMENT,
+                base.minus(1, ChronoUnit.DAYS), null);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].enrollmentId").value(newest))
+                .andExpect(jsonPath("$[1].enrollmentId").value(middle))
+                .andExpect(jsonPath("$[2].enrollmentId").value(oldest));
+    }
+
+    @Test
+    void list_tenantIsolation_onlyReturnsCallersSchoolPayments() throws Exception {
+        Course otherCourse = createCourse(school2, "Other School Course", new BigDecimal("99.00"));
+        Student otherStudent = createStudent(school2, "Other Student", "other@example.com");
+
+        Instant now = Instant.now();
+        createEnrollment(course, student, EnrollmentStatus.PENDING_PAYMENT, now, null);
+        Long otherId = createEnrollment(otherCourse, otherStudent, EnrollmentStatus.PENDING_PAYMENT, now, null);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].courseTitle").value("Bachata Beginners"));
+
+        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner2))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].enrollmentId").value(otherId))
+                .andExpect(jsonPath("$[0].courseTitle").value("Other School Course"));
+    }
+
+    // --- Helpers ---
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser ownerUser) {
+        School s = new School();
+        s.setName(name);
+        entityManager.persist(s);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(ownerUser);
+        member.setSchool(s);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return s;
+    }
+
+    private Course createCourse(School s, String title, BigDecimal price) {
+        Course c = new Course();
+        c.setSchool(s);
+        c.setTitle(title);
+        c.setDanceStyle(DanceStyle.BACHATA);
+        c.setLevel(CourseLevel.BEGINNER);
+        c.setCourseType(CourseType.PARTNER);
+        c.setMaxParticipants(20);
+        c.setStartDate(LocalDate.now().plusWeeks(2));
+        c.setEndDate(LocalDate.now().plusWeeks(10));
+        c.setLocation("Studio A");
+        c.setTeachers("Teacher");
+        c.setStartTime(LocalTime.of(19, 0));
+        c.setEndTime(LocalTime.of(20, 0));
+        c.setDayOfWeek(DayOfWeek.MONDAY);
+        c.setRecurrenceType(RecurrenceType.WEEKLY);
+        c.setNumberOfSessions(8);
+        c.setPriceModel(PriceModel.FIXED_COURSE);
+        c.setPrice(price);
+        c.setPublishedAt(LocalDate.now().minusDays(1));
+        entityManager.persist(c);
+        return c;
+    }
+
+    private Student createStudent(School s, String name, String email) {
+        Student st = new Student();
+        st.setSchool(s);
+        st.setName(name);
+        st.setEmail(email);
+        entityManager.persist(st);
+        return st;
+    }
+
+    private Long createEnrollment(Course c, Student s, EnrollmentStatus status,
+                                  Instant enrolledAt, Instant paidAt) {
+        Enrollment e = new Enrollment();
+        e.setCourse(c);
+        e.setStudent(s);
+        e.setDanceRole(DanceRole.LEAD);
+        e.setStatus(status);
+        e.setEnrolledAt(enrolledAt);
+        e.setPaidAt(paidAt);
+        entityManager.persist(e);
+        return e.getId();
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
@@ -1,0 +1,174 @@
+package ch.ruppen.danceschool.payment;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.course.PriceModel;
+import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.enrollment.DanceRole;
+import ch.ruppen.danceschool.enrollment.Enrollment;
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.student.Student;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Proves /api/me/payments fires a constant number of SQL statements regardless of
+ * payment count — the JPQL constructor expression projects scalar fields directly,
+ * so no per-row lazy load is triggered.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class PaymentListSqlBudgetTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private AppUser owner;
+    private School school;
+    private Course course;
+
+    @BeforeEach
+    void setUp() {
+        owner = createUser("owner@example.com", "Owner", "firebase-owner");
+        school = createSchoolWithOwner("Test School", owner);
+        course = createCourse(school);
+        entityManager.flush();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 5, 20})
+    void listPayments_sqlCountDoesNotScaleWithN(int n) throws Exception {
+        for (int i = 0; i < n; i++) {
+            Student s = createStudent(school, "Student " + i, "s" + i + "@example.com");
+            createEnrollment(course, s);
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        Statistics stats = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        mockMvc.perform(get("/api/me/payments")
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk());
+
+        // 1 query for school resolution + 1 for the payment list = 2.
+        // Allow a small headroom for security/auth bookkeeping.
+        assertThat(stats.getPrepareStatementCount())
+                .as("SQL budget for /api/me/payments with N=%d", n)
+                .isLessThanOrEqualTo(3);
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser ownerUser) {
+        School s = new School();
+        s.setName(name);
+        entityManager.persist(s);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(ownerUser);
+        member.setSchool(s);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return s;
+    }
+
+    private Course createCourse(School s) {
+        Course c = new Course();
+        c.setSchool(s);
+        c.setTitle("Bachata Beginners");
+        c.setDanceStyle(DanceStyle.BACHATA);
+        c.setLevel(CourseLevel.BEGINNER);
+        c.setCourseType(CourseType.PARTNER);
+        c.setMaxParticipants(50);
+        c.setStartDate(LocalDate.now().plusWeeks(2));
+        c.setEndDate(LocalDate.now().plusWeeks(10));
+        c.setLocation("Studio A");
+        c.setTeachers("Test Teacher");
+        c.setStartTime(LocalTime.of(19, 0));
+        c.setEndTime(LocalTime.of(20, 0));
+        c.setDayOfWeek(DayOfWeek.MONDAY);
+        c.setRecurrenceType(RecurrenceType.WEEKLY);
+        c.setNumberOfSessions(8);
+        c.setPriceModel(PriceModel.FIXED_COURSE);
+        c.setPrice(new BigDecimal("166.50"));
+        c.setPublishedAt(LocalDate.now().minusDays(1));
+        entityManager.persist(c);
+        return c;
+    }
+
+    private Student createStudent(School s, String name, String email) {
+        Student st = new Student();
+        st.setSchool(s);
+        st.setName(name);
+        st.setEmail(email);
+        entityManager.persist(st);
+        return st;
+    }
+
+    private void createEnrollment(Course c, Student s) {
+        Enrollment e = new Enrollment();
+        e.setCourse(c);
+        e.setStudent(s);
+        e.setDanceRole(DanceRole.LEAD);
+        e.setStatus(EnrollmentStatus.PENDING_PAYMENT);
+        e.setEnrolledAt(Instant.now());
+        entityManager.persist(e);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/frontend/src/app/payments/payment.service.ts
+++ b/frontend/src/app/payments/payment.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export type PaymentStatus = 'OPEN' | 'COMPLETED';
+
+export interface Payment {
+  enrollmentId: number;
+  studentName: string;
+  studentEmail: string;
+  courseTitle: string;
+  amount: number;
+  status: PaymentStatus;
+  billingDate: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PaymentService {
+  private http = inject(HttpClient);
+
+  getPayments(): Observable<Payment[]> {
+    return this.http.get<Payment[]>(`${environment.apiUrl}/api/me/payments`);
+  }
+}

--- a/frontend/src/app/payments/payments.html
+++ b/frontend/src/app/payments/payments.html
@@ -1,0 +1,93 @@
+@if (loaded() && !error()) {
+  @if (hasAnyPayments()) {
+    <div class="ds-page-toolbar">
+      <nav mat-tab-nav-bar [tabPanel]="paymentsTabPanel" mat-align-tabs="start" class="ds-page-toolbar__tabs">
+        @for (tab of tabs; track tab.status; let i = $index) {
+          <a
+            mat-tab-link
+            (click)="selectTab(i)"
+            [active]="activeTabIndex() === i"
+          >
+            <span class="ds-tab-label">{{ tab.label }}</span>
+            <span class="ds-tab-count">{{ tabCounts()[i] }}</span>
+          </a>
+        }
+      </nav>
+    </div>
+
+    <div class="ds-filter-bar">
+      <mat-form-field class="ds-filter-search" appearance="outline" subscriptSizing="dynamic">
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput placeholder="Search payments..." [(ngModel)]="searchText" (ngModelChange)="applyFilter()" />
+      </mat-form-field>
+    </div>
+
+    <mat-tab-nav-panel #paymentsTabPanel>
+      <div class="ds-table-card payments-table">
+        <table mat-table [dataSource]="activeDataSource()" matSort matSortActive="billingDate" matSortDirection="desc">
+          <ng-container matColumnDef="studentName">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Student Name</th>
+            <td mat-cell *matCellDef="let row">{{ row.studentName }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="email">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Email</th>
+            <td mat-cell *matCellDef="let row">{{ row.studentEmail }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="course">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Course</th>
+            <td mat-cell *matCellDef="let row">{{ row.courseTitle }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="amount">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Amount</th>
+            <td mat-cell *matCellDef="let row">{{ formatAmount(row.amount) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="billingDate">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Billing Date</th>
+            <td mat-cell *matCellDef="let row">{{ formatBillingDate(row.billingDate) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef>Actions</th>
+            <td mat-cell *matCellDef="let row">
+              @if (isOpenTab()) {
+                <button mat-icon-button class="mark-paid-button" aria-label="Mark payment as paid"
+                        matTooltip="Mark Paid" (click)="onMarkPaid(row.enrollmentId)">
+                  <mat-icon>check_circle</mat-icon>
+                </button>
+              }
+            </td>
+          </ng-container>
+
+          <tr class="mat-mdc-row empty-row" *matNoDataRow>
+            <td class="mat-mdc-cell empty-cell" [attr.colspan]="columns.length">
+              {{ activeTab().emptyMessage }}
+            </td>
+          </tr>
+
+          <tr mat-header-row *matHeaderRowDef="columns; sticky: true"></tr>
+          <tr mat-row *matRowDef="let row; columns: columns;"></tr>
+        </table>
+
+        <div class="ds-table-footer">
+          Showing {{ activeDataSource().filteredData.length }} of {{ tabCounts()[activeTabIndex()] }} payments
+        </div>
+      </div>
+    </mat-tab-nav-panel>
+  } @else {
+    <div class="empty-state">
+      <mat-icon class="empty-state-icon">payments</mat-icon>
+      <h2 class="empty-state-title">No payments yet</h2>
+      <p class="empty-state-text">Payments will appear here as students enroll in your courses.</p>
+    </div>
+  }
+} @else if (error()) {
+  <p class="error-text">Could not load payments. Please try again later.</p>
+} @else {
+  <div class="loading">
+    <p>Loading payments...</p>
+  </div>
+}

--- a/frontend/src/app/payments/payments.scss
+++ b/frontend/src/app/payments/payments.scss
@@ -1,0 +1,72 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-4);
+}
+
+.payments-table {
+  ::ng-deep .mat-column-studentName { width: 18%; }
+  ::ng-deep .mat-column-email       { width: 22%; }
+  ::ng-deep .mat-column-course      { width: 22%; }
+  ::ng-deep .mat-column-amount      { width: 12%; }
+  ::ng-deep .mat-column-billingDate { width: 14%; }
+  ::ng-deep .mat-column-actions     { width: 12%; }
+}
+
+.empty-row .empty-cell {
+  text-align: center;
+  padding: var(--ds-spacing-8);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--ds-spacing-12) var(--ds-spacing-6);
+}
+
+.empty-state-icon {
+  font-size: var(--ds-spacing-16);
+  width: var(--ds-spacing-16);
+  height: var(--ds-spacing-16);
+  color: var(--mat-sys-on-surface-variant);
+  margin-bottom: var(--ds-spacing-4);
+}
+
+.empty-state-title {
+  font: var(--mat-sys-headline-small);
+  color: var(--mat-sys-on-surface);
+  margin: 0 0 var(--ds-spacing-2);
+}
+
+.empty-state-text {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0 0 var(--ds-spacing-6);
+  max-width: var(--ds-max-width-narrow);
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: var(--ds-spacing-12);
+
+  p {
+    font: var(--mat-sys-body-large);
+    color: var(--mat-sys-on-surface-variant);
+  }
+}
+
+.error-text {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-error);
+  text-align: center;
+  padding: var(--ds-spacing-12);
+}
+
+.mark-paid-button {
+  color: var(--ds-color-success);
+}

--- a/frontend/src/app/payments/payments.spec.ts
+++ b/frontend/src/app/payments/payments.spec.ts
@@ -1,0 +1,250 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { PaymentsComponent } from './payments';
+import { Payment } from './payment.service';
+
+function makePayment(overrides: Partial<Payment> = {}): Payment {
+  return {
+    enrollmentId: 1,
+    studentName: 'Anna Mueller',
+    studentEmail: 'anna@example.com',
+    courseTitle: 'Bachata Beginners',
+    amount: 166.5,
+    status: 'OPEN',
+    billingDate: '2026-04-10T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('PaymentsComponent', () => {
+  let fixture: ComponentFixture<PaymentsComponent>;
+  let httpTesting: HttpTestingController;
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PaymentsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideAnimationsAsync(),
+      ],
+    });
+
+    fixture = TestBed.createComponent(PaymentsComponent);
+    httpTesting = TestBed.inject(HttpTestingController);
+    el = fixture.nativeElement;
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  function flushPayments(payments: Payment[]): void {
+    httpTesting.expectOne(req => req.url.includes('/api/me/payments')).flush(payments);
+  }
+
+  it('shows loading state then renders the table when payments arrive', () => {
+    fixture.detectChanges();
+    expect(el.querySelector('.loading')).toBeTruthy();
+
+    flushPayments([makePayment()]);
+    fixture.detectChanges();
+
+    expect(el.querySelector('.loading')).toBeFalsy();
+    expect(el.querySelector('table[mat-table]')).toBeTruthy();
+  });
+
+  it('renders all six column headers', () => {
+    fixture.detectChanges();
+    flushPayments([makePayment()]);
+    fixture.detectChanges();
+
+    const headers = Array.from(el.querySelectorAll('th[mat-header-cell]')).map(h => h.textContent?.trim());
+    expect(headers).toEqual(['Student Name', 'Email', 'Course', 'Amount', 'Billing Date', 'Actions']);
+  });
+
+  it('renders each payment field in the row', () => {
+    fixture.detectChanges();
+    flushPayments([makePayment({
+      studentName: 'Marco Rossi', studentEmail: 'marco@example.com',
+      courseTitle: 'Salsa Advanced', amount: 220, billingDate: '2026-03-15T10:00:00Z',
+    })]);
+    fixture.detectChanges();
+
+    const row = el.querySelector('tr[mat-row]');
+    expect(row?.textContent).toContain('Marco Rossi');
+    expect(row?.textContent).toContain('marco@example.com');
+    expect(row?.textContent).toContain('Salsa Advanced');
+    expect(row?.textContent).toContain('CHF 220.00');
+    expect(row?.textContent).toContain('Mar 15, 2026');
+  });
+
+  it('partitions rows into Open / Completed and shows correct tab counts', () => {
+    fixture.detectChanges();
+    flushPayments([
+      makePayment({ enrollmentId: 1, status: 'OPEN' }),
+      makePayment({ enrollmentId: 2, status: 'OPEN' }),
+      makePayment({ enrollmentId: 3, status: 'COMPLETED' }),
+    ]);
+    fixture.detectChanges();
+
+    const counts = Array.from(el.querySelectorAll('.ds-tab-count')).map(c => c.textContent?.trim());
+    expect(counts).toEqual(['2', '1']);
+
+    // Default: Open tab is active → 2 rows
+    expect(el.querySelectorAll('tr[mat-row]').length).toBe(2);
+  });
+
+  it('switches to the Completed tab on click and shows only completed rows', () => {
+    fixture.detectChanges();
+    flushPayments([
+      makePayment({ enrollmentId: 1, status: 'OPEN', studentName: 'Open Anna' }),
+      makePayment({ enrollmentId: 2, status: 'COMPLETED', studentName: 'Done Bob' }),
+    ]);
+    fixture.detectChanges();
+
+    const tabs = el.querySelectorAll('a[mat-tab-link]');
+    (tabs[1] as HTMLElement).click();
+    fixture.detectChanges();
+
+    const rows = el.querySelectorAll('tr[mat-row]');
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('Done Bob');
+  });
+
+  it('renders the mark-paid action only on the Open tab', () => {
+    fixture.detectChanges();
+    flushPayments([
+      makePayment({ enrollmentId: 1, status: 'OPEN' }),
+      makePayment({ enrollmentId: 2, status: 'COMPLETED' }),
+    ]);
+    fixture.detectChanges();
+
+    expect(el.querySelector('tr[mat-row] .mark-paid-button')).toBeTruthy();
+
+    const tabs = el.querySelectorAll('a[mat-tab-link]');
+    (tabs[1] as HTMLElement).click();
+    fixture.detectChanges();
+
+    expect(el.querySelector('tr[mat-row] .mark-paid-button')).toBeFalsy();
+  });
+
+  it('filters rows client-side on student name, email, and course title', () => {
+    fixture.detectChanges();
+    flushPayments([
+      makePayment({ enrollmentId: 1, studentName: 'Anna', studentEmail: 'anna@example.com', courseTitle: 'Bachata' }),
+      makePayment({ enrollmentId: 2, studentName: 'Marco', studentEmail: 'marco@example.com', courseTitle: 'Salsa' }),
+      makePayment({ enrollmentId: 3, studentName: 'Laura', studentEmail: 'laura@example.com', courseTitle: 'Bachata Sensual' }),
+    ]);
+    fixture.detectChanges();
+
+    const component = fixture.componentInstance as unknown as { searchText: string; applyFilter: () => void };
+
+    // Match by student name
+    component.searchText = 'anna';
+    component.applyFilter();
+    fixture.detectChanges();
+    expect(el.querySelectorAll('tr[mat-row]').length).toBe(1);
+
+    // Match by email
+    component.searchText = 'marco@';
+    component.applyFilter();
+    fixture.detectChanges();
+    expect(el.querySelectorAll('tr[mat-row]').length).toBe(1);
+
+    // Match by course title — substring match across multiple rows
+    component.searchText = 'bachata';
+    component.applyFilter();
+    fixture.detectChanges();
+    expect(el.querySelectorAll('tr[mat-row]').length).toBe(2);
+  });
+
+  it('footer reflects filtered count out of total in the active tab', async () => {
+    fixture.detectChanges();
+    flushPayments([
+      makePayment({ enrollmentId: 1, status: 'OPEN', studentName: 'Anna', studentEmail: 'a@x.com', courseTitle: 'C1' }),
+      makePayment({ enrollmentId: 2, status: 'OPEN', studentName: 'Marco', studentEmail: 'm@x.com', courseTitle: 'C2' }),
+      makePayment({ enrollmentId: 3, status: 'COMPLETED', studentName: 'Laura', studentEmail: 'l@x.com', courseTitle: 'C3' }),
+    ]);
+    fixture.detectChanges();
+
+    expect(el.querySelector('.ds-table-footer')?.textContent?.trim()).toBe('Showing 2 of 2 payments');
+
+    const component = fixture.componentInstance as unknown as { searchText: string; applyFilter: () => void };
+    component.searchText = 'anna';
+    component.applyFilter();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(el.querySelector('.ds-table-footer')?.textContent?.trim()).toBe('Showing 1 of 2 payments');
+  });
+
+  it('Mark Paid calls markPaid endpoint and refetches the list', () => {
+    fixture.detectChanges();
+    flushPayments([makePayment({ enrollmentId: 99, status: 'OPEN' })]);
+    fixture.detectChanges();
+
+    const btn = el.querySelector('.mark-paid-button') as HTMLButtonElement;
+    btn.click();
+    fixture.detectChanges();
+
+    const markPaidReq = httpTesting.expectOne(req =>
+      req.url.includes('/api/enrollments/99/mark-paid') && req.method === 'PUT');
+    markPaidReq.flush({ enrollmentId: 99, status: 'CONFIRMED' });
+
+    // Refetch
+    httpTesting.expectOne(req => req.url.includes('/api/me/payments')).flush([]);
+  });
+
+  it('Mark Paid error path shows snackbar and does not refetch', () => {
+    fixture.detectChanges();
+    flushPayments([makePayment({ enrollmentId: 7, status: 'OPEN' })]);
+    fixture.detectChanges();
+
+    const btn = el.querySelector('.mark-paid-button') as HTMLButtonElement;
+    btn.click();
+    fixture.detectChanges();
+
+    const markPaidReq = httpTesting.expectOne(req =>
+      req.url.includes('/api/enrollments/7/mark-paid') && req.method === 'PUT');
+    markPaidReq.flush({ detail: 'Already paid' }, { status: 409, statusText: 'Conflict' });
+
+    // No refetch — afterEach httpTesting.verify() confirms no outstanding requests.
+  });
+
+  it('shows centered "No payments yet" empty state when school has zero payments', () => {
+    fixture.detectChanges();
+    flushPayments([]);
+    fixture.detectChanges();
+
+    expect(el.querySelector('.empty-state')).toBeTruthy();
+    expect(el.querySelector('.empty-state-title')?.textContent?.trim()).toBe('No payments yet');
+    expect(el.querySelector('table[mat-table]')).toBeFalsy();
+  });
+
+  it('shows in-table empty message when active tab is empty but the other has data', () => {
+    fixture.detectChanges();
+    flushPayments([makePayment({ enrollmentId: 1, status: 'COMPLETED' })]);
+    fixture.detectChanges();
+
+    // Default Open tab — no rows, but other tab has data
+    expect(el.querySelector('.empty-cell')?.textContent?.trim()).toBe('No open payments');
+
+    const tabs = el.querySelectorAll('a[mat-tab-link]');
+    (tabs[1] as HTMLElement).click();
+    fixture.detectChanges();
+    expect(el.querySelectorAll('tr[mat-row]').length).toBe(1);
+  });
+
+  it('shows error state when the payments request fails', () => {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.includes('/api/me/payments'))
+      .flush({ detail: 'oops' }, { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+
+    expect(el.querySelector('.error-text')).toBeTruthy();
+    expect(el.querySelector('table[mat-table]')).toBeFalsy();
+  });
+});

--- a/frontend/src/app/payments/payments.ts
+++ b/frontend/src/app/payments/payments.ts
@@ -1,36 +1,154 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, OnInit, signal, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { Payment, PaymentService } from './payment.service';
+import { EnrollmentService } from '../courses/enrollment.service';
+import { extractErrorMessage } from '../shared/error-utils';
+
+interface TabConfig {
+  status: 'OPEN' | 'COMPLETED';
+  label: string;
+  emptyMessage: string;
+}
+
+const COLUMNS = ['studentName', 'email', 'course', 'amount', 'billingDate', 'actions'];
+
+const TAB_CONFIGS: TabConfig[] = [
+  { status: 'OPEN', label: 'Open', emptyMessage: 'No open payments' },
+  { status: 'COMPLETED', label: 'Completed', emptyMessage: 'No completed payments' },
+];
+
+const OPEN_TAB_INDEX = 0;
+const COMPLETED_TAB_INDEX = 1;
 
 @Component({
   selector: 'app-payments',
-  imports: [MatIconModule],
-  template: `
-    <div class="placeholder">
-      <mat-icon class="placeholder-icon">construction</mat-icon>
-      <h2>Payments</h2>
-      <p>Coming soon!</p>
-    </div>
-  `,
-  styles: `
-    .placeholder {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      min-height: var(--ds-spacing-24);
-      color: var(--mat-sys-on-surface-variant);
-      text-align: center;
-    }
-    .placeholder-icon {
-      font-size: var(--ds-spacing-12);
-      width: var(--ds-spacing-12);
-      height: var(--ds-spacing-12);
-      margin-bottom: var(--ds-spacing-4);
-      opacity: 0.4;
-    }
-    h2 { font: var(--mat-sys-headline-small); color: var(--mat-sys-on-surface); margin: 0 0 var(--ds-spacing-2); }
-    p { font: var(--mat-sys-body-large); margin: 0; }
-  `,
+  imports: [
+    FormsModule,
+    MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule,
+    MatSortModule, MatTableModule, MatTabsModule, MatTooltipModule,
+  ],
+  templateUrl: './payments.html',
+  styleUrl: './payments.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PaymentsComponent {}
+export class PaymentsComponent implements OnInit {
+  private paymentService = inject(PaymentService);
+  private enrollmentService = inject(EnrollmentService);
+  private snackBar = inject(MatSnackBar);
+  private destroyRef = inject(DestroyRef);
+
+  protected tabs = TAB_CONFIGS;
+  protected activeTabIndex = signal(OPEN_TAB_INDEX);
+  protected loaded = signal(false);
+  protected error = signal(false);
+  protected hasAnyPayments = signal(false);
+
+  protected tabData: MatTableDataSource<Payment>[] = TAB_CONFIGS.map(() => new MatTableDataSource<Payment>([]));
+  protected tabCounts = signal<number[]>(TAB_CONFIGS.map(() => 0));
+
+  protected searchText = '';
+  protected columns = COLUMNS;
+
+  protected activeDataSource = computed(() => this.tabData[this.activeTabIndex()]);
+  protected activeTab = computed(() => TAB_CONFIGS[this.activeTabIndex()]);
+  protected isOpenTab = computed(() => this.activeTabIndex() === OPEN_TAB_INDEX);
+
+  @ViewChild(MatSort) set sort(sort: MatSort) {
+    if (sort) {
+      this.tabData[this.activeTabIndex()].sort = sort;
+    }
+  }
+
+  ngOnInit(): void {
+    this.tabData.forEach(ds => {
+      ds.filterPredicate = this.createFilterPredicate();
+      ds.sortingDataAccessor = (payment, column) => {
+        switch (column) {
+          case 'studentName': return payment.studentName;
+          case 'email': return payment.studentEmail;
+          case 'course': return payment.courseTitle;
+          case 'amount': return payment.amount;
+          case 'billingDate': return payment.billingDate;
+          default: return '';
+        }
+      };
+    });
+
+    this.loadPayments();
+  }
+
+  protected selectTab(index: number): void {
+    this.activeTabIndex.set(index);
+  }
+
+  protected applyFilter(): void {
+    const text = this.searchText.trim().toLowerCase();
+    this.tabData.forEach(ds => ds.filter = text);
+  }
+
+  protected onMarkPaid(enrollmentId: number): void {
+    this.enrollmentService.markPaid(enrollmentId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.snackBar.open('Payment confirmed', 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        this.loadPayments();
+      },
+      error: (err: HttpErrorResponse) => {
+        this.snackBar.open(extractErrorMessage(err, 'Failed to confirm payment'), 'Close',
+          { duration: 5000, panelClass: 'snackbar-error' });
+      },
+    });
+  }
+
+  protected formatAmount(amount: number): string {
+    return `CHF ${amount.toFixed(2)}`;
+  }
+
+  protected formatBillingDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  private loadPayments(): void {
+    this.paymentService.getPayments().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (payments) => {
+        this.partition(payments);
+        this.hasAnyPayments.set(payments.length > 0);
+        this.loaded.set(true);
+      },
+      error: () => {
+        this.error.set(true);
+        this.loaded.set(true);
+      },
+    });
+  }
+
+  private partition(payments: Payment[]): void {
+    const open: Payment[] = [];
+    const completed: Payment[] = [];
+    for (const p of payments) {
+      if (p.status === 'OPEN') open.push(p);
+      else completed.push(p);
+    }
+    this.tabData[OPEN_TAB_INDEX].data = open;
+    this.tabData[COMPLETED_TAB_INDEX].data = completed;
+    this.tabCounts.set([open.length, completed.length]);
+  }
+
+  private createFilterPredicate(): (data: Payment, filter: string) => boolean {
+    return (data: Payment, filter: string): boolean => {
+      if (!filter) return true;
+      const searchable = [data.studentName, data.studentEmail, data.courseTitle].join(' ').toLowerCase();
+      return searchable.includes(filter);
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- **Backend:** new `ch.ruppen.danceschool.payment` package exposing `GET /api/me/payments`. A `Payment` is a read-only projection over `Enrollment + Course + Student` — same semantics as the per-course OPEN_PAYMENTS view, widened to school scope. Single JPQL constructor-expression query; no new entity, no migration. Mark-paid reuses the existing `PUT /api/enrollments/{id}/mark-paid`.
- **Frontend:** rewrote `/app/payments` to match the Figma spec — tabs (Open / Completed) with counts, client-side `MatTableDataSource` search + sort (default `billingDate` desc), sticky header, non-clickable rows, `check_circle` Mark Paid icon button on the Open tab only, snackbar + refetch on success.
- **DevDataSeeder:** each seeded school now has ≥5 `PENDING_PAYMENT` and ≥5 paid (`CONFIRMED` with `paidAt`) enrollments so the page demos meaningfully.
- **Tests:** `PaymentIntegrationTest` (partition, billingDate resolution, exclusions, ordering, tenant isolation), `PaymentListSqlBudgetTest` (statement count stays constant for N=1/5/20 via Hibernate `Statistics`), and `payments.spec.ts` (13 cases — columns, tab partition, filter, Mark Paid happy/error, empty states, error state).

## Test plan

- [x] `./mvnw test` — 160 passed
- [x] `npx ng test --browsers chromium --no-watch` — 123 passed
- [x] Playwright visual check at 1440×900 as `owner@test.com`:
  - Open tab renders 6 rows, headers, sticky header, Billing Date desc sort, CHF-prefixed amounts, Mark Paid icons
  - Completed tab renders 10 rows, empty Actions cells
  - Mark Paid on a row moves it from Open→Completed and tab counts update (6/10 → 5/11)
- [x] `gh pr checks <n> --watch` before merge

## Review notes (not addressed)

- `frontend/src/app/payments/payments.scss` duplicates the empty-state/loading/error CSS from `courses.scss`. First duplication; leaving for a future pass to extract into `_table.scss` or a new partial.
- `toLocaleDateString('en-US', …)` hardcodes US date format for a Swiss app; consistent with `course-overview.ts`. Worth a later pass to move to a shared locale-aware formatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)