### PR TITLE
Course DELETE guardrail: DRAFT-only (#313)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,5 +57,12 @@ public class CourseController {
                                  @Valid @RequestBody CreateCourseDto dto,
                                  @AuthenticationPrincipal AuthenticatedUser principal) {
         return courseService.updateCourse(principal.userId(), id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id,
+                       @AuthenticationPrincipal AuthenticatedUser principal) {
+        courseService.deleteCourse(principal.userId(), id);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -76,6 +76,21 @@ public class CourseService {
     }
 
     @Transactional
+    @BusinessOperation(event = "CourseDeleted")
+    public void deleteCourse(Long userId, Long courseId) {
+        School school = schoolService.findSchoolByMember(userId);
+        Course course = courseRepository.findByIdAndSchoolId(courseId, school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
+
+        if (course.getPublishedAt() != null) {
+            throw new DomainRuleViolationException(
+                    "Course " + courseId + " cannot be deleted: only unpublished (DRAFT) courses can be deleted.");
+        }
+
+        courseRepository.delete(course);
+    }
+
+    @Transactional
     @BusinessOperation(event = "CoursePublished")
     public CourseDetailDto publishCourse(Long userId, Long courseId) {
         School school = schoolService.findSchoolByMember(userId);

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -258,6 +259,82 @@ class CourseCrudIntegrationTest {
     }
 
     @Nested
+    class Delete {
+
+        @Test
+        void deleteCourse_returns204_whenDraft() throws Exception {
+            Course course = createDraftCourse(schoolA, "Draft Course");
+            Long id = course.getId();
+            entityManager.flush();
+
+            mockMvc.perform(delete("/api/courses/{id}", id)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isNoContent());
+
+            entityManager.flush();
+            entityManager.clear();
+            mockMvc.perform(get("/api/courses/{id}", id)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void deleteCourse_returns409_whenOpen() throws Exception {
+            // Published, startDate in future → OPEN
+            Course course = createPublishedCourse(schoolA, "Open Course",
+                    LocalDate.now().plusDays(30), LocalDate.now().minusDays(1));
+            entityManager.flush();
+
+            mockMvc.perform(delete("/api/courses/{id}", course.getId())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.detail").value(
+                            "Course " + course.getId() + " cannot be deleted: only unpublished (DRAFT) courses can be deleted."));
+        }
+
+        @Test
+        void deleteCourse_returns409_whenRunning() throws Exception {
+            // Published, startDate in past, endDate in future → RUNNING
+            Course course = createPublishedCourse(schoolA, "Running Course",
+                    LocalDate.now().minusDays(7), LocalDate.now().minusDays(14));
+            entityManager.flush();
+
+            mockMvc.perform(delete("/api/courses/{id}", course.getId())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict());
+        }
+
+        @Test
+        void deleteCourse_returns409_whenFinished() throws Exception {
+            // Published, endDate in past → FINISHED
+            Course course = createPublishedCourse(schoolA, "Finished Course",
+                    LocalDate.now().minusDays(90), LocalDate.now().minusDays(120));
+            entityManager.flush();
+
+            mockMvc.perform(delete("/api/courses/{id}", course.getId())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict());
+        }
+
+        @Test
+        void deleteCourse_returns404_forOtherSchoolsCourse() throws Exception {
+            Course course = createDraftCourse(schoolB, "School B Draft");
+            entityManager.flush();
+
+            mockMvc.perform(delete("/api/courses/{id}", course.getId())
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void deleteCourse_returns404_forNonExistentId() throws Exception {
+            mockMvc.perform(delete("/api/courses/{id}", 99999)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
     class DomainRules {
 
         @Test
@@ -338,7 +415,14 @@ class CourseCrudIntegrationTest {
     }
 
     private Course createCourse(School school, String title) {
-        LocalDate startDate = LocalDate.now().plusDays(30);
+        return createPublishedCourse(school, title, LocalDate.now().plusDays(30), LocalDate.now());
+    }
+
+    private Course createDraftCourse(School school, String title) {
+        return createPublishedCourse(school, title, LocalDate.now().plusDays(30), null);
+    }
+
+    private Course createPublishedCourse(School school, String title, LocalDate startDate, LocalDate publishedAt) {
         Course course = new Course();
         course.setSchool(school);
         course.setTitle(title);
@@ -356,7 +440,7 @@ class CourseCrudIntegrationTest {
         course.setMaxParticipants(12);
         course.setPriceModel(PriceModel.FIXED_COURSE);
         course.setPrice(new BigDecimal("310.00"));
-        course.setPublishedAt(LocalDate.now());
+        course.setPublishedAt(publishedAt);
         entityManager.persist(course);
         return course;
     }


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/courses/{id}` — 204 only when `publishedAt == null` (DRAFT); 409 when OPEN / RUNNING / FINISHED.
- Tenant isolation via the existing `findByIdAndSchoolId` pattern — cross-school requests get 404.
- Integration tests cover all AC cases (DRAFT, OPEN, RUNNING, FINISHED, other school's course, nonexistent id).

Closes #313.

## Test plan

- [x] `./mvnw test -Dtest='CourseCrudIntegrationTest\$Delete'` — 6/6 pass
- [x] `./mvnw test` — 183/183 pass
- [x] No UI impact (issue confirms no Delete button exists yet; frontend untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)