### PR TITLE
Drop self-reference hack in auto-promote; log directly

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -17,7 +17,6 @@ import ch.ruppen.danceschool.student.StudentDanceLevel;
 import ch.ruppen.danceschool.student.StudentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,9 +38,6 @@ public class EnrollmentService {
     private final StudentService studentService;
     private final SchoolMemberService schoolMemberService;
     private final Clock clock;
-    // Self-reference via ObjectProvider so auto-promote calls go through the Spring proxy,
-    // which is required for @BusinessOperation to fire on each promotion.
-    private final ObjectProvider<EnrollmentService> selfProvider;
 
     @Transactional
     @BusinessOperation(event = "StudentEnrolled")
@@ -266,8 +262,12 @@ public class EnrollmentService {
         boolean anyPromoted = false;
         for (Enrollment candidate : candidates) {
             if (resolveWaitlist(course, candidate.getDanceRole()) == null) {
-                // Self-invocation through the proxy fires @BusinessOperation per promotion.
-                selfProvider.getObject().autoPromoteEnrollment(candidate.getId());
+                candidate.setStatus(EnrollmentStatus.PENDING_PAYMENT);
+                candidate.setWaitlistReason(null);
+                candidate.setWaitlistPosition(null);
+                // Matches the BusinessLoggingAspect output format; emitted directly because
+                // self-invocation bypasses the aspect.
+                log.info("BUSINESS | EnrollmentAutoPromoted | enrollmentId={}", candidate.getId());
                 committed++;
                 anyPromoted = true;
                 if (committed >= course.getMaxParticipants()) {
@@ -278,23 +278,6 @@ public class EnrollmentService {
         if (anyPromoted) {
             renumberWaitlistPositions(course);
         }
-    }
-
-    /**
-     * Internal — do not expose via controller. Public only so the Spring proxy can fire
-     * the {@link BusinessOperation} aspect on self-invocation; no school-scope check here
-     * because the caller ({@link #autoPromoteWaitlist}) has already resolved the enrollment
-     * from a tenant-scoped course.
-     */
-    @Transactional
-    @BusinessOperation(event = "EnrollmentAutoPromoted")
-    public EnrollmentResponseDto autoPromoteEnrollment(Long enrollmentId) {
-        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
-                .orElseThrow(() -> new ResourceNotFoundException("Enrollment", enrollmentId));
-        enrollment.setStatus(EnrollmentStatus.PENDING_PAYMENT);
-        enrollment.setWaitlistReason(null);
-        enrollment.setWaitlistPosition(null);
-        return new EnrollmentResponseDto(enrollment.getId(), enrollment.getStatus());
     }
 
     private void renumberWaitlistPositions(Course course) {

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/WaitlistAutoPromotionIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/WaitlistAutoPromotionIntegrationTest.java
@@ -74,12 +74,12 @@ class WaitlistAutoPromotionIntegrationTest {
 
         logAppender = new ListAppender<>();
         logAppender.start();
-        ((Logger) LoggerFactory.getLogger("ch.ruppen.danceschool.shared.logging.BusinessLoggingAspect")).addAppender(logAppender);
+        ((Logger) LoggerFactory.getLogger(EnrollmentService.class.getName())).addAppender(logAppender);
     }
 
     @AfterEach
     void tearDown() {
-        ((Logger) LoggerFactory.getLogger("ch.ruppen.danceschool.shared.logging.BusinessLoggingAspect")).detachAppender(logAppender);
+        ((Logger) LoggerFactory.getLogger(EnrollmentService.class.getName())).detachAppender(logAppender);
     }
 
     // --- Direct-pay path ---


### PR DESCRIPTION
## Summary
- Follow-up to #308. The `ObjectProvider<EnrollmentService>` self-injection was introduced purely so `@BusinessOperation` would fire per promotion via Spring's proxy. That cost was too high: it forced a public `autoPromoteEnrollment(Long)` method with no school-scope check as a proxy-invocation target — a leaky internal mutation dressed up as a service API.
- Drop the self-reference and the public method. Emit the log line directly from `autoPromoteWaitlist`, matching the `BusinessLoggingAspect` format so downstream log parsing stays uniform.

## Test plan
- [x] `./mvnw test` — 174/174 green
- [x] `WaitlistAutoPromotionIntegrationTest` still asserts `BUSINESS | EnrollmentAutoPromoted` count per scenario; only the log source changed (aspect → `EnrollmentService` logger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)