### PR TITLE
Students 'Active' tab: include OPEN courses (#306)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
@@ -19,16 +19,13 @@ interface StudentRepository extends JpaRepository<Student, Long> {
 
     /**
      * Returns students for a school along with the count of their "active" courses —
-     * seat-holding enrollments in courses currently RUNNING. The RUNNING predicate
-     * (publishedAt set, startDate ≤ today ≤ endDate) mirrors
-     * {@link ch.ruppen.danceschool.course.CourseRepository#findRunningBySchoolId};
-     * keep the two in sync if the derivation changes.
+     * seat-holding enrollments in courses that are published and not yet finished
+     * (covers both OPEN, i.e. published with a future start date, and RUNNING).
      */
     @Query("""
             SELECT new ch.ruppen.danceschool.student.StudentListDto(
                 s.id, s.name, s.email, s.phoneNumber,
                 COUNT(DISTINCT CASE WHEN c.publishedAt IS NOT NULL
-                                     AND c.startDate <= :today
                                      AND c.endDate   >= :today
                                     THEN c.id END)
             )

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentListIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentListIntegrationTest.java
@@ -103,17 +103,15 @@ class StudentListIntegrationTest {
     }
 
     @Test
-    void list_countsSeatHoldingEnrollmentsInRunningCoursesOnly() throws Exception {
+    void list_countsSeatHoldingEnrollmentsInPublishedNotFinishedCoursesOnly() throws Exception {
         LocalDate today = LocalDate.now();
 
-        Course running1 = createCourse(schoolA, "Running 1",
+        Course running = createCourse(schoolA, "Running",
                 today.minusDays(1), today.minusWeeks(3), today.plusWeeks(3));
-        Course running2 = createCourse(schoolA, "Running 2",
-                today.minusDays(1), today.minusWeeks(2), today.plusWeeks(4));
-        Course finished = createCourse(schoolA, "Finished",
-                today.minusMonths(3), today.minusMonths(2), today.minusDays(2));
         Course open = createCourse(schoolA, "Open",
                 today.minusDays(1), today.plusDays(7), today.plusWeeks(8));
+        Course finished = createCourse(schoolA, "Finished",
+                today.minusMonths(3), today.minusMonths(2), today.minusDays(2));
         Course draft = createCourse(schoolA, "Draft",
                 null, today.plusDays(10), today.plusWeeks(10));
 
@@ -121,25 +119,24 @@ class StudentListIntegrationTest {
         Student oneActive = createStudent(schoolA, "One Active", "one@example.com");
         Student twoActive = createStudent(schoolA, "Two Active", "two@example.com");
 
-        // zeroActive: enrolled only in non-RUNNING courses, or non-seat-holding status
+        // zeroActive: only non-counting courses, or non-seat-holding statuses on a counted course
         createEnrollment(finished, zeroActive, EnrollmentStatus.CONFIRMED);
-        createEnrollment(open, zeroActive, EnrollmentStatus.CONFIRMED);
         createEnrollment(draft, zeroActive, EnrollmentStatus.CONFIRMED);
-        createEnrollment(running1, zeroActive, EnrollmentStatus.WAITLISTED);
-        createEnrollment(running1, zeroActive, EnrollmentStatus.REJECTED);
-        createEnrollment(running1, zeroActive, EnrollmentStatus.PENDING_APPROVAL);
+        createEnrollment(running, zeroActive, EnrollmentStatus.WAITLISTED);
+        createEnrollment(running, zeroActive, EnrollmentStatus.REJECTED);
+        createEnrollment(running, zeroActive, EnrollmentStatus.PENDING_APPROVAL);
 
-        // oneActive: one seat-holding enrollment in a RUNNING course
-        createEnrollment(running1, oneActive, EnrollmentStatus.CONFIRMED);
+        // oneActive: a single seat-holding enrollment in an OPEN course (now counts)
+        createEnrollment(open, oneActive, EnrollmentStatus.CONFIRMED);
         // plus noise that must not count
         createEnrollment(finished, oneActive, EnrollmentStatus.CONFIRMED);
-        createEnrollment(running2, oneActive, EnrollmentStatus.WAITLISTED);
+        createEnrollment(running, oneActive, EnrollmentStatus.WAITLISTED);
 
-        // twoActive: two seat-holding enrollments in RUNNING courses (one CONFIRMED, one PENDING_PAYMENT)
-        // Plus a duplicate CONFIRMED enrollment on running1 — DISTINCT in the query collapses it to 1.
-        createEnrollment(running1, twoActive, EnrollmentStatus.CONFIRMED);
-        createEnrollment(running1, twoActive, EnrollmentStatus.CONFIRMED);
-        createEnrollment(running2, twoActive, EnrollmentStatus.PENDING_PAYMENT);
+        // twoActive: seat-holding in one RUNNING and one OPEN course (one CONFIRMED, one PENDING_PAYMENT).
+        // Plus a duplicate CONFIRMED enrollment on the RUNNING course — DISTINCT collapses it to 1.
+        createEnrollment(running, twoActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(running, twoActive, EnrollmentStatus.CONFIRMED);
+        createEnrollment(open, twoActive, EnrollmentStatus.PENDING_PAYMENT);
 
         entityManager.flush();
 


### PR DESCRIPTION
## Summary
- Drop `c.startDate <= :today` from the active-courses count predicate in `StudentRepository.findListBySchoolId` so seat-holding enrollments in published-but-not-yet-started (OPEN) courses also mark the student Active.
- Update the JavaDoc to read "published and not yet finished" and remove the stale `findRunningBySchoolId` cross-reference.
- Rename the integration test to `list_countsSeatHoldingEnrollmentsInPublishedNotFinishedCoursesOnly` and restructure fixtures: the OPEN-course enrollment now contributes (via `oneActive`), and `twoActive` covers the RUNNING + OPEN combo with the DISTINCT-collapse case.

DRAFT (unpublished) and FINISHED (endDate past) remain excluded. Non-seat-holding statuses (WAITLISTED / REJECTED / PENDING_APPROVAL) still don't count. No frontend change.

Closes #306

## Test plan
- [x] `./mvnw test -Dtest=StudentListIntegrationTest` — 4/4 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)