### PR TITLE
Logging improvements: less noise, tenant MDC, richer business events

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -17,6 +17,8 @@ import ch.ruppen.danceschool.student.StudentDanceLevel;
 import ch.ruppen.danceschool.student.StudentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +33,11 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class EnrollmentService {
+
+    // Dedicated logger shared with BusinessLoggingAspect — auto-promote emits directly
+    // (self-invocation bypasses the aspect) but must land on the same logger so downstream
+    // filters treat both paths identically.
+    private static final Logger businessLog = LoggerFactory.getLogger("business");
 
     private final EnrollmentRepository enrollmentRepository;
     private final SchoolService schoolService;
@@ -267,7 +274,8 @@ public class EnrollmentService {
                 candidate.setWaitlistPosition(null);
                 // Matches the BusinessLoggingAspect output format; emitted directly because
                 // self-invocation bypasses the aspect.
-                log.info("BUSINESS | EnrollmentAutoPromoted | enrollmentId={}", candidate.getId());
+                businessLog.info("event=EnrollmentAutoPromoted enrollmentId={} status={}",
+                        candidate.getId(), EnrollmentStatus.PENDING_PAYMENT);
                 committed++;
                 anyPromoted = true;
                 if (committed >= course.getMaxParticipants()) {

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
@@ -26,6 +26,17 @@ public class SchoolMemberService {
         return schoolMemberRepository.findByUserIdAndSchoolId(userId, schoolId);
     }
 
+    /**
+     * Phase 1 assumes a single school per user (enforced by a unique constraint on
+     * {@code school_member.user_id}). Phase 2 will revisit when users can belong to multiple
+     * schools — this method will need to change shape accordingly.
+     */
+    public Optional<Long> findSchoolIdByUserId(Long userId) {
+        return schoolMemberRepository.findByUserId(userId).stream()
+                .findFirst()
+                .map(m -> m.getSchool().getId());
+    }
+
     @BusinessOperation(event = "MembershipCreated")
     public SchoolMember createMembership(SchoolMember member) {
         return schoolMemberRepository.save(member);

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspect.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspect.java
@@ -5,17 +5,21 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
-@Slf4j
 class BusinessLoggingAspect {
+
+    // Dedicated logger name — downstream filters/levels can target business events independently
+    // of the aspect's package, and log aggregators see a clean `logger=business` field.
+    private static final Logger log = LoggerFactory.getLogger("business");
 
     @AfterReturning(pointcut = "@annotation(op)", returning = "result")
     void logBusinessEvent(JoinPoint joinPoint, BusinessOperation op, Object result) {
@@ -24,12 +28,13 @@ class BusinessLoggingAspect {
         extractResultDetails(result, details);
 
         StringJoiner joiner = new StringJoiner(" ");
+        joiner.add("event=" + op.event());
         details.forEach((key, value) ->
                 joiner.add(value instanceof String
                         ? key + "=\"" + value + "\""
                         : key + "=" + value));
 
-        log.info("BUSINESS | {} | {}", op.event(), joiner);
+        log.info("{}", joiner);
     }
 
     private void extractArgumentDetails(JoinPoint joinPoint, Map<String, Object> details) {
@@ -66,9 +71,11 @@ class BusinessLoggingAspect {
             return;
         }
         extractAccessor(result, "id", details);
+        extractAccessor(result, "enrollmentId", details);
         extractAccessor(result, "name", details);
         extractAccessor(result, "title", details);
         extractAccessor(result, "role", details);
+        extractAccessor(result, "status", details);
         extractNestedId(result, "school", "schoolId", details);
         extractNestedId(result, "user", "userId", details);
     }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/logging/ControllerLoggingAspect.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/logging/ControllerLoggingAspect.java
@@ -20,8 +20,7 @@ class ControllerLoggingAspect {
         String className = joinPoint.getTarget().getClass().getSimpleName();
         String methodName = joinPoint.getSignature().getName();
 
-        log.info("Entering {}.{}", className, methodName);
-        log.debug("Arguments: {}", Arrays.toString(joinPoint.getArgs()));
+        log.debug("Arguments to {}.{}: {}", className, methodName, Arrays.toString(joinPoint.getArgs()));
 
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/logging/TenantContextFilter.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/logging/TenantContextFilter.java
@@ -1,0 +1,58 @@
+package ch.ruppen.danceschool.shared.logging;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Populates MDC with {@code schoolId} and {@code userId} for the duration of each request so
+ * every log line emitted in the request scope — including framework logs — carries tenant
+ * context. Registered after Spring Security's {@code AuthorizationFilter} so the principal is
+ * already on the {@link SecurityContextHolder}.
+ * <p>
+ * MDC is cleared in a {@code finally} block to prevent leakage across thread-pool reuse.
+ * <p>
+ * Spring Boot auto-registers any {@code OncePerRequestFilter} bean on the main servlet chain
+ * (outside {@code springSecurityFilterChain}), which would run before authentication and the
+ * {@code ALREADY_FILTERED} guard would then suppress the in-security-chain invocation. A
+ * companion {@code FilterRegistrationBean} with {@code enabled=false} disables that
+ * auto-registration so only the explicit {@code addFilterAfter(...)} wiring runs.
+ */
+@Component
+public class TenantContextFilter extends OncePerRequestFilter {
+
+    public static final String MDC_SCHOOL_ID = "schoolId";
+    public static final String MDC_USER_ID = "userId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            populateMdc();
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_SCHOOL_ID);
+            MDC.remove(MDC_USER_ID);
+        }
+    }
+
+    private void populateMdc() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof AuthenticatedUser user)) {
+            return;
+        }
+        MDC.put(MDC_USER_ID, String.valueOf(user.userId()));
+        if (user.schoolId() != null) {
+            MDC.put(MDC_SCHOOL_ID, String.valueOf(user.schoolId()));
+        }
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/logging/TenantContextFilterRegistrationConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/logging/TenantContextFilterRegistrationConfig.java
@@ -1,0 +1,27 @@
+package ch.ruppen.danceschool.shared.logging;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Disables Spring Boot's automatic servlet-chain registration of {@link TenantContextFilter}.
+ * <p>
+ * Without this, the filter would run on the main servlet chain <em>before</em> Spring Security
+ * authenticates — seeing an empty {@code SecurityContextHolder} — and then the
+ * {@code ALREADY_FILTERED} guard in {@link org.springframework.web.filter.OncePerRequestFilter}
+ * would make the intended in-security-chain registration a no-op. The filter is wired into the
+ * Spring Security chain explicitly via {@code addFilterAfter(..., AuthorizationFilter.class)}
+ * in each {@code SecurityFilterChain} bean.
+ */
+@Configuration
+class TenantContextFilterRegistrationConfig {
+
+    @Bean
+    FilterRegistrationBean<TenantContextFilter> tenantContextFilterRegistration(
+            TenantContextFilter filter) {
+        FilterRegistrationBean<TenantContextFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/AuthenticatedUser.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/AuthenticatedUser.java
@@ -1,4 +1,10 @@
 package ch.ruppen.danceschool.shared.security;
 
-public record AuthenticatedUser(Long userId, String email) {
+/**
+ * Authenticated principal exposed to controllers.
+ * <p>
+ * {@code schoolId} is {@code null} when the user has no {@code SchoolMember} row yet
+ * (needs-onboarding state). Phase 1 assumes a single school per user.
+ */
+public record AuthenticatedUser(Long userId, String email, Long schoolId) {
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevSecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevSecurityConfig.java
@@ -1,5 +1,7 @@
 package ch.ruppen.danceschool.shared.security;
 
+import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
+import ch.ruppen.danceschool.shared.logging.TenantContextFilter;
 import ch.ruppen.danceschool.user.AppUser;
 import ch.ruppen.danceschool.user.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,6 +21,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.cors.CorsConfiguration;
@@ -42,6 +45,8 @@ public class DevSecurityConfig {
 
     private final AppSecurityProperties securityProperties;
     private final UserService userService;
+    private final SchoolMemberService schoolMemberService;
+    private final TenantContextFilter tenantContextFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -61,7 +66,8 @@ public class DevSecurityConfig {
                 .logout(logout -> logout
                         .logoutUrl("/api/auth/logout")
                         .logoutSuccessHandler((req, res, auth) -> res.setStatus(HttpServletResponse.SC_OK))
-                        .invalidateHttpSession(true));
+                        .invalidateHttpSession(true))
+                .addFilterAfter(tenantContextFilter, AuthorizationFilter.class);
 
         return http.build();
     }
@@ -92,7 +98,8 @@ public class DevSecurityConfig {
             AppUser appUser = userService.findByEmail(email)
                     .orElseThrow(() -> new IllegalStateException("Dev user not found: " + email));
 
-            var principal = new AuthenticatedUser(appUser.getId(), appUser.getEmail());
+            Long schoolId = schoolMemberService.findSchoolIdByUserId(appUser.getId()).orElse(null);
+            var principal = new AuthenticatedUser(appUser.getId(), appUser.getEmail(), schoolId);
             var devToken = new DevAuthenticationToken(
                     principal, AuthorityUtils.createAuthorityList("ROLE_USER"));
 

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/FirebaseJwtAuthenticationConverter.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/FirebaseJwtAuthenticationConverter.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.shared.security;
 
+import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
 import ch.ruppen.danceschool.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.convert.converter.Converter;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class FirebaseJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
     private final UserService userService;
+    private final SchoolMemberService schoolMemberService;
 
     @Override
     public AbstractAuthenticationToken convert(Jwt jwt) {
@@ -22,7 +24,8 @@ public class FirebaseJwtAuthenticationConverter implements Converter<Jwt, Abstra
         String name = jwt.getClaimAsString("name");
 
         var appUser = userService.findOrCreateByFirebaseUid(firebaseUid, email, name);
-        var principal = new AuthenticatedUser(appUser.getId(), appUser.getEmail());
+        Long schoolId = schoolMemberService.findSchoolIdByUserId(appUser.getId()).orElse(null);
+        var principal = new AuthenticatedUser(appUser.getId(), appUser.getEmail(), schoolId);
 
         var token = new JwtAuthenticationToken(jwt, AuthorityUtils.createAuthorityList("ROLE_USER"));
         return new FirebaseAuthenticationToken(principal, jwt, token.getAuthorities());

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.shared.security;
 
+import ch.ruppen.danceschool.shared.logging.TenantContextFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -10,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -31,6 +33,7 @@ public class SecurityConfig {
 
     private final AppSecurityProperties securityProperties;
     private final FirebaseJwtAuthenticationConverter firebaseJwtAuthenticationConverter;
+    private final TenantContextFilter tenantContextFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -47,7 +50,8 @@ public class SecurityConfig {
                         .anyRequest().permitAll())
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(firebaseJwtAuthenticationConverter)))
-                .formLogin(AbstractHttpConfigurer::disable);
+                .formLogin(AbstractHttpConfigurer::disable)
+                .addFilterAfter(tenantContextFilter, AuthorizationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Adds schoolId/userId MDC keys (populated by TenantContextFilter) to every log line so log
+  aggregators can filter/group by tenant. Keys render empty for unauthenticated requests
+  (login, health, static resources) and for non-request threads (startup, shutdown).
+-->
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([schoolId=%X{schoolId:-} userId=%X{userId:-}]){faint} %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
@@ -250,7 +250,7 @@ class CourseControllerIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
@@ -362,7 +362,7 @@ class CourseCrudIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseFilterIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseFilterIntegrationTest.java
@@ -191,7 +191,7 @@ class CourseFilterIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CoursePublishTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CoursePublishTest.java
@@ -168,7 +168,7 @@ class CoursePublishTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
@@ -147,7 +147,7 @@ class CourseTenantIsolationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -966,7 +966,7 @@ class EnrollmentIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
@@ -175,7 +175,7 @@ class EnrollmentListSqlBudgetTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/WaitlistAutoPromotionIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/WaitlistAutoPromotionIntegrationTest.java
@@ -74,12 +74,12 @@ class WaitlistAutoPromotionIntegrationTest {
 
         logAppender = new ListAppender<>();
         logAppender.start();
-        ((Logger) LoggerFactory.getLogger(EnrollmentService.class.getName())).addAppender(logAppender);
+        ((Logger) LoggerFactory.getLogger("business")).addAppender(logAppender);
     }
 
     @AfterEach
     void tearDown() {
-        ((Logger) LoggerFactory.getLogger(EnrollmentService.class.getName())).detachAppender(logAppender);
+        ((Logger) LoggerFactory.getLogger("business")).detachAppender(logAppender);
     }
 
     // --- Direct-pay path ---
@@ -424,9 +424,9 @@ class WaitlistAutoPromotionIntegrationTest {
     private void assertBusinessEventFired(String event, int expectedCount) {
         long count = logAppender.list.stream()
                 .map(ILoggingEvent::getFormattedMessage)
-                .filter(m -> m.startsWith("BUSINESS | " + event + " |"))
+                .filter(m -> m.startsWith("event=" + event + " ") || m.equals("event=" + event))
                 .count();
-        assertThat(count).as("count of '%s' BUSINESS logs", event).isEqualTo(expectedCount);
+        assertThat(count).as("count of '%s' business logs", event).isEqualTo(expectedCount);
     }
 
     private Course createCourse(String title, CourseType type, int maxParticipants, Integer threshold) {
@@ -535,7 +535,7 @@ class WaitlistAutoPromotionIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/image/ImageControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/image/ImageControllerIntegrationTest.java
@@ -133,7 +133,7 @@ class ImageControllerIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentIntegrationTest.java
@@ -265,7 +265,7 @@ class PaymentIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
@@ -167,7 +167,7 @@ class PaymentListSqlBudgetTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolControllerIntegrationTest.java
@@ -340,7 +340,7 @@ class SchoolControllerIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolImageDeletionIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolImageDeletionIntegrationTest.java
@@ -233,7 +233,7 @@ class SchoolImageDeletionIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolTenantIsolationTest.java
@@ -160,7 +160,7 @@ class SchoolTenantIsolationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspectTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/shared/logging/BusinessLoggingAspectTest.java
@@ -25,13 +25,13 @@ class BusinessLoggingAspectTest {
     void setUp() {
         logAppender = new ListAppender<>();
         logAppender.start();
-        Logger logger = (Logger) LoggerFactory.getLogger(BusinessLoggingAspect.class);
+        Logger logger = (Logger) LoggerFactory.getLogger("business");
         logger.addAppender(logAppender);
     }
 
     @AfterEach
     void tearDown() {
-        Logger logger = (Logger) LoggerFactory.getLogger(BusinessLoggingAspect.class);
+        Logger logger = (Logger) LoggerFactory.getLogger("business");
         logger.detachAppender(logAppender);
     }
 
@@ -44,7 +44,7 @@ class BusinessLoggingAspectTest {
 
         aspect.logBusinessEvent(joinPoint, op, null);
 
-        assertLogContains("BUSINESS | UserOnboarded | userId=3 email=\"leon@test.com\"");
+        assertLogContains("event=UserOnboarded userId=3 email=\"leon@test.com\"");
     }
 
     @Test
@@ -56,7 +56,7 @@ class BusinessLoggingAspectTest {
 
         aspect.logBusinessEvent(joinPoint, op, 12L);
 
-        assertLogContains("BUSINESS | CourseCreated | userId=3 title=\"Bachata Beginners\" resultId=12");
+        assertLogContains("event=CourseCreated userId=3 title=\"Bachata Beginners\" resultId=12");
     }
 
     @Test
@@ -68,7 +68,7 @@ class BusinessLoggingAspectTest {
 
         aspect.logBusinessEvent(joinPoint, op, new SampleResult(5L, "Tanzwerk"));
 
-        assertLogContains("BUSINESS | SchoolCreated | userId=3 id=5 name=\"Tanzwerk\"");
+        assertLogContains("event=SchoolCreated userId=3 id=5 name=\"Tanzwerk\"");
     }
 
     @Test
@@ -88,7 +88,7 @@ class BusinessLoggingAspectTest {
         aspect.logBusinessEvent(joinPoint, op, result);
 
         String logLine = lastLogMessage();
-        assertThat(logLine).contains("BUSINESS | MembershipCreated");
+        assertThat(logLine).contains("event=MembershipCreated");
         assertThat(logLine).contains("role=\"OWNER\"");
         assertThat(logLine).contains("schoolId=5");
         assertThat(logLine).contains("userId=7");
@@ -118,7 +118,22 @@ class BusinessLoggingAspectTest {
 
         aspect.logBusinessEvent(joinPoint, op, null);
 
-        assertLogContains("BUSINESS | TestEvent | userId=3");
+        assertLogContains("event=TestEvent userId=3");
+    }
+
+    @Test
+    void logsStatusFieldFromResult() {
+        JoinPoint joinPoint = mockJoinPoint(
+                new String[]{"userId"},
+                new Object[]{3L});
+        BusinessOperation op = mockOperation("StudentEnrolled");
+
+        aspect.logBusinessEvent(joinPoint, op, new SampleEnrollmentResult(42L, "WAITLISTED"));
+
+        String logLine = lastLogMessage();
+        assertThat(logLine).contains("event=StudentEnrolled");
+        assertThat(logLine).contains("enrollmentId=42");
+        assertThat(logLine).contains("status=\"WAITLISTED\"");
     }
 
     // --- helpers ---
@@ -155,6 +170,8 @@ class BusinessLoggingAspectTest {
     record SampleResult(Long id, String name) {}
 
     record SampleDetailResult(Long id, String title) {}
+
+    record SampleEnrollmentResult(Long enrollmentId, String status) {}
 
     static class SampleParent {
         private final Long id;

--- a/backend/src/test/java/ch/ruppen/danceschool/shared/logging/TenantContextFilterIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/shared/logging/TenantContextFilterIntegrationTest.java
@@ -1,0 +1,130 @@
+package ch.ruppen.danceschool.shared.logging;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies that {@link TenantContextFilter} actually populates MDC during request handling —
+ * catches regressions where the filter ends up auto-registered on the main servlet chain
+ * (before Spring Security authenticates) and is then silently suppressed on the in-security
+ * chain by the {@code ALREADY_FILTERED} guard.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class TenantContextFilterIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void setUp() {
+        // ControllerLoggingAspect emits "Completed ..." on every request — captured events
+        // include the MDC snapshot at log time.
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        controllerLogger().addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        controllerLogger().detachAppender(logAppender);
+    }
+
+    @Test
+    void populatesUserIdAndSchoolIdInMdc_onAuthenticatedRequest() throws Exception {
+        AppUser user = new AppUser();
+        user.setEmail("mdc-test@example.com");
+        user.setName("MDC Test");
+        user.setFirebaseUid("mdc-test-uid");
+        entityManager.persist(user);
+
+        School school = new School();
+        school.setName("MDC School");
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(user);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/auth/me")
+                        .with(authentication(authToken(user, school.getId()))))
+                .andExpect(status().isOk());
+
+        Map<String, String> mdc = lastEventMdc();
+        assertThat(mdc).containsEntry("userId", String.valueOf(user.getId()));
+        assertThat(mdc).containsEntry("schoolId", String.valueOf(school.getId()));
+    }
+
+    @Test
+    void leavesSchoolIdEmpty_whenPrincipalHasNoSchool() throws Exception {
+        AppUser user = new AppUser();
+        user.setEmail("no-school@example.com");
+        user.setName("No School");
+        user.setFirebaseUid("no-school-uid");
+        entityManager.persist(user);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/auth/me")
+                        .with(authentication(authToken(user, null))))
+                .andExpect(status().isOk());
+
+        Map<String, String> mdc = lastEventMdc();
+        assertThat(mdc).containsEntry("userId", String.valueOf(user.getId()));
+        assertThat(mdc).doesNotContainKey("schoolId");
+    }
+
+    private Map<String, String> lastEventMdc() {
+        List<ILoggingEvent> events = logAppender.list;
+        assertThat(events).isNotEmpty();
+        return events.getLast().getMDCPropertyMap();
+    }
+
+    private Logger controllerLogger() {
+        return (Logger) LoggerFactory.getLogger(
+                "ch.ruppen.danceschool.shared.logging.ControllerLoggingAspect");
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user, Long schoolId) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), schoolId);
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentCrudIntegrationTest.java
@@ -235,7 +235,7 @@ class StudentCrudIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentListIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentListIntegrationTest.java
@@ -250,7 +250,7 @@ class StudentListIntegrationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentTenantIsolationTest.java
@@ -147,7 +147,7 @@ class StudentTenantIsolationTest {
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {
-        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail());
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
         return new UsernamePasswordAuthenticationToken(
                 principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
     }


### PR DESCRIPTION
Closes #305. Bundles all four sections of the issue into one PR.

## Summary

- **Less noise (§1):** drop the `Entering X.y` INFO line from `ControllerLoggingAspect` — `Completed` already carries duration + result.
- **Cleaner business log format (§2):** move business events to a dedicated `business` SLF4J logger with a `event=Name k=v k=v` format; drops the hand-rolled `BUSINESS |` prefix that collided with log-viewer column separators.
- **Tenant MDC (§3, the heavy one):**
  - `AuthenticatedUser` gains a nullable `schoolId` (Phase 1 single-school-per-user invariant). Populated at both auth mint sites — `DevSecurityConfig#devAuthSuccessHandler` and `FirebaseJwtAuthenticationConverter#convert` — via a new `SchoolMemberService#findSchoolIdByUserId` helper.
  - `TenantContextFilter extends OncePerRequestFilter` reads the principal after Spring Security's `AuthorizationFilter` and puts `schoolId`/`userId` on MDC for the request, clearing in `finally`.
  - `TenantContextFilterRegistrationConfig` installs a disabled `FilterRegistrationBean` to suppress Spring Boot's default auto-registration on the main servlet chain — otherwise the filter runs before authentication, sees an empty `SecurityContext`, and the `ALREADY_FILTERED` guard would silently neutralize the explicit in-security-chain wiring.
  - `logback-spring.xml` renders `[schoolId=… userId=…]` on every line; keys stay empty for unauthenticated requests and non-request threads (startup, health).
- **Richer business events (§4):** extend `BusinessLoggingAspect.extractResultDetails` allow-list with `enrollmentId` and `status`. Existing `StudentEnrolled` / `EnrollmentApproved` / `EnrollmentAutoPromoted` now carry outcome context, so the waitlist branch is no longer silent. No new `@BusinessOperation` annotations — every event the issue proposes beyond what exists is for features that aren't implemented yet (cancellation #246, course delete, member removal, Stripe-vs-offline payment split). Those land when the features land.

## Test plan

- [x] `./mvnw test` — 177/177 green, including:
  - `TenantContextFilterIntegrationTest` (new) — asserts MDC keys are populated mid-request via captured `ILoggingEvent.getMDCPropertyMap()`; covers the blocker the code reviewer flagged (filter auto-registration bypass)
  - `BusinessLoggingAspectTest` — new `logsStatusFieldFromResult` case for the allow-list change, existing cases updated for the `event=` format
  - `WaitlistAutoPromotionIntegrationTest` — existing assertions updated for the new `business` logger name and `event=` format
- [x] Manual log inspection during test runs confirms `[schoolId=1 userId=2]` on authenticated requests and `[schoolId= userId=3]` on authenticated requests without a membership.
- No frontend changes; visual verification skipped.

## Deferred per review

- `@LoggedField` / explicit payload DTO to replace the field allow-list — viable once event count grows; not load-bearing today.
- `AuthenticatedUser.of(appUser, schoolMemberService)` helper to deduplicate the two mint sites — skipped for minimum diff, revisit in Phase 2 multi-school refactor.
- `MdcTaskDecorator` — unneeded until the codebase introduces `@Async`/`@Scheduled` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)