### PR TITLE
Students list page: Active/Inactive tabs + table (#293)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -29,6 +30,11 @@ public class StudentController {
                                     @AuthenticationPrincipal AuthenticatedUser principal) {
         Long id = studentService.createStudent(principal.userId(), dto);
         return Map.of("id", id);
+    }
+
+    @GetMapping
+    public List<StudentListDto> list(@AuthenticationPrincipal AuthenticatedUser principal) {
+        return studentService.listStudents(principal.userId());
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentListDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentListDto.java
@@ -1,0 +1,10 @@
+package ch.ruppen.danceschool.student;
+
+public record StudentListDto(
+        Long id,
+        String name,
+        String email,
+        String phoneNumber,
+        long activeCoursesCount
+) {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
@@ -1,7 +1,11 @@
 package ch.ruppen.danceschool.student;
 
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +16,30 @@ interface StudentRepository extends JpaRepository<Student, Long> {
     Optional<Student> findByIdAndSchoolId(Long id, Long schoolId);
 
     boolean existsBySchoolId(Long schoolId);
+
+    /**
+     * Returns students for a school along with the count of their "active" courses —
+     * seat-holding enrollments in courses currently RUNNING. The RUNNING predicate
+     * (publishedAt set, startDate ≤ today ≤ endDate) mirrors
+     * {@link ch.ruppen.danceschool.course.CourseRepository#findRunningBySchoolId};
+     * keep the two in sync if the derivation changes.
+     */
+    @Query("""
+            SELECT new ch.ruppen.danceschool.student.StudentListDto(
+                s.id, s.name, s.email, s.phoneNumber,
+                COUNT(DISTINCT CASE WHEN c.publishedAt IS NOT NULL
+                                     AND c.startDate <= :today
+                                     AND c.endDate   >= :today
+                                    THEN c.id END)
+            )
+            FROM Student s
+            LEFT JOIN Enrollment e ON e.student = s AND e.status IN :statuses
+            LEFT JOIN e.course c
+            WHERE s.school.id = :schoolId
+            GROUP BY s.id, s.name, s.email, s.phoneNumber
+            ORDER BY s.name ASC
+            """)
+    List<StudentListDto> findListBySchoolId(@Param("schoolId") Long schoolId,
+                                            @Param("statuses") List<EnrollmentStatus> statuses,
+                                            @Param("today") LocalDate today);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.student;
 
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
@@ -9,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -18,6 +21,7 @@ public class StudentService {
 
     private final StudentRepository studentRepository;
     private final SchoolService schoolService;
+    private final Clock clock;
 
     @Transactional
     @BusinessOperation(event = "StudentCreated")
@@ -42,6 +46,15 @@ public class StudentService {
 
         studentRepository.save(student);
         return student.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudentListDto> listStudents(Long userId) {
+        School school = schoolService.findSchoolByMember(userId);
+        return studentRepository.findListBySchoolId(
+                school.getId(),
+                EnrollmentStatus.SEAT_HOLDING_STATI,
+                LocalDate.now(clock));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentListIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentListIntegrationTest.java
@@ -1,0 +1,260 @@
+package ch.ruppen.danceschool.student;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.course.PriceModel;
+import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.enrollment.DanceRole;
+import ch.ruppen.danceschool.enrollment.Enrollment;
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class StudentListIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private AppUser ownerA;
+    private AppUser ownerB;
+    private School schoolA;
+    private School schoolB;
+
+    @BeforeEach
+    void setUp() {
+        ownerA = createUser("owner-a@example.com", "Owner A", "firebase-a");
+        ownerB = createUser("owner-b@example.com", "Owner B", "firebase-b");
+        schoolA = createSchoolWithOwner("School A", ownerA);
+        schoolB = createSchoolWithOwner("School B", ownerB);
+    }
+
+    @Test
+    void list_scopesToCallerSchool() throws Exception {
+        createStudent(schoolA, "Alice", "alice@example.com");
+        createStudent(schoolA, "Bob", "bob@example.com");
+        createStudent(schoolB, "Carol", "carol@example.com");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/students")
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].name").value("Alice"))
+                .andExpect(jsonPath("$[1].name").value("Bob"));
+
+        mockMvc.perform(get("/api/students")
+                        .with(authentication(authToken(ownerB))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name").value("Carol"));
+    }
+
+    @Test
+    void list_returnsEmptyList_forSchoolWithoutStudents() throws Exception {
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/students")
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void list_countsSeatHoldingEnrollmentsInRunningCoursesOnly() throws Exception {
+        LocalDate today = LocalDate.now();
+
+        Course running1 = createCourse(schoolA, "Running 1",
+                today.minusDays(1), today.minusWeeks(3), today.plusWeeks(3));
+        Course running2 = createCourse(schoolA, "Running 2",
+                today.minusDays(1), today.minusWeeks(2), today.plusWeeks(4));
+        Course finished = createCourse(schoolA, "Finished",
+                today.minusMonths(3), today.minusMonths(2), today.minusDays(2));
+        Course open = createCourse(schoolA, "Open",
+                today.minusDays(1), today.plusDays(7), today.plusWeeks(8));
+        Course draft = createCourse(schoolA, "Draft",
+                null, today.plusDays(10), today.plusWeeks(10));
+
+        Student zeroActive = createStudent(schoolA, "Zero Active", "zero@example.com");
+        Student oneActive = createStudent(schoolA, "One Active", "one@example.com");
+        Student twoActive = createStudent(schoolA, "Two Active", "two@example.com");
+
+        // zeroActive: enrolled only in non-RUNNING courses, or non-seat-holding status
+        createEnrollment(finished, zeroActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(open, zeroActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(draft, zeroActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(running1, zeroActive, EnrollmentStatus.WAITLISTED);
+        createEnrollment(running1, zeroActive, EnrollmentStatus.REJECTED);
+        createEnrollment(running1, zeroActive, EnrollmentStatus.PENDING_APPROVAL);
+
+        // oneActive: one seat-holding enrollment in a RUNNING course
+        createEnrollment(running1, oneActive, EnrollmentStatus.CONFIRMED);
+        // plus noise that must not count
+        createEnrollment(finished, oneActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(running2, oneActive, EnrollmentStatus.WAITLISTED);
+
+        // twoActive: two seat-holding enrollments in RUNNING courses (one CONFIRMED, one PENDING_PAYMENT)
+        // Plus a duplicate CONFIRMED enrollment on running1 — DISTINCT in the query collapses it to 1.
+        createEnrollment(running1, twoActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(running1, twoActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(running2, twoActive, EnrollmentStatus.PENDING_PAYMENT);
+
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/students")
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                // Ordered by name ASC
+                .andExpect(jsonPath("$[0].name").value("One Active"))
+                .andExpect(jsonPath("$[0].activeCoursesCount").value(1))
+                .andExpect(jsonPath("$[1].name").value("Two Active"))
+                .andExpect(jsonPath("$[1].activeCoursesCount").value(2))
+                .andExpect(jsonPath("$[2].name").value("Zero Active"))
+                .andExpect(jsonPath("$[2].activeCoursesCount").value(0));
+    }
+
+    @Test
+    void list_firesExactlyOneQueryForTheListItself() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            Student s = createStudent(schoolA, "Student " + i, "s" + i + "@example.com");
+            Course c = createCourse(schoolA, "Course " + i,
+                    LocalDate.now().minusDays(1),
+                    LocalDate.now().minusWeeks(1),
+                    LocalDate.now().plusWeeks(3));
+            createEnrollment(c, s, EnrollmentStatus.CONFIRMED);
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        Statistics stats = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        mockMvc.perform(get("/api/students")
+                        .with(authentication(authToken(ownerA))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(10)));
+
+        // The list itself fires 1 query (aggregate over student + enrollment + course).
+        // Budget also covers the auth user lookup + school-membership lookup.
+        assertThat(stats.getPrepareStatementCount())
+                .as("SQL budget for /api/students")
+                .isLessThanOrEqualTo(3);
+    }
+
+    private AppUser createUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private School createSchoolWithOwner(String name, AppUser ownerUser) {
+        School school = new School();
+        school.setName(name);
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(ownerUser);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
+        return school;
+    }
+
+    private Student createStudent(School school, String name, String email) {
+        Student student = new Student();
+        student.setSchool(school);
+        student.setName(name);
+        student.setEmail(email);
+        entityManager.persist(student);
+        return student;
+    }
+
+    private Course createCourse(School school, String title, LocalDate publishedAt,
+                                LocalDate startDate, LocalDate endDate) {
+        Course c = new Course();
+        c.setSchool(school);
+        c.setTitle(title);
+        c.setDanceStyle(DanceStyle.SALSA);
+        c.setLevel(CourseLevel.BEGINNER);
+        c.setCourseType(CourseType.PARTNER);
+        c.setMaxParticipants(20);
+        c.setStartDate(startDate);
+        c.setEndDate(endDate);
+        c.setLocation("Studio A");
+        c.setTeachers("Test Teacher");
+        c.setStartTime(LocalTime.of(19, 0));
+        c.setEndTime(LocalTime.of(20, 0));
+        c.setDayOfWeek(DayOfWeek.MONDAY);
+        c.setRecurrenceType(RecurrenceType.WEEKLY);
+        c.setNumberOfSessions(8);
+        c.setPriceModel(PriceModel.FIXED_COURSE);
+        c.setPrice(new BigDecimal("200.00"));
+        c.setPublishedAt(publishedAt);
+        entityManager.persist(c);
+        return c;
+    }
+
+    private void createEnrollment(Course course, Student student, EnrollmentStatus status) {
+        Enrollment e = new Enrollment();
+        e.setCourse(course);
+        e.setStudent(student);
+        e.setDanceRole(DanceRole.LEAD);
+        e.setStatus(status);
+        e.setEnrolledAt(Instant.now());
+        entityManager.persist(e);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/frontend/src/app/courses/courses.html
+++ b/frontend/src/app/courses/courses.html
@@ -83,7 +83,7 @@
             </td>
           </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="columns"></tr>
+          <tr mat-header-row *matHeaderRowDef="columns; sticky: true"></tr>
           <tr mat-row *matRowDef="let row; columns: columns;" [routerLink]="['/app/courses', row.id]" class="clickable-row"></tr>
         </table>
 

--- a/frontend/src/app/students/student.service.ts
+++ b/frontend/src/app/students/student.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface StudentListItem {
+  id: number;
+  name: string;
+  email: string;
+  phoneNumber: string | null;
+  activeCoursesCount: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class StudentService {
+  private http = inject(HttpClient);
+
+  getStudents(): Observable<StudentListItem[]> {
+    return this.http.get<StudentListItem[]>(`${environment.apiUrl}/api/students`);
+  }
+}

--- a/frontend/src/app/students/students.html
+++ b/frontend/src/app/students/students.html
@@ -1,0 +1,71 @@
+@if (hasSchool()) {
+  @if (loaded() && !error()) {
+    <div class="ds-page-toolbar">
+      <nav mat-tab-nav-bar [tabPanel]="studentsTabPanel" mat-align-tabs="start" class="ds-page-toolbar__tabs">
+        @for (tab of tabs; track tab.label; let i = $index) {
+          <a
+            mat-tab-link
+            (click)="selectTab(i)"
+            [active]="activeTabIndex() === i"
+          >
+            <span class="ds-tab-label">{{ tab.label }}</span>
+            <span class="ds-tab-count">{{ tabCounts()[i] }}</span>
+          </a>
+        }
+      </nav>
+    </div>
+
+    <div class="ds-filter-bar">
+      <mat-form-field class="ds-filter-search" appearance="outline" subscriptSizing="dynamic">
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput placeholder="Search students..." [(ngModel)]="searchText" (ngModelChange)="applyFilter()" />
+      </mat-form-field>
+    </div>
+
+    <mat-tab-nav-panel #studentsTabPanel>
+      <div class="ds-table-card students-table">
+        <table mat-table [dataSource]="activeDataSource()" matSort matSortActive="name" matSortDirection="asc" matSortDisableClear>
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
+            <td mat-cell *matCellDef="let student">{{ student.name }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="email">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Email</th>
+            <td mat-cell *matCellDef="let student">{{ student.email }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="phone">
+            <th mat-header-cell *matHeaderCellDef>Phone</th>
+            <td mat-cell *matCellDef="let student">{{ student.phoneNumber || '—' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="activeCourses">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Active Courses</th>
+            <td mat-cell *matCellDef="let student">{{ student.activeCoursesCount }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="columns; sticky: true"></tr>
+          <tr mat-row *matRowDef="let row; columns: columns;"></tr>
+        </table>
+
+        <div class="ds-table-footer">
+          Showing {{ activeDataSource().filteredData.length }} students
+        </div>
+      </div>
+    </mat-tab-nav-panel>
+  } @else if (error()) {
+    <p class="error-text">Could not load students. Please try again later.</p>
+  } @else {
+    <div class="loading">
+      <p>Loading students...</p>
+    </div>
+  }
+} @else {
+  <div class="empty-state">
+    <mat-icon class="empty-state-icon">business</mat-icon>
+    <h2 class="empty-state-title">Set up your school to get started</h2>
+    <p class="empty-state-text">Create your dance school profile to begin managing students.</p>
+    <a mat-flat-button routerLink="/app/my-school/edit">Create School</a>
+  </div>
+}

--- a/frontend/src/app/students/students.scss
+++ b/frontend/src/app/students/students.scss
@@ -1,0 +1,60 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-4);
+}
+
+.students-table {
+  ::ng-deep .mat-column-name          { width: 30%; }
+  ::ng-deep .mat-column-email         { width: 32%; }
+  ::ng-deep .mat-column-phone         { width: 20%; }
+  ::ng-deep .mat-column-activeCourses { width: 18%; }
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--ds-spacing-12) var(--ds-spacing-6);
+}
+
+.empty-state-icon {
+  font-size: var(--ds-spacing-16);
+  width: var(--ds-spacing-16);
+  height: var(--ds-spacing-16);
+  color: var(--mat-sys-on-surface-variant);
+  margin-bottom: var(--ds-spacing-4);
+}
+
+.empty-state-title {
+  font: var(--mat-sys-headline-small);
+  color: var(--mat-sys-on-surface);
+  margin: 0 0 var(--ds-spacing-2);
+}
+
+.empty-state-text {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0 0 var(--ds-spacing-6);
+  max-width: var(--ds-max-width-narrow);
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: var(--ds-spacing-12);
+
+  p {
+    font: var(--mat-sys-body-large);
+    color: var(--mat-sys-on-surface-variant);
+  }
+}
+
+.error-text {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-error);
+  text-align: center;
+  padding: var(--ds-spacing-12);
+}

--- a/frontend/src/app/students/students.spec.ts
+++ b/frontend/src/app/students/students.spec.ts
@@ -1,0 +1,227 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { StudentsComponent } from './students';
+import { StudentListItem } from './student.service';
+import { AuthService } from '../shared/auth/auth.service';
+
+function makeStudent(overrides: Partial<StudentListItem> = {}): StudentListItem {
+  return {
+    id: 1,
+    name: 'Alice Anderson',
+    email: 'alice@example.com',
+    phoneNumber: '+41 79 000 00 00',
+    activeCoursesCount: 1,
+    ...overrides,
+  };
+}
+
+function fakeAuthService(hasSchool: boolean) {
+  return {
+    user: signal(hasSchool
+      ? {
+          id: 1,
+          email: 'owner@test.com',
+          name: 'Owner',
+          avatarUrl: null,
+          memberships: [{ schoolId: 1, schoolName: 'Test', role: 'OWNER' as const }],
+        }
+      : {
+          id: 1,
+          email: 'onboarding@test.com',
+          name: 'Onboarding',
+          avatarUrl: null,
+          memberships: [],
+        }),
+  };
+}
+
+describe('StudentsComponent', () => {
+  let fixture: ComponentFixture<StudentsComponent>;
+  let httpTesting: HttpTestingController;
+  let el: HTMLElement;
+
+  function setup(hasSchool = true): void {
+    TestBed.configureTestingModule({
+      imports: [StudentsComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: fakeAuthService(hasSchool) },
+      ],
+    });
+
+    fixture = TestBed.createComponent(StudentsComponent);
+    httpTesting = TestBed.inject(HttpTestingController);
+    el = fixture.nativeElement;
+  }
+
+  afterEach(() => {
+    httpTesting?.verify();
+  });
+
+  function flushInit(students: StudentListItem[] = []): void {
+    fixture.detectChanges();
+    const reqs = httpTesting.match(req => req.url.includes('/api/students'));
+    expect(reqs.length).toBe(1);
+    reqs[0].flush(students);
+    fixture.detectChanges();
+  }
+
+  it('fires exactly one GET /api/students on init', () => {
+    setup();
+    fixture.detectChanges();
+    const reqs = httpTesting.match(req => req.url.includes('/api/students'));
+    expect(reqs.length).toBe(1);
+    reqs[0].flush([]);
+  });
+
+  it('skips the fetch and shows the set-up-school empty state when the user has no school', () => {
+    setup(false);
+    fixture.detectChanges();
+
+    const reqs = httpTesting.match(req => req.url.includes('/api/students'));
+    expect(reqs.length).toBe(0);
+    expect(el.querySelector('.empty-state')).toBeTruthy();
+    expect(el.querySelector('.empty-state-title')?.textContent?.trim())
+      .toBe('Set up your school to get started');
+  });
+
+  it('shows loading state initially', () => {
+    setup();
+    fixture.detectChanges();
+    expect(el.querySelector('.loading')).toBeTruthy();
+    flushInit();
+  });
+
+  it('renders all four columns with mock data', () => {
+    setup();
+    flushInit([makeStudent()]);
+
+    const headers = Array.from(el.querySelectorAll('th')).map(th => th.textContent?.trim());
+    expect(headers).toEqual(['Name', 'Email', 'Phone', 'Active Courses']);
+
+    const cells = Array.from(el.querySelectorAll('td')).map(td => td.textContent?.trim());
+    expect(cells).toEqual(['Alice Anderson', 'alice@example.com', '+41 79 000 00 00', '1']);
+  });
+
+  it('renders em-dash placeholder when phoneNumber is null', () => {
+    setup();
+    flushInit([makeStudent({ phoneNumber: null })]);
+
+    const phoneCell = el.querySelector('td.mat-column-phone');
+    expect(phoneCell?.textContent?.trim()).toBe('—');
+  });
+
+  it('renders 2 tabs (Active, Inactive) with counts', () => {
+    setup();
+    flushInit([
+      makeStudent({ id: 1, activeCoursesCount: 2 }),
+      makeStudent({ id: 2, activeCoursesCount: 1 }),
+      makeStudent({ id: 3, activeCoursesCount: 0 }),
+    ]);
+
+    const tabs = el.querySelectorAll('a[mat-tab-link]');
+    expect(tabs.length).toBe(2);
+
+    const labels = Array.from(tabs).map(t => t.querySelector('.ds-tab-label')?.textContent?.trim());
+    const counts = Array.from(tabs).map(t => t.querySelector('.ds-tab-count')?.textContent?.trim());
+    expect(labels).toEqual(['Active', 'Inactive']);
+    expect(counts).toEqual(['2', '1']);
+  });
+
+  it('partitions rows into Active / Inactive tabs based on activeCoursesCount > 0', () => {
+    setup();
+    flushInit([
+      makeStudent({ id: 1, name: 'Alice',   activeCoursesCount: 2 }),
+      makeStudent({ id: 2, name: 'Bob',     activeCoursesCount: 0 }),
+      makeStudent({ id: 3, name: 'Carol',   activeCoursesCount: 1 }),
+      makeStudent({ id: 4, name: 'Dave',    activeCoursesCount: 0 }),
+    ]);
+
+    const component = fixture.componentInstance as unknown as {
+      tabData: { data: StudentListItem[] }[];
+      selectTab: (i: number) => void;
+    };
+
+    const activeIds = component.tabData[0].data.map(s => s.id).sort();
+    const inactiveIds = component.tabData[1].data.map(s => s.id).sort();
+    expect(activeIds).toEqual([1, 3]);
+    expect(inactiveIds).toEqual([2, 4]);
+  });
+
+  it('applies client-side filter on name', () => {
+    setup();
+    flushInit([
+      makeStudent({ id: 1, name: 'Alice Anderson', email: 'alice@example.com' }),
+      makeStudent({ id: 2, name: 'Bob Brown',      email: 'bob@example.com' }),
+    ]);
+
+    const component = fixture.componentInstance as unknown as {
+      tabData: { filteredData: StudentListItem[] }[];
+      searchText: string;
+      applyFilter: () => void;
+    };
+    component.searchText = 'alice';
+    component.applyFilter();
+
+    expect(component.tabData[0].filteredData.map(s => s.id)).toEqual([1]);
+  });
+
+  it('applies client-side filter on email', () => {
+    setup();
+    flushInit([
+      makeStudent({ id: 1, name: 'Alice', email: 'alice@example.com' }),
+      makeStudent({ id: 2, name: 'Bob',   email: 'bob@somewhere.com' }),
+    ]);
+
+    const component = fixture.componentInstance as unknown as {
+      tabData: { filteredData: StudentListItem[] }[];
+      searchText: string;
+      applyFilter: () => void;
+    };
+    component.searchText = 'somewhere';
+    component.applyFilter();
+
+    expect(component.tabData[0].filteredData.map(s => s.id)).toEqual([2]);
+  });
+
+  it('shows the current count in the footer', () => {
+    setup();
+    flushInit([
+      makeStudent({ id: 1, name: 'Alice', activeCoursesCount: 1 }),
+      makeStudent({ id: 2, name: 'Bob',   activeCoursesCount: 1 }),
+    ]);
+
+    const footer = el.querySelector('.ds-table-footer')?.textContent?.trim();
+    expect(footer).toBe('Showing 2 students');
+  });
+
+  it('renders empty tab body (headers still visible) when the tab has no students', () => {
+    setup();
+    flushInit([makeStudent({ id: 1, activeCoursesCount: 2 })]);
+
+    // Active tab has 1 row; Inactive tab (index 1) is empty.
+    const component = fixture.componentInstance as unknown as { selectTab: (i: number) => void };
+    component.selectTab(1);
+    fixture.detectChanges();
+
+    const headers = Array.from(el.querySelectorAll('th'));
+    expect(headers.length).toBe(4);
+    const bodyRows = Array.from(el.querySelectorAll('tr.mat-mdc-row'));
+    expect(bodyRows.length).toBe(0);
+  });
+
+  it('displays error state', () => {
+    setup();
+    fixture.detectChanges();
+    const reqs = httpTesting.match(req => req.url.includes('/api/students'));
+    reqs[0].error(new ProgressEvent('error'));
+    fixture.detectChanges();
+
+    expect(el.querySelector('.error-text')).toBeTruthy();
+  });
+});

--- a/frontend/src/app/students/students.ts
+++ b/frontend/src/app/students/students.ts
@@ -1,72 +1,126 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal, OnInit, ViewChild, computed } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { MatButtonModule } from '@angular/material/button';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatSortModule, MatSort } from '@angular/material/sort';
 import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatTabsModule } from '@angular/material/tabs';
 import { AuthService } from '../shared/auth/auth.service';
+import { StudentListItem, StudentService } from './student.service';
+
+interface TabConfig {
+  label: string;
+}
+
+const COLUMNS = ['name', 'email', 'phone', 'activeCourses'];
+
+const TAB_CONFIGS: TabConfig[] = [
+  { label: 'Active' },
+  { label: 'Inactive' },
+];
+
+const ACTIVE_TAB_INDEX = 0;
+const INACTIVE_TAB_INDEX = 1;
 
 @Component({
   selector: 'app-students',
-  imports: [RouterLink, MatButtonModule, MatIconModule],
-  template: `
-    @if (hasSchool()) {
-      <div class="students-page">
-        <h2>Students</h2>
-        <p>Manage and view all students enrolled in your dance school</p>
-      </div>
-    } @else {
-      <div class="empty-state">
-        <mat-icon class="empty-state-icon">business</mat-icon>
-        <h2 class="empty-state-title">Set up your school to get started</h2>
-        <p class="empty-state-text">Create your dance school profile to begin managing students.</p>
-        <a mat-flat-button routerLink="/app/my-school/edit">Create School</a>
-      </div>
-    }
-  `,
-  styles: `
-    .students-page {
-      h2 {
-        font: var(--mat-sys-headline-small);
-        color: var(--mat-sys-on-surface);
-        margin-bottom: var(--ds-spacing-2);
-      }
-      p {
-        font: var(--mat-sys-body-large);
-        color: var(--mat-sys-on-surface-variant);
-      }
-    }
-    .empty-state {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      padding: var(--ds-spacing-12) var(--ds-spacing-6);
-    }
-    .empty-state-icon {
-      font-size: var(--ds-spacing-16);
-      width: var(--ds-spacing-16);
-      height: var(--ds-spacing-16);
-      color: var(--mat-sys-on-surface-variant);
-      margin-bottom: var(--ds-spacing-4);
-    }
-    .empty-state-title {
-      font: var(--mat-sys-headline-small);
-      color: var(--mat-sys-on-surface);
-      margin-bottom: var(--ds-spacing-2);
-    }
-    .empty-state-text {
-      font: var(--mat-sys-body-large);
-      color: var(--mat-sys-on-surface-variant);
-      margin-bottom: var(--ds-spacing-6);
-      max-width: var(--ds-max-width-narrow);
-    }
-  `,
+  imports: [
+    MatTableModule, MatSortModule, MatIconModule, MatButtonModule,
+    MatFormFieldModule, MatInputModule, MatTabsModule,
+    FormsModule, RouterLink,
+  ],
+  templateUrl: './students.html',
+  styleUrl: './students.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class StudentsComponent {
+export class StudentsComponent implements OnInit {
   private auth = inject(AuthService);
+  private studentService = inject(StudentService);
+  private destroyRef = inject(DestroyRef);
+
   protected hasSchool = computed(() => {
     const u = this.auth.user();
     return u ? u.memberships.length > 0 : false;
   });
+
+  protected tabs = TAB_CONFIGS;
+  protected activeTabIndex = signal(ACTIVE_TAB_INDEX);
+  protected loaded = signal(false);
+  protected error = signal(false);
+
+  protected tabData: MatTableDataSource<StudentListItem>[] = TAB_CONFIGS.map(() => new MatTableDataSource<StudentListItem>([]));
+  protected tabCounts = signal<number[]>(TAB_CONFIGS.map(() => 0));
+
+  protected searchText = '';
+
+  protected columns = COLUMNS;
+  protected activeDataSource = computed(() => this.tabData[this.activeTabIndex()]);
+
+  private matSort?: MatSort;
+
+  @ViewChild(MatSort) set sort(sort: MatSort) {
+    if (sort) {
+      this.matSort = sort;
+      this.tabData[this.activeTabIndex()].sort = sort;
+    }
+  }
+
+  ngOnInit(): void {
+    if (!this.hasSchool()) return;
+
+    this.tabData.forEach(ds => {
+      ds.filterPredicate = this.createFilterPredicate();
+    });
+
+    this.studentService.getStudents().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (students) => {
+        this.partitionStudents(students);
+        this.loaded.set(true);
+      },
+      error: () => {
+        this.error.set(true);
+        this.loaded.set(true);
+      },
+    });
+  }
+
+  protected selectTab(index: number): void {
+    this.activeTabIndex.set(index);
+    if (this.matSort) {
+      this.tabData[index].sort = this.matSort;
+    }
+  }
+
+  private partitionStudents(students: StudentListItem[]): void {
+    const active: StudentListItem[] = [];
+    const inactive: StudentListItem[] = [];
+    for (const s of students) {
+      if (s.activeCoursesCount > 0) active.push(s);
+      else inactive.push(s);
+    }
+    this.tabData[ACTIVE_TAB_INDEX].data = active;
+    this.tabData[INACTIVE_TAB_INDEX].data = inactive;
+
+    const counts = this.tabCounts().slice();
+    counts[ACTIVE_TAB_INDEX] = active.length;
+    counts[INACTIVE_TAB_INDEX] = inactive.length;
+    this.tabCounts.set(counts);
+  }
+
+  protected applyFilter(): void {
+    const text = this.searchText.trim().toLowerCase();
+    this.tabData.forEach(ds => ds.filter = text);
+  }
+
+  private createFilterPredicate(): (data: StudentListItem, filter: string) => boolean {
+    return (data: StudentListItem, filter: string): boolean => {
+      if (!filter) return true;
+      const searchable = [data.name, data.email].join(' ').toLowerCase();
+      return searchable.includes(filter);
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- New `GET /api/students` backed by a single JPQL constructor-expression query. `StudentListDto` carries `(id, name, email, phoneNumber, activeCoursesCount)` where `activeCoursesCount` is the number of distinct RUNNING courses the student holds a seat in (`PENDING_PAYMENT` or `CONFIRMED`). RUNNING derivation mirrors `CourseRepository.findRunningBySchoolId` — javadoc cross-links the two.
- New `StudentsComponent` built on the shared `_table.scss` chrome. Active/Inactive tabs partition client-side by `activeCoursesCount > 0`; search filters on name + email; `MatTable` sorts on Name / Email / Active Courses (default Name ASC); sticky header; non-clickable rows; footer shows the current tab's visible count.
- Bonus: Courses table header gets `sticky: true` too — both list pages now behave consistently.

Closes #293.

## Test plan
- [x] Backend: `StudentListIntegrationTest` — tenant isolation, empty-school, `activeCoursesCount` across RUNNING + non-RUNNING courses and seat-holding vs non-seat-holding statuses (covers duplicate seat-holding enrollments for the same course collapsing to 1 via `DISTINCT`), Hibernate-Statistics SQL budget (≤3 statements for 10 students — proves not N+1). All 4 pass.
- [x] Frontend: new `students.spec.ts` — 12 tests covering init request, set-up-school guard, loading/error states, 4-column render, em-dash on missing phone, tabs + counts, partitioning, search on name and email, footer, empty-tab (headers visible, no rows). All 122 frontend tests pass.
- [x] Visual check (Playwright, 1440×900, `owner@test.com`): `/app/students` renders tabs `Active 7 / Inactive 0`, table sorted Name ASC with em-dash fallback on missing phone, `Showing 7 students` footer. Inactive tab shows headers + `Showing 0 students` with no empty-state messaging, per spec. Courses page still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)