### PR TITLE
Course edit guardrails + auto-promote on capacity change (#314)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
@@ -28,6 +28,7 @@ public record CourseDetailDto(
         CourseLifecycleStatus status,
         LocalDate publishedAt,
         int enrolledStudents,
-        int completedSessions
+        int completedSessions,
+        CourseEditPolicy.Tier editTier
 ) {
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseEditPolicy.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseEditPolicy.java
@@ -1,0 +1,110 @@
+package ch.ruppen.danceschool.course;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Pure functions that answer "may this course be edited, and which fields?". Reuses
+ * {@link CourseStatusDerivation#deriveStatus} as the single source of truth for lifecycle
+ * status — no parallel state machine.
+ *
+ * <h2>Tier model</h2>
+ * <pre>
+ * DRAFT                              → FULLY_EDITABLE
+ * OPEN,     0 non-terminal enrolments → FULLY_EDITABLE
+ * OPEN,   ≥ 1 non-terminal enrolments → RESTRICTED (cosmetic fields still editable)
+ * RUNNING  (any count)                → READ_ONLY
+ * FINISHED (any count)                → READ_ONLY
+ * </pre>
+ *
+ * "Cosmetic" = {@code title, description, teachers, location, maxParticipants,
+ * roleBalanceThreshold}. Everything else is locked in the RESTRICTED tier, and every field is
+ * locked in READ_ONLY.
+ */
+public final class CourseEditPolicy {
+
+    public enum Tier {
+        FULLY_EDITABLE,
+        RESTRICTED,
+        READ_ONLY
+    }
+
+    static final Set<String> LOCKED_IN_RESTRICTED = Set.of(
+            "courseType", "price", "priceModel",
+            "danceStyle", "level",
+            "startDate", "endDate", "dayOfWeek",
+            "startTime", "endTime",
+            "numberOfSessions", "recurrenceType",
+            "publishedAt"
+    );
+
+    private CourseEditPolicy() {
+    }
+
+    public static Tier tierOf(CourseLifecycleStatus status, int nonTerminalEnrollments) {
+        return switch (status) {
+            case DRAFT -> Tier.FULLY_EDITABLE;
+            case OPEN -> nonTerminalEnrollments >= 1 ? Tier.RESTRICTED : Tier.FULLY_EDITABLE;
+            case RUNNING, FINISHED -> Tier.READ_ONLY;
+        };
+    }
+
+    public static boolean isFieldEditable(Tier tier, String field) {
+        return switch (tier) {
+            case FULLY_EDITABLE -> true;
+            case RESTRICTED -> !LOCKED_IN_RESTRICTED.contains(field);
+            case READ_ONLY -> false;
+        };
+    }
+
+    /**
+     * Compares the incoming DTO against the stored entity and returns the DTO-present field
+     * names that the given tier doesn't allow to change. {@code endDate}, {@code dayOfWeek}
+     * and {@code publishedAt} are intentionally skipped — they are derived or server-owned
+     * and not part of the DTO contract.
+     */
+    public static List<String> findLockedFieldChanges(Course current, CreateCourseDto incoming, Tier tier) {
+        if (tier == Tier.FULLY_EDITABLE) {
+            return List.of();
+        }
+        List<String> rejected = new ArrayList<>();
+
+        // Fields locked in both RESTRICTED and READ_ONLY
+        if (!Objects.equals(current.getCourseType(), incoming.courseType())) rejected.add("courseType");
+        if (!Objects.equals(current.getDanceStyle(), incoming.danceStyle())) rejected.add("danceStyle");
+        if (!Objects.equals(current.getLevel(), incoming.level())) rejected.add("level");
+        if (!Objects.equals(current.getPriceModel(), incoming.priceModel())) rejected.add("priceModel");
+        if (priceChanged(current.getPrice(), incoming.price())) rejected.add("price");
+        if (!Objects.equals(current.getStartDate(), incoming.startDate())) rejected.add("startDate");
+        if (!Objects.equals(current.getStartTime(), incoming.startTime())) rejected.add("startTime");
+        if (!Objects.equals(current.getEndTime(), incoming.endTime())) rejected.add("endTime");
+        if (current.getNumberOfSessions() != incoming.numberOfSessions()) rejected.add("numberOfSessions");
+        if (!Objects.equals(current.getRecurrenceType(), incoming.recurrenceType())) rejected.add("recurrenceType");
+
+        if (tier == Tier.READ_ONLY) {
+            // Cosmetic fields are also locked in READ_ONLY.
+            if (!Objects.equals(current.getTitle(), incoming.title())) rejected.add("title");
+            if (!Objects.equals(nullToEmpty(current.getDescription()), nullToEmpty(incoming.description())))
+                rejected.add("description");
+            if (!Objects.equals(nullToEmpty(current.getTeachers()), nullToEmpty(incoming.teachers())))
+                rejected.add("teachers");
+            if (!Objects.equals(current.getLocation(), incoming.location())) rejected.add("location");
+            if (current.getMaxParticipants() != incoming.maxParticipants()) rejected.add("maxParticipants");
+            if (!Objects.equals(current.getRoleBalanceThreshold(), incoming.roleBalanceThreshold()))
+                rejected.add("roleBalanceThreshold");
+        }
+        return rejected;
+    }
+
+    private static boolean priceChanged(java.math.BigDecimal current, java.math.BigDecimal incoming) {
+        if (current == null && incoming == null) return false;
+        if (current == null || incoming == null) return true;
+        return current.compareTo(incoming) != 0;
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.enrollment.EnrollmentService;
 import ch.ruppen.danceschool.enrollment.RoleCounts;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
+import ch.ruppen.danceschool.shared.error.CourseEditPolicyViolationException;
 import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
 import ch.ruppen.danceschool.shared.error.PublishValidationException;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
@@ -18,6 +19,7 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -63,8 +65,29 @@ public class CourseService {
         School school = schoolService.findSchoolByMember(userId);
         Course course = courseRepository.findByIdAndSchoolId(courseId, school.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
+
+        LocalDate today = LocalDate.now(clock);
+        CourseLifecycleStatus status = CourseStatusDerivation.deriveStatus(
+                course.getPublishedAt(), course.getStartDate(), course.getEndDate(), today);
+        int nonTerminal = enrollmentService.countNonTerminalByCourse(course.getId());
+        CourseEditPolicy.Tier tier = CourseEditPolicy.tierOf(status, nonTerminal);
+
+        List<String> rejected = CourseEditPolicy.findLockedFieldChanges(course, dto, tier);
+        if (!rejected.isEmpty()) {
+            throw new CourseEditPolicyViolationException(tier.name(), rejected);
+        }
+
+        int prevMax = course.getMaxParticipants();
+        Integer prevThreshold = course.getRoleBalanceThreshold();
+
         applyDto(course, dto);
-        return toDetailDto(course, LocalDate.now(clock));
+
+        if (prevMax != dto.maxParticipants()
+                || !Objects.equals(prevThreshold, dto.roleBalanceThreshold())) {
+            enrollmentService.autoPromoteWaitlist(course);
+        }
+
+        return toDetailDto(course, today);
     }
 
     @Transactional(readOnly = true)
@@ -246,6 +269,10 @@ public class CourseService {
 
     private CourseDetailDto toDetailDto(Course course, LocalDate today) {
         int enrolledStudents = enrollmentService.countSeatHoldersByCourse(course.getId());
+        int nonTerminal = enrollmentService.countNonTerminalByCourse(course.getId());
+        CourseLifecycleStatus status = CourseStatusDerivation.deriveStatus(
+                course.getPublishedAt(), course.getStartDate(), course.getEndDate(), today);
+        CourseEditPolicy.Tier editTier = CourseEditPolicy.tierOf(status, nonTerminal);
         return new CourseDetailDto(
                 course.getId(),
                 course.getTitle(),
@@ -266,12 +293,12 @@ public class CourseService {
                 course.getRoleBalanceThreshold(),
                 course.getPriceModel(),
                 course.getPrice(),
-                CourseStatusDerivation.deriveStatus(
-                        course.getPublishedAt(), course.getStartDate(), course.getEndDate(), today),
+                status,
                 course.getPublishedAt(),
                 enrolledStudents,
                 CourseStatusDerivation.deriveCompletedSessions(
-                        course.getStartDate(), course.getDayOfWeek(), course.getNumberOfSessions(), today)
+                        course.getStartDate(), course.getDayOfWeek(), course.getNumberOfSessions(), today),
+                editTier
         );
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -167,6 +167,12 @@ public class EnrollmentService {
                 courseId, EnrollmentStatus.SEAT_HOLDING_STATI);
     }
 
+    @Transactional(readOnly = true)
+    public int countNonTerminalByCourse(Long courseId) {
+        return (int) enrollmentRepository.countByCourseIdAndStatusIn(
+                courseId, EnrollmentStatus.NON_TERMINAL_STATI);
+    }
+
     private Course loadCourseInSchool(Long courseId, School school) {
         return courseRepository.findByIdAndSchoolId(courseId, school.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Course", courseId));
@@ -251,11 +257,19 @@ public class EnrollmentService {
     }
 
     /**
-     * Re-evaluates role-imbalance waitlist after a seat-holding enrollment lands.
-     * Short-circuits when the course is full; capacity-waitlisted entries can only
-     * exist in that state, so they are never touched by this flow.
+     * Re-evaluates the waitlist against current capacity and role-balance rules and promotes
+     * any entries that no longer violate them. Called after:
+     * <ul>
+     *   <li>a seat-holding enrollment lands (may free up role-imbalance waitlisted entries of
+     *       the opposite role)</li>
+     *   <li>a course's {@code maxParticipants} is raised (promotes capacity-waitlisted entries
+     *       in waitlist order until capacity is reached)</li>
+     *   <li>a course's {@code roleBalanceThreshold} changes (promotes role-imbalance
+     *       waitlisted entries that now fit the looser rule)</li>
+     * </ul>
+     * Short-circuits when the course is already at or over capacity.
      */
-    private void autoPromoteWaitlist(Course course) {
+    public void autoPromoteWaitlist(Course course) {
         long committed = enrollmentRepository.countByCourseIdAndStatusIn(
                 course.getId(), EnrollmentStatus.SEAT_HOLDING_STATI);
         if (committed >= course.getMaxParticipants()) {

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentStatus.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentStatus.java
@@ -15,4 +15,13 @@ public enum EnrollmentStatus {
      * PENDING_APPROVAL does not reserve a seat until approved; WAITLISTED / REJECTED never do.
      */
     public static final List<EnrollmentStatus> SEAT_HOLDING_STATI = List.of(PENDING_PAYMENT, CONFIRMED);
+
+    /**
+     * Enrollments whose lifecycle is still live — anything except REJECTED. Used by
+     * {@code CourseEditPolicy} to decide whether a published course is edit-restricted: a
+     * student who applied or waitlisted signed up against the course's published contract,
+     * so changing locked fields under them must be rejected.
+     */
+    public static final List<EnrollmentStatus> NON_TERMINAL_STATI =
+            List.of(PENDING_APPROVAL, PENDING_PAYMENT, CONFIRMED, WAITLISTED);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/error/CourseEditPolicyViolationException.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/error/CourseEditPolicyViolationException.java
@@ -1,0 +1,23 @@
+package ch.ruppen.danceschool.shared.error;
+
+import java.util.List;
+
+public class CourseEditPolicyViolationException extends RuntimeException {
+
+    private final String tier;
+    private final List<String> rejectedFields;
+
+    public CourseEditPolicyViolationException(String tier, List<String> rejectedFields) {
+        super("Course edit not allowed for fields: " + rejectedFields);
+        this.tier = tier;
+        this.rejectedFields = List.copyOf(rejectedFields);
+    }
+
+    public String getTier() {
+        return tier;
+    }
+
+    public List<String> getRejectedFields() {
+        return rejectedFields;
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/error/GlobalExceptionHandler.java
@@ -41,6 +41,15 @@ class GlobalExceptionHandler {
         return problem;
     }
 
+    @ExceptionHandler(CourseEditPolicyViolationException.class)
+    ProblemDetail handleCourseEditPolicyViolation(CourseEditPolicyViolationException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problem.setTitle("Course Edit Not Allowed");
+        problem.setProperty("tier", ex.getTier());
+        problem.setProperty("rejectedFields", ex.getRejectedFields());
+        return problem;
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     ProblemDetail handleValidation(MethodArgumentNotValidException ex) {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST,

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
@@ -1,12 +1,18 @@
 package ch.ruppen.danceschool.course;
 
 import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.enrollment.DanceRole;
+import ch.ruppen.danceschool.enrollment.Enrollment;
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
+import ch.ruppen.danceschool.enrollment.WaitlistReason;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.schoolmember.MemberRole;
 import ch.ruppen.danceschool.schoolmember.SchoolMember;
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.student.Student;
 import ch.ruppen.danceschool.user.AppUser;
 import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -217,7 +224,8 @@ class CourseCrudIntegrationTest {
 
         @Test
         void updateCourse_returnsUpdatedFields() throws Exception {
-            Course course = createCourse(schoolA, "Original Title");
+            // Draft course (publishedAt=null) → fully editable
+            Course course = createDraftCourse(schoolA, "Original Title");
             entityManager.flush();
 
             String updateJson = validCourseJson().replace("\"Salsa Beginners\"", "\"Updated Title\"");
@@ -233,7 +241,7 @@ class CourseCrudIntegrationTest {
 
         @Test
         void updateCourse_returns404_forOtherSchoolsCourse() throws Exception {
-            Course course = createCourse(schoolB, "School B Course");
+            Course course = createDraftCourse(schoolB, "School B Course");
             entityManager.flush();
 
             mockMvc.perform(put("/api/courses/{id}", course.getId())
@@ -245,7 +253,7 @@ class CourseCrudIntegrationTest {
 
         @Test
         void updateCourse_returns400_whenValidationFails() throws Exception {
-            Course course = createCourse(schoolA, "Test Course");
+            Course course = createDraftCourse(schoolA, "Test Course");
             entityManager.flush();
 
             String json = validCourseJson().replace("\"Salsa Beginners\"", "\"\"");
@@ -255,6 +263,156 @@ class CourseCrudIntegrationTest {
                             .content(json)
                             .with(authentication(authToken(ownerA))))
                     .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void updateCourse_cosmeticChangesOnRestricted_returns200() throws Exception {
+            Course course = createOpenCourse(schoolA, "Original Title");
+            Student s = createStudent(schoolA, "Anna", "anna@example.com");
+            persistEnrollment(course, s, DanceRole.LEAD, EnrollmentStatus.CONFIRMED, null, null);
+            entityManager.flush();
+
+            String json = jsonFor(course,
+                    "\"Original Title\"", "\"New Title\"",
+                    "\"Studio A\"", "\"Studio B\"",
+                    "\"maxParticipants\": 12", "\"maxParticipants\": 14");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value("New Title"))
+                    .andExpect(jsonPath("$.location").value("Studio B"))
+                    .andExpect(jsonPath("$.maxParticipants").value(14))
+                    .andExpect(jsonPath("$.editTier").value("RESTRICTED"));
+        }
+
+        @Test
+        void updateCourse_lockedFieldChangeOnRestricted_returns409WithRejectedFields() throws Exception {
+            Course course = createOpenCourse(schoolA, "Title");
+            Student s = createStudent(schoolA, "Anna", "anna@example.com");
+            persistEnrollment(course, s, DanceRole.LEAD, EnrollmentStatus.CONFIRMED, null, null);
+            entityManager.flush();
+
+            String json = jsonFor(course,
+                    "\"BACHATA\"", "\"SALSA\"",        // flip danceStyle
+                    "\"price\": 310.00", "\"price\": 999.00"); // flip price
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.tier").value("RESTRICTED"))
+                    .andExpect(jsonPath("$.rejectedFields[*]").value(
+                            org.hamcrest.Matchers.containsInAnyOrder("danceStyle", "price")));
+        }
+
+        @Test
+        void updateCourse_anyChangeOnRunning_returns409() throws Exception {
+            Course course = createRunningCourse(schoolA, "Running Course");
+            entityManager.flush();
+
+            // Flip only the title (a cosmetic field). READ_ONLY tier must still reject it.
+            String json = jsonFor(course, "\"Running Course\"", "\"Renamed\"");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.tier").value("READ_ONLY"))
+                    .andExpect(jsonPath("$.rejectedFields[0]").value("title"));
+        }
+
+        @Test
+        void updateCourse_anyChangeOnFinished_returns409() throws Exception {
+            Course course = createFinishedCourse(schoolA, "Finished Course");
+            entityManager.flush();
+
+            String json = jsonFor(course, "\"Finished Course\"", "\"Renamed\"");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.tier").value("READ_ONLY"));
+        }
+
+        @Test
+        void updateCourse_openWithZeroEnrollments_allowsLockedFieldChange() throws Exception {
+            Course course = createOpenCourse(schoolA, "Open No Enrollments");
+            entityManager.flush();
+
+            String json = jsonFor(course, "\"BACHATA\"", "\"SALSA\"");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.danceStyle").value("SALSA"))
+                    .andExpect(jsonPath("$.editTier").value("FULLY_EDITABLE"));
+        }
+
+        @Test
+        void updateCourse_raisingMaxParticipants_promotesCapacityWaitlist() throws Exception {
+            // max=2, 2 CONFIRMED seat-holders + 1 WAITLISTED(CAPACITY). Raise max to 3.
+            Course course = createOpenCourseWithCapacity(schoolA, "Capacity Course", 2);
+            Student a = createStudent(schoolA, "A", "a@example.com");
+            Student b = createStudent(schoolA, "B", "b@example.com");
+            Student c = createStudent(schoolA, "C", "c@example.com");
+            persistEnrollment(course, a, DanceRole.LEAD, EnrollmentStatus.CONFIRMED, null, null);
+            persistEnrollment(course, b, DanceRole.FOLLOW, EnrollmentStatus.CONFIRMED, null, null);
+            Enrollment waitlisted = persistEnrollment(course, c, DanceRole.LEAD,
+                    EnrollmentStatus.WAITLISTED, WaitlistReason.CAPACITY, 1);
+            entityManager.flush();
+
+            String json = jsonFor(course,
+                    "\"maxParticipants\": 2", "\"maxParticipants\": 3");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.maxParticipants").value(3));
+
+            entityManager.flush();
+            entityManager.refresh(waitlisted);
+            Assertions.assertThat(waitlisted.getStatus()).isEqualTo(EnrollmentStatus.PENDING_PAYMENT);
+            Assertions.assertThat(waitlisted.getWaitlistPosition()).isNull();
+            Assertions.assertThat(waitlisted.getWaitlistReason()).isNull();
+        }
+
+        @Test
+        void updateCourse_changingRoleBalanceThreshold_promotesRoleImbalanceWaitlist() throws Exception {
+            // max=10, 2 LEADS CONFIRMED, 0 FOLLOWS; threshold=1 → 1 lead waitlisted by role imbalance.
+            // Raise threshold to 5 → imbalance no longer blocks; lead should be promoted.
+            Course course = createOpenCourseWithCapacityAndThreshold(schoolA, "Role Course", 10, 1);
+            Student a = createStudent(schoolA, "A", "a@example.com");
+            Student b = createStudent(schoolA, "B", "b@example.com");
+            Student c = createStudent(schoolA, "C", "c@example.com");
+            persistEnrollment(course, a, DanceRole.LEAD, EnrollmentStatus.CONFIRMED, null, null);
+            persistEnrollment(course, b, DanceRole.LEAD, EnrollmentStatus.CONFIRMED, null, null);
+            Enrollment waitlisted = persistEnrollment(course, c, DanceRole.LEAD,
+                    EnrollmentStatus.WAITLISTED, WaitlistReason.ROLE_IMBALANCE, 1);
+            entityManager.flush();
+
+            String json = jsonFor(course,
+                    "\"roleBalanceThreshold\": 1", "\"roleBalanceThreshold\": 5");
+
+            mockMvc.perform(put("/api/courses/{id}", course.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json)
+                            .with(authentication(authToken(ownerA))))
+                    .andExpect(status().isOk());
+
+            entityManager.flush();
+            entityManager.refresh(waitlisted);
+            Assertions.assertThat(waitlisted.getStatus()).isEqualTo(EnrollmentStatus.PENDING_PAYMENT);
         }
     }
 
@@ -415,14 +573,50 @@ class CourseCrudIntegrationTest {
     }
 
     private Course createCourse(School school, String title) {
-        return createPublishedCourse(school, title, LocalDate.now().plusDays(30), LocalDate.now());
+        // Default: OPEN course — published, startDate in the future.
+        return persistCourse(school, title, LocalDate.now().plusDays(30),
+                LocalDate.now(), 12, null);
     }
 
     private Course createDraftCourse(School school, String title) {
-        return createPublishedCourse(school, title, LocalDate.now().plusDays(30), null);
+        return persistCourse(school, title, LocalDate.now().plusDays(30),
+                null, 12, null);
+    }
+
+    private Course createOpenCourse(School school, String title) {
+        return createCourse(school, title);
+    }
+
+    private Course createOpenCourseWithCapacity(School school, String title, int maxParticipants) {
+        return persistCourse(school, title, LocalDate.now().plusDays(30),
+                LocalDate.now(), maxParticipants, null);
+    }
+
+    private Course createOpenCourseWithCapacityAndThreshold(School school, String title,
+                                                            int maxParticipants, Integer roleBalanceThreshold) {
+        return persistCourse(school, title, LocalDate.now().plusDays(30),
+                LocalDate.now(), maxParticipants, roleBalanceThreshold);
+    }
+
+    private Course createRunningCourse(School school, String title) {
+        // startDate already passed, endDate still in the future.
+        LocalDate startDate = LocalDate.now().minusDays(14);
+        return persistCourse(school, title, startDate, startDate, 12, null);
+    }
+
+    private Course createFinishedCourse(School school, String title) {
+        // Both startDate and endDate in the past.
+        LocalDate startDate = LocalDate.now().minusWeeks(20);
+        return persistCourse(school, title, startDate, startDate, 12, null);
     }
 
     private Course createPublishedCourse(School school, String title, LocalDate startDate, LocalDate publishedAt) {
+        return persistCourse(school, title, startDate, publishedAt, 12, null);
+    }
+
+    private Course persistCourse(School school, String title, LocalDate startDate,
+                                 LocalDate publishedAt, int maxParticipants,
+                                 Integer roleBalanceThreshold) {
         Course course = new Course();
         course.setSchool(school);
         course.setTitle(title);
@@ -437,12 +631,96 @@ class CourseCrudIntegrationTest {
         course.setStartTime(LocalTime.of(20, 0));
         course.setEndTime(LocalTime.of(21, 15));
         course.setLocation("Studio A");
-        course.setMaxParticipants(12);
+        course.setMaxParticipants(maxParticipants);
+        course.setRoleBalanceThreshold(roleBalanceThreshold);
         course.setPriceModel(PriceModel.FIXED_COURSE);
         course.setPrice(new BigDecimal("310.00"));
         course.setPublishedAt(publishedAt);
         entityManager.persist(course);
         return course;
+    }
+
+    private Student createStudent(School school, String name, String email) {
+        Student student = new Student();
+        student.setSchool(school);
+        student.setName(name);
+        student.setEmail(email);
+        entityManager.persist(student);
+        return student;
+    }
+
+    private Enrollment persistEnrollment(Course course, Student student, DanceRole role,
+                                         EnrollmentStatus status, WaitlistReason waitlistReason,
+                                         Integer waitlistPosition) {
+        Enrollment enrollment = new Enrollment();
+        enrollment.setCourse(course);
+        enrollment.setStudent(student);
+        enrollment.setDanceRole(role);
+        enrollment.setStatus(status);
+        enrollment.setEnrolledAt(Instant.now());
+        enrollment.setWaitlistReason(waitlistReason);
+        enrollment.setWaitlistPosition(waitlistPosition);
+        entityManager.persist(enrollment);
+        return enrollment;
+    }
+
+    /**
+     * Builds a JSON payload that exactly matches the course's current field values, then
+     * applies sequential find/replace pairs. Lets tests mutate a single field without the
+     * rest of the DTO differing (which would look like a locked-field change to the policy).
+     */
+    private String jsonFor(Course course, String... replacements) {
+        String teachersJson = course.getTeachers() == null ? "null" : "\"" + course.getTeachers() + "\"";
+        String descriptionJson = course.getDescription() == null ? "null" : "\"" + course.getDescription() + "\"";
+        String roleBalanceJson = course.getRoleBalanceThreshold() == null
+                ? "null" : course.getRoleBalanceThreshold().toString();
+        String json = """
+                {
+                  "title": "%s",
+                  "danceStyle": "%s",
+                  "level": "%s",
+                  "courseType": "%s",
+                  "description": %s,
+                  "startDate": "%s",
+                  "recurrenceType": "%s",
+                  "numberOfSessions": %d,
+                  "startTime": "%s",
+                  "endTime": "%s",
+                  "location": "%s",
+                  "teachers": %s,
+                  "maxParticipants": %d,
+                  "roleBalanceThreshold": %s,
+                  "priceModel": "%s",
+                  "price": %s
+                }
+                """.formatted(
+                        course.getTitle(),
+                        course.getDanceStyle(),
+                        course.getLevel(),
+                        course.getCourseType(),
+                        descriptionJson,
+                        course.getStartDate(),
+                        course.getRecurrenceType(),
+                        course.getNumberOfSessions(),
+                        course.getStartTime(),
+                        course.getEndTime(),
+                        course.getLocation(),
+                        teachersJson,
+                        course.getMaxParticipants(),
+                        roleBalanceJson,
+                        course.getPriceModel(),
+                        course.getPrice());
+        if ((replacements.length & 1) != 0) {
+            throw new IllegalArgumentException("jsonFor replacements must be pairs");
+        }
+        for (int i = 0; i < replacements.length; i += 2) {
+            if (!json.contains(replacements[i])) {
+                throw new IllegalArgumentException(
+                        "jsonFor: pattern not found in JSON: " + replacements[i]);
+            }
+            json = json.replace(replacements[i], replacements[i + 1]);
+        }
+        return json;
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseEditPolicyTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseEditPolicyTest.java
@@ -1,0 +1,283 @@
+package ch.ruppen.danceschool.course;
+
+import ch.ruppen.danceschool.course.CourseEditPolicy.Tier;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CourseEditPolicyTest {
+
+    @Nested
+    class TierOf {
+        @Test
+        void draft_isFullyEditable_regardlessOfEnrollmentCount() {
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.DRAFT, 0)).isEqualTo(Tier.FULLY_EDITABLE);
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.DRAFT, 5)).isEqualTo(Tier.FULLY_EDITABLE);
+        }
+
+        @Test
+        void open_withZeroEnrollments_isFullyEditable() {
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.OPEN, 0)).isEqualTo(Tier.FULLY_EDITABLE);
+        }
+
+        @Test
+        void open_withNonTerminalEnrollments_isRestricted() {
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.OPEN, 1)).isEqualTo(Tier.RESTRICTED);
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.OPEN, 50)).isEqualTo(Tier.RESTRICTED);
+        }
+
+        @Test
+        void running_isReadOnly_regardlessOfEnrollmentCount() {
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.RUNNING, 0)).isEqualTo(Tier.READ_ONLY);
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.RUNNING, 10)).isEqualTo(Tier.READ_ONLY);
+        }
+
+        @Test
+        void finished_isReadOnly_regardlessOfEnrollmentCount() {
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.FINISHED, 0)).isEqualTo(Tier.READ_ONLY);
+            assertThat(CourseEditPolicy.tierOf(CourseLifecycleStatus.FINISHED, 10)).isEqualTo(Tier.READ_ONLY);
+        }
+    }
+
+    @Nested
+    class IsFieldEditable {
+
+        private static final List<String> LOCKED_FIELDS = List.of(
+                "courseType", "price", "priceModel",
+                "danceStyle", "level",
+                "startDate", "endDate", "dayOfWeek",
+                "startTime", "endTime",
+                "numberOfSessions", "recurrenceType",
+                "publishedAt");
+
+        private static final List<String> COSMETIC_FIELDS = List.of(
+                "title", "description", "teachers", "location",
+                "maxParticipants", "roleBalanceThreshold");
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "title", "description", "teachers", "location",
+                "maxParticipants", "roleBalanceThreshold",
+                "courseType", "price", "priceModel", "danceStyle", "level",
+                "startDate", "endDate", "dayOfWeek", "startTime", "endTime",
+                "numberOfSessions", "recurrenceType", "publishedAt"})
+        void fullyEditable_allowsEveryField(String field) {
+            assertThat(CourseEditPolicy.isFieldEditable(Tier.FULLY_EDITABLE, field)).isTrue();
+        }
+
+        @Test
+        void restricted_locksLockedFields() {
+            for (String f : LOCKED_FIELDS) {
+                assertThat(CourseEditPolicy.isFieldEditable(Tier.RESTRICTED, f))
+                        .as("restricted must lock %s", f)
+                        .isFalse();
+            }
+        }
+
+        @Test
+        void restricted_allowsCosmeticFields() {
+            for (String f : COSMETIC_FIELDS) {
+                assertThat(CourseEditPolicy.isFieldEditable(Tier.RESTRICTED, f))
+                        .as("restricted must allow %s", f)
+                        .isTrue();
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "title", "description", "teachers", "location",
+                "maxParticipants", "roleBalanceThreshold",
+                "courseType", "price", "priceModel", "danceStyle", "level",
+                "startDate", "endDate", "dayOfWeek", "startTime", "endTime",
+                "numberOfSessions", "recurrenceType", "publishedAt"})
+        void readOnly_locksEveryField(String field) {
+            assertThat(CourseEditPolicy.isFieldEditable(Tier.READ_ONLY, field)).isFalse();
+        }
+    }
+
+    @Nested
+    class FindLockedFieldChanges {
+
+        @Test
+        void fullyEditable_neverReportsViolations() {
+            Course current = sampleCourse();
+            CreateCourseDto changed = dtoWith(current, d -> d.title("different").price(new BigDecimal("999.00")));
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current, changed, Tier.FULLY_EDITABLE)).isEmpty();
+        }
+
+        @Test
+        void restricted_withIdenticalDto_reportsNone() {
+            Course current = sampleCourse();
+            CreateCourseDto same = dtoWith(current, d -> d);
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current, same, Tier.RESTRICTED)).isEmpty();
+        }
+
+        @Test
+        void restricted_reportsChangedLockedFields_butNotCosmetic() {
+            Course current = sampleCourse();
+            CreateCourseDto changed = dtoWith(current, d -> d
+                    .title("cosmetic change ok")
+                    .location("also ok")
+                    .danceStyle(DanceStyle.KIZOMBA)
+                    .price(new BigDecimal("888.00")));
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current, changed, Tier.RESTRICTED))
+                    .containsExactlyInAnyOrder("danceStyle", "price");
+        }
+
+        @Test
+        void restricted_reportsEachLockedFieldIndividually() {
+            Course current = sampleCourse();
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.courseType(CourseType.SOLO)), Tier.RESTRICTED))
+                    .containsExactly("courseType");
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.level(CourseLevel.BEGINNER)), Tier.RESTRICTED))
+                    .containsExactly("level");
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.startDate(current.getStartDate().plusDays(1))), Tier.RESTRICTED))
+                    .containsExactly("startDate");
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.startTime(current.getStartTime().plusHours(1))), Tier.RESTRICTED))
+                    .containsExactly("startTime");
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.endTime(current.getEndTime().plusHours(1))), Tier.RESTRICTED))
+                    .containsExactly("endTime");
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.numberOfSessions(current.getNumberOfSessions() + 1)), Tier.RESTRICTED))
+                    .containsExactly("numberOfSessions");
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.price(current.getPrice().add(new BigDecimal("10")))), Tier.RESTRICTED))
+                    .containsExactly("price");
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current,
+                    dtoWith(current, d -> d.danceStyle(DanceStyle.BACHATA)), Tier.RESTRICTED))
+                    .containsExactly("danceStyle");
+        }
+
+        @Test
+        void readOnly_withIdenticalDto_reportsNone() {
+            Course current = sampleCourse();
+            CreateCourseDto same = dtoWith(current, d -> d);
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current, same, Tier.READ_ONLY)).isEmpty();
+        }
+
+        @Test
+        void readOnly_reportsEvenCosmeticChanges() {
+            Course current = sampleCourse();
+            CreateCourseDto changed = dtoWith(current, d -> d.title("new title"));
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current, changed, Tier.READ_ONLY))
+                    .containsExactly("title");
+        }
+
+        @Test
+        void readOnly_reportsAllChangedFields() {
+            Course current = sampleCourse();
+            CreateCourseDto changed = dtoWith(current, d -> d
+                    .title("x")
+                    .location("y")
+                    .maxParticipants(current.getMaxParticipants() + 1)
+                    .price(new BigDecimal("777.00")));
+            assertThat(CourseEditPolicy.findLockedFieldChanges(current, changed, Tier.READ_ONLY))
+                    .containsExactlyInAnyOrder("title", "location", "maxParticipants", "price");
+        }
+
+        private Course sampleCourse() {
+            Course c = new Course();
+            c.setTitle("Salsa");
+            c.setDanceStyle(DanceStyle.SALSA);
+            c.setLevel(CourseLevel.INTERMEDIATE);
+            c.setCourseType(CourseType.PARTNER);
+            c.setDescription("desc");
+            c.setStartDate(LocalDate.of(2026, 6, 1));
+            c.setRecurrenceType(RecurrenceType.WEEKLY);
+            c.setDayOfWeek(DayOfWeek.MONDAY);
+            c.setNumberOfSessions(8);
+            c.setEndDate(LocalDate.of(2026, 7, 20));
+            c.setStartTime(LocalTime.of(19, 0));
+            c.setEndTime(LocalTime.of(20, 0));
+            c.setLocation("Studio A");
+            c.setTeachers("Maria");
+            c.setMaxParticipants(20);
+            c.setRoleBalanceThreshold(3);
+            c.setPriceModel(PriceModel.FIXED_COURSE);
+            c.setPrice(new BigDecimal("180.00"));
+            return c;
+        }
+
+        /**
+         * Builder-like helper: start from a DTO matching the current course, apply the
+         * caller's mutation, return the result.
+         */
+        private CreateCourseDto dtoWith(Course c, java.util.function.UnaryOperator<DtoBuilder> mutate) {
+            DtoBuilder b = new DtoBuilder()
+                    .title(c.getTitle())
+                    .danceStyle(c.getDanceStyle())
+                    .level(c.getLevel())
+                    .courseType(c.getCourseType())
+                    .description(c.getDescription())
+                    .startDate(c.getStartDate())
+                    .recurrenceType(c.getRecurrenceType())
+                    .numberOfSessions(c.getNumberOfSessions())
+                    .startTime(c.getStartTime())
+                    .endTime(c.getEndTime())
+                    .location(c.getLocation())
+                    .teachers(c.getTeachers())
+                    .maxParticipants(c.getMaxParticipants())
+                    .roleBalanceThreshold(c.getRoleBalanceThreshold())
+                    .priceModel(c.getPriceModel())
+                    .price(c.getPrice());
+            return mutate.apply(b).build();
+        }
+
+        private static final class DtoBuilder {
+            private String title;
+            private DanceStyle danceStyle;
+            private CourseLevel level;
+            private CourseType courseType;
+            private String description;
+            private LocalDate startDate;
+            private RecurrenceType recurrenceType;
+            private int numberOfSessions;
+            private LocalTime startTime;
+            private LocalTime endTime;
+            private String location;
+            private String teachers;
+            private int maxParticipants;
+            private Integer roleBalanceThreshold;
+            private PriceModel priceModel;
+            private BigDecimal price;
+
+            DtoBuilder title(String v) { this.title = v; return this; }
+            DtoBuilder danceStyle(DanceStyle v) { this.danceStyle = v; return this; }
+            DtoBuilder level(CourseLevel v) { this.level = v; return this; }
+            DtoBuilder courseType(CourseType v) { this.courseType = v; return this; }
+            DtoBuilder description(String v) { this.description = v; return this; }
+            DtoBuilder startDate(LocalDate v) { this.startDate = v; return this; }
+            DtoBuilder recurrenceType(RecurrenceType v) { this.recurrenceType = v; return this; }
+            DtoBuilder numberOfSessions(int v) { this.numberOfSessions = v; return this; }
+            DtoBuilder startTime(LocalTime v) { this.startTime = v; return this; }
+            DtoBuilder endTime(LocalTime v) { this.endTime = v; return this; }
+            DtoBuilder location(String v) { this.location = v; return this; }
+            DtoBuilder teachers(String v) { this.teachers = v; return this; }
+            DtoBuilder maxParticipants(int v) { this.maxParticipants = v; return this; }
+            DtoBuilder roleBalanceThreshold(Integer v) { this.roleBalanceThreshold = v; return this; }
+            DtoBuilder priceModel(PriceModel v) { this.priceModel = v; return this; }
+            DtoBuilder price(BigDecimal v) { this.price = v; return this; }
+
+            CreateCourseDto build() {
+                return new CreateCourseDto(title, danceStyle, level, courseType, description,
+                        startDate, recurrenceType, numberOfSessions, startTime, endTime,
+                        location, teachers, maxParticipants, roleBalanceThreshold, priceModel, price);
+            }
+        }
+    }
+
+}

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -25,6 +25,8 @@ export interface CourseListItem {
   completedSessions: number;
 }
 
