### PR TITLE
docs(backend): note business logger and tenant MDC in CLAUDE.md

### DIFF
--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -60,7 +60,8 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 
 ### 8. Logging
 - AOP aspects in `shared/logging/` handle general logging (controllers, services), expand if necessary
-- Annotate service methods that represent domain events (create, update, delete) with `@BusinessOperation(event = "EventName")` — the `BusinessLoggingAspect` logs these automatically
+- Annotate service methods that represent domain events (create, update, delete) with `@BusinessOperation(event = "EventName")` — the `BusinessLoggingAspect` logs these on a dedicated `business` logger in `event=Name k=v` format
+- Every log line carries `[schoolId=… userId=…]` via MDC (populated per-request by `TenantContextFilter`) — do **not** also pass `schoolId`/`userId` as kv args; it's redundant
 
 ## Security
 


### PR DESCRIPTION
## Summary

Follow-up to #310. Adds two lines under the backend CLAUDE.md Logging section so future contributors know the `BusinessLoggingAspect` emits on a dedicated `business` logger in `event=Name k=v` format, and every line already carries `[schoolId=… userId=…]` via MDC — passing those as kv args is redundant.

## Test plan

- [x] Docs-only change; no code or tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)