+export type CourseEditTier = 'FULLY_EDITABLE' | 'RESTRICTED' | 'READ_ONLY';
+
 export interface CourseDetail {
   id: number;
   title: string;
@@ -49,6 +51,7 @@ export interface CourseDetail {
   publishedAt: string | null;
   enrolledStudents: number;
   completedSessions: number;
+  editTier: CourseEditTier;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/frontend/src/app/courses/create/course-create.html
+++ b/frontend/src/app/courses/create/course-create.html
@@ -4,6 +4,12 @@
   <h1 class="wizard-title">{{ isEditMode ? 'Edit Course' : 'Create New Course' }}</h1>
 </div>
 
+@if (isReadOnly) {
+  <div class="lock-banner" role="status">
+    This course is no longer editable.
+  </div>
+}
+
 <!-- Wizard Card -->
 <div class="wizard-card">
   <!-- Stepper -->
@@ -48,7 +54,8 @@
           </mat-form-field>
 
           <div class="form-row">
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('danceStyle')" matTooltipPosition="above">
               <mat-label>Dance Style</mat-label>
               <mat-select formControlName="danceStyle">
                 @for (style of danceStyles; track style.value) {
@@ -60,7 +67,8 @@
               }
             </mat-form-field>
 
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('level')" matTooltipPosition="above">
               <mat-label>Level</mat-label>
               <mat-select formControlName="level">
                 @for (level of levels; track level.value) {
@@ -74,7 +82,8 @@
           </div>
 
           <div class="form-row">
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('courseType')" matTooltipPosition="above">
               <mat-label>Course Type</mat-label>
               <mat-select formControlName="courseType">
                 @for (type of courseTypes; track type.value) {
@@ -99,7 +108,8 @@
         <!-- Schedule Step -->
         <div class="schedule-step" [formGroup]="scheduleGroup">
           <div class="form-row">
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('startDate')" matTooltipPosition="above">
               <mat-label>Start Date</mat-label>
               <input matInput type="date" formControlName="startDate" />
               @if (scheduleGroup.controls.startDate.hasError('required')) {
@@ -109,7 +119,8 @@
               }
             </mat-form-field>
 
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('recurrenceType')" matTooltipPosition="above">
               <mat-label>Recurrence</mat-label>
               <mat-select formControlName="recurrenceType">
                 @for (type of recurrenceTypes; track type.value) {
@@ -120,7 +131,8 @@
           </div>
 
           <div class="form-row sessions-row">
-            <mat-form-field class="third-width" appearance="outline">
+            <mat-form-field class="third-width" appearance="outline"
+                            [matTooltip]="lockTooltip('numberOfSessions')" matTooltipPosition="above">
               <mat-label>Number of Sessions</mat-label>
               <input matInput type="number" formControlName="numberOfSessions" min="1" />
               @if (scheduleGroup.controls.numberOfSessions.hasError('required')) {
@@ -142,7 +154,8 @@
           </div>
 
           <div class="form-row">
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('startTime')" matTooltipPosition="above">
               <mat-label>Start Time</mat-label>
               <input matInput type="time" formControlName="startTime" />
               @if (scheduleGroup.controls.startTime.hasError('required')) {
@@ -150,7 +163,8 @@
               }
             </mat-form-field>
 
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('endTime')" matTooltipPosition="above">
               <mat-label>End Time</mat-label>
               <input matInput type="time" formControlName="endTime" />
               @if (scheduleGroup.controls.endTime.hasError('required')) {
@@ -218,7 +232,8 @@
         <!-- Pricing Step -->
         <div class="pricing-step" [formGroup]="pricingGroup">
           <div class="form-row">
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('priceModel')" matTooltipPosition="above">
               <mat-label>Price Model</mat-label>
               <mat-select formControlName="priceModel">
                 @for (model of priceModels; track model.value) {
@@ -230,7 +245,8 @@
               }
             </mat-form-field>
 
-            <mat-form-field class="half-width" appearance="outline">
+            <mat-form-field class="half-width" appearance="outline"
+                            [matTooltip]="lockTooltip('price')" matTooltipPosition="above">
               <mat-label>Price (CHF)</mat-label>
               <input matInput type="number" formControlName="price" min="0" step="0.01" />
               @if (pricingGroup.controls.price.hasError('required')) {
@@ -261,7 +277,7 @@
     <span class="nav-spacer"></span>
     @if (currentStep() < steps.length - 1) {
       <button mat-flat-button (click)="next()" type="button">Next</button>
-    } @else {
+    } @else if (!isReadOnly) {
       <button mat-flat-button (click)="save()" type="button" [disabled]="saving()">
         @if (isEditMode) {
           Save Changes

--- a/frontend/src/app/courses/create/course-create.scss
+++ b/frontend/src/app/courses/create/course-create.scss
@@ -6,6 +6,14 @@
   gap: var(--ds-spacing-6);
 }
 
+.lock-banner {
+  background: var(--ds-color-info-container);
+  color: var(--ds-color-info);
+  padding: var(--ds-spacing-3) var(--ds-spacing-4);
+  border-radius: var(--ds-radius-md);
+  font: var(--mat-sys-body-medium);
+}
+
 // Header
 .wizard-header {
   display: flex;

--- a/frontend/src/app/courses/create/course-create.ts
+++ b/frontend/src/app/courses/create/course-create.ts
@@ -8,6 +8,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { CourseFormService } from './course-form.service';
@@ -31,7 +32,7 @@ interface StepDef {
   imports: [
     ReactiveFormsModule, RouterLink,
     MatFormFieldModule, MatInputModule, MatSelectModule,
-    MatButtonModule, MatSlideToggleModule,
+    MatButtonModule, MatSlideToggleModule, MatTooltipModule,
     CourseSummaryComponent,
   ],
   providers: [CourseFormService],
@@ -158,6 +159,21 @@ export class CourseCreateComponent implements OnInit, OnDestroy {
 
   protected get roleBalancingEnabled(): boolean {
     return this.formService.roleBalancingEnabled;
+  }
+
+  protected isFieldLocked(field: string): boolean {
+    return this.formService.isFieldLocked(field);
+  }
+
+  protected lockTooltip(field: string): string {
+    if (!this.formService.isFieldLocked(field)) return '';
+    return this.formService.editTier() === 'READ_ONLY'
+      ? 'This course is no longer editable.'
+      : "Locked \u2014 students have already enrolled. This field can't be changed.";
+  }
+
+  protected get isReadOnly(): boolean {
+    return this.formService.editTier() === 'READ_ONLY';
   }
 
   protected onRoleBalancingToggle(enabled: boolean): void {

--- a/frontend/src/app/courses/create/course-form.service.spec.ts
+++ b/frontend/src/app/courses/create/course-form.service.spec.ts
@@ -89,6 +89,89 @@ describe('CourseFormService.toDto', () => {
   });
 });
 
+describe('CourseFormService.isFieldLocked (edit-tier signal)', () => {
+  let service: CourseFormService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [CourseFormService] });
+    service = TestBed.inject(CourseFormService);
+  });
+
+  function populateWith(editTier: string | undefined): void {
+    service.populate({
+      title: 'T',
+      danceStyle: 'BACHATA',
+      level: 'BEGINNER',
+      courseType: 'PARTNER',
+      description: '',
+      startDate: '2030-01-01',
+      recurrenceType: 'WEEKLY',
+      numberOfSessions: 8,
+      startTime: '19:30',
+      endTime: '20:45',
+      location: 'Studio A',
+      teachers: '',
+      maxParticipants: 20,
+      roleBalanceThreshold: null,
+      priceModel: 'FIXED_COURSE',
+      price: 100,
+      editTier,
+    });
+  }
+
+  it('FULLY_EDITABLE tier: no field is locked', () => {
+    populateWith('FULLY_EDITABLE');
+    expect(service.isFieldLocked('title')).toBe(false);
+    expect(service.isFieldLocked('danceStyle')).toBe(false);
+    expect(service.isFieldLocked('price')).toBe(false);
+    expect(service.isFieldLocked('startTime')).toBe(false);
+  });
+
+  it('RESTRICTED tier: locks the locked-field list, leaves cosmetic fields editable', () => {
+    populateWith('RESTRICTED');
+    expect(service.isFieldLocked('courseType')).toBe(true);
+    expect(service.isFieldLocked('price')).toBe(true);
+    expect(service.isFieldLocked('danceStyle')).toBe(true);
+    expect(service.isFieldLocked('startDate')).toBe(true);
+    expect(service.isFieldLocked('numberOfSessions')).toBe(true);
+
+    expect(service.isFieldLocked('title')).toBe(false);
+    expect(service.isFieldLocked('description')).toBe(false);
+    expect(service.isFieldLocked('teachers')).toBe(false);
+    expect(service.isFieldLocked('location')).toBe(false);
+    expect(service.isFieldLocked('maxParticipants')).toBe(false);
+    expect(service.isFieldLocked('roleBalanceThreshold')).toBe(false);
+  });
+
+  it('READ_ONLY tier: every field is locked', () => {
+    populateWith('READ_ONLY');
+    expect(service.isFieldLocked('title')).toBe(true);
+    expect(service.isFieldLocked('maxParticipants')).toBe(true);
+    expect(service.isFieldLocked('danceStyle')).toBe(true);
+  });
+
+  it('missing editTier defaults to FULLY_EDITABLE', () => {
+    populateWith(undefined);
+    expect(service.isFieldLocked('danceStyle')).toBe(false);
+  });
+
+  it('RESTRICTED tier disables the locked form controls', () => {
+    populateWith('RESTRICTED');
+    expect(service.form.controls.details.controls.danceStyle.disabled).toBe(true);
+    expect(service.form.controls.pricing.controls.price.disabled).toBe(true);
+    expect(service.form.controls.schedule.controls.startTime.disabled).toBe(true);
+    expect(service.form.controls.details.controls.title.disabled).toBe(false);
+    expect(service.form.controls.schedule.controls.location.disabled).toBe(false);
+  });
+
+  it('READ_ONLY tier disables every form control', () => {
+    populateWith('READ_ONLY');
+    expect(service.form.controls.details.controls.title.disabled).toBe(true);
+    expect(service.form.controls.schedule.controls.location.disabled).toBe(true);
+    expect(service.form.controls.registration.controls.maxParticipants.disabled).toBe(true);
+  });
+});
+
 describe('CourseFormService role-balancing toggle', () => {
   let service: CourseFormService;
 

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -1,10 +1,34 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
+import type { CourseEditTier } from '../course.service';
 
 export const DEFAULT_ROLE_BALANCE_THRESHOLD = 3;
 
+/**
+ * Fields locked in the RESTRICTED tier. Mirrors {@code CourseEditPolicy.LOCKED_IN_RESTRICTED}
+ * on the backend. Kept as a client-side list so the template can disable controls without a
+ * round-trip per field; the backend remains the canonical enforcement point.
+ */
+const LOCKED_IN_RESTRICTED: ReadonlySet<string> = new Set([
+  'courseType',
+  'price',
+  'priceModel',
+  'danceStyle',
+  'level',
+  'startDate',
+  'endDate',
+  'dayOfWeek',
+  'startTime',
+  'endTime',
+  'numberOfSessions',
+  'recurrenceType',
+]);
+
 @Injectable()
 export class CourseFormService {
+  private readonly _editTier = signal<CourseEditTier>('FULLY_EDITABLE');
+  readonly editTier = this._editTier.asReadonly();
+
   readonly form = new FormGroup({
     details: new FormGroup({
       title: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -80,8 +104,48 @@ export class CourseFormService {
         price: data['price'] as number,
       },
     });
+    const tier = (data['editTier'] as CourseEditTier | undefined) ?? 'FULLY_EDITABLE';
+    this._editTier.set(tier);
+    this.applyTierToControls(tier);
     // Mark as pristine after loading — form is not "dirty" until user edits
     this.form.markAsPristine();
+  }
+
+  isFieldLocked(field: string): boolean {
+    const tier = this._editTier();
+    if (tier === 'FULLY_EDITABLE') return false;
+    if (tier === 'READ_ONLY') return true;
+    return LOCKED_IN_RESTRICTED.has(field);
+  }
+
+  private applyTierToControls(_tier: CourseEditTier): void {
+    // Disable every named form control whose field is locked under the current tier.
+    // Reactive-forms `.disable()` is how Material input/select read disabled state.
+    const named: Array<[string, AbstractControl]> = [
+      ['title', this.form.controls.details.controls.title],
+      ['danceStyle', this.form.controls.details.controls.danceStyle],
+      ['level', this.form.controls.details.controls.level],
+      ['courseType', this.form.controls.details.controls.courseType],
+      ['description', this.form.controls.details.controls.description],
+      ['startDate', this.form.controls.schedule.controls.startDate],
+      ['recurrenceType', this.form.controls.schedule.controls.recurrenceType],
+      ['numberOfSessions', this.form.controls.schedule.controls.numberOfSessions],
+      ['startTime', this.form.controls.schedule.controls.startTime],
+      ['endTime', this.form.controls.schedule.controls.endTime],
+      ['location', this.form.controls.schedule.controls.location],
+      ['teachers', this.form.controls.schedule.controls.teachers],
+      ['maxParticipants', this.form.controls.registration.controls.maxParticipants],
+      ['roleBalanceThreshold', this.form.controls.registration.controls.roleBalanceThreshold],
+      ['priceModel', this.form.controls.pricing.controls.priceModel],
+      ['price', this.form.controls.pricing.controls.price],
+    ];
+    for (const [name, control] of named) {
+      if (this.isFieldLocked(name)) {
+        control.disable({ emitEvent: false });
+      } else {
+        control.enable({ emitEvent: false });
+      }
+    }
   }
 
   get roleBalancingEnabled(): boolean {
@@ -116,6 +180,8 @@ export class CourseFormService {
 
   reset(): void {
     this.form.reset();
+    this._editTier.set('FULLY_EDITABLE');
+    this.applyTierToControls('FULLY_EDITABLE');
   }
 }
 

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -32,6 +32,7 @@ function makeCourseDetail(overrides: Partial<CourseDetail> = {}): CourseDetail {
     publishedAt: null,
     enrolledStudents: 12,
     completedSessions: 0,
+    editTier: 'FULLY_EDITABLE',
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Add `CourseEditPolicy` — a static utility that classifies a course into `FULLY_EDITABLE` / `RESTRICTED` / `READ_ONLY` using `CourseStatusDerivation.deriveStatus` + the non-terminal enrollment count.
- `PUT /api/courses/{id}` rejects locked-field changes with 409 `{ tier, rejectedFields }`, and runs `EnrollmentService.autoPromoteWaitlist` in the same transaction whenever `maxParticipants` or `roleBalanceThreshold` changes. `autoPromoteWaitlist` visibility was bumped `private → public`; the existing implementation already handles the broadened trigger set correctly.
- Frontend `CourseFormService.populate` reads the new `editTier` from `CourseDetailDto`, disables the locked reactive-form controls, shows per-field tooltips, and renders a banner + hides Save on READ_ONLY courses.

## Tier model

| Status | Non-terminal count | Tier |
|---|---|---|
| DRAFT | any | FULLY_EDITABLE |
| OPEN | 0 | FULLY_EDITABLE |
| OPEN | ≥1 | RESTRICTED (cosmetic only) |
| RUNNING / FINISHED | any | READ_ONLY |

Note: RUNNING / FINISHED read-only was "Out of scope" in PRD #312. Tightened in this slice per offline agreement — the PRD #312 body will be updated to match.

Closes #314.

## Test plan

- [x] `./mvnw test -Dtest=CourseEditPolicyTest` — 52 unit cases cover tier × field matrix + `findLockedFieldChanges` on each locked field.
- [x] `./mvnw test -Dtest=CourseCrudIntegrationTest` — 29 tests: existing (including #315 DELETE) plus new cosmetic-accepted / locked-rejected / RUNNING / FINISHED / zero-enrollment / capacity-raise-promotes / threshold-change-promotes.
- [x] `./mvnw test` — full suite, 236+ tests pass.
- [x] `npx ng test --browsers chromium --no-watch` — 141 frontend tests, including new `CourseFormService.isFieldLocked` coverage.
- [x] Visual: DRAFT form fully editable, RESTRICTED form disables locked fields with tooltip, RUNNING form shows banner + all disabled + Save hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)