### PR TITLE
Course detail: Delete button on DRAFT courses (#316)

### DIFF
--- a/frontend/src/app/courses/course.service.spec.ts
+++ b/frontend/src/app/courses/course.service.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { CourseService } from './course.service';
+import { environment } from '../../environments/environment';
+
+describe('CourseService', () => {
+  let service: CourseService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(CourseService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  describe('deleteCourse', () => {
+    it('issues DELETE /api/courses/:id and completes on 204', () => {
+      let completed = false;
+      service.deleteCourse(42).subscribe({ complete: () => (completed = true) });
+
+      const req = httpTesting.expectOne(`${environment.apiUrl}/api/courses/42`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+
+      expect(completed).toBe(true);
+    });
+
+    it('propagates HTTP errors (e.g. 409 conflict) to the subscriber', () => {
+      let errorStatus: number | undefined;
+      service.deleteCourse(7).subscribe({
+        error: (err) => (errorStatus = err.status),
+      });
+
+      const req = httpTesting.expectOne(`${environment.apiUrl}/api/courses/7`);
+      req.flush({ detail: 'Course is published' }, { status: 409, statusText: 'Conflict' });
+
+      expect(errorStatus).toBe(409);
+    });
+  });
+});

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -83,4 +83,8 @@ export class CourseService {
   publishCourse(id: number): Observable<CourseDetail> {
     return this.http.post<CourseDetail>(`${environment.apiUrl}/api/courses/${id}/publish`, null);
   }
+
+  deleteCourse(id: number): Observable<void> {
+    return this.http.delete<void>(`${environment.apiUrl}/api/courses/${id}`);
+  }
 }

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -13,9 +13,14 @@
           </span>
         </div>
         @if (c.status === 'DRAFT') {
-          <button mat-flat-button class="publish-button" (click)="onPublish()" [disabled]="publishing()">
-            Publish
-          </button>
+          <div class="draft-actions">
+            <button mat-stroked-button class="delete-button" (click)="onDelete()" [disabled]="deleting() || publishing()">
+              Delete
+            </button>
+            <button mat-flat-button class="publish-button" (click)="onPublish()" [disabled]="publishing() || deleting()">
+              Publish
+            </button>
+          </div>
         }
       </div>
     </div>

--- a/frontend/src/app/courses/overview/course-overview.scss
+++ b/frontend/src/app/courses/overview/course-overview.scss
@@ -40,6 +40,16 @@
   margin: 0;
 }
 
+.draft-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-spacing-2);
+}
+
+.delete-button {
+  color: var(--mat-sys-error);
+}
+
 .content-card {
   background: var(--mat-sys-surface);
   border: 1px solid var(--mat-sys-outline-variant);

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { vi } from 'vitest';
 import { CourseOverviewComponent } from './course-overview';
 import { ActivatedRoute } from '@angular/router';
 import { CourseDetail } from '../course.service';
@@ -63,6 +65,7 @@ describe('CourseOverviewComponent', () => {
 
   afterEach(() => {
     httpTesting.verify();
+    vi.restoreAllMocks();
   });
 
   /** Flush the course detail request and the enrollment request that follows for non-DRAFT courses. */
@@ -275,6 +278,102 @@ describe('CourseOverviewComponent', () => {
       markPaidReq.flush({ enrollmentId: 99, status: 'CONFIRMED' });
 
       httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
+    });
+  });
+
+  describe('Delete button', () => {
+    function deleteButton(): HTMLButtonElement | null {
+      return el.querySelector('.delete-button') as HTMLButtonElement | null;
+    }
+
+    it('is rendered for DRAFT courses', () => {
+      fixture.detectChanges();
+      flushCourse({ status: 'DRAFT' });
+      fixture.detectChanges();
+
+      expect(deleteButton()).toBeTruthy();
+    });
+
+    it('is not rendered for OPEN / RUNNING / FINISHED courses', () => {
+      for (const status of ['OPEN', 'RUNNING', 'FINISHED']) {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [CourseOverviewComponent],
+          providers: [
+            provideRouter([]),
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            {
+              provide: ActivatedRoute,
+              useValue: { snapshot: { paramMap: { get: () => '1' }, queryParamMap: { get: () => null } } },
+            },
+          ],
+        });
+        const f = TestBed.createComponent(CourseOverviewComponent);
+        const http = TestBed.inject(HttpTestingController);
+        const node = f.nativeElement as HTMLElement;
+
+        f.detectChanges();
+        http.expectOne(req => req.url.includes('/api/courses/1') && !req.url.includes('enrollments'))
+          .flush(makeCourseDetail({ status }));
+        http.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
+        f.detectChanges();
+
+        expect(node.querySelector('.delete-button'), `status=${status}`).toBeFalsy();
+        http.verify();
+      }
+    });
+
+    it('does nothing when the confirm dialog is cancelled', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      fixture.detectChanges();
+      flushCourse({ status: 'DRAFT' });
+      fixture.detectChanges();
+
+      deleteButton()!.click();
+      fixture.detectChanges();
+
+      // No DELETE request issued — afterEach httpTesting.verify() asserts this
+      expect(confirmSpy).toHaveBeenCalled();
+    });
+
+    it('sends DELETE and navigates to /app/courses when confirmed', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const router = TestBed.inject(Router);
+      const navigateSpy = vi.spyOn(router, 'navigate');
+
+      fixture.detectChanges();
+      flushCourse({ status: 'DRAFT' });
+      fixture.detectChanges();
+
+      deleteButton()!.click();
+      fixture.detectChanges();
+
+      const req = httpTesting.expectOne(req => req.url.includes('/api/courses/1') && req.method === 'DELETE');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+
+      expect(navigateSpy).toHaveBeenCalledWith(['/app/courses']);
+    });
+
+    it('stays on the page and surfaces the server message on error', () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      const router = TestBed.inject(Router);
+      const navigateSpy = vi.spyOn(router, 'navigate');
+      const snackBar = TestBed.inject(MatSnackBar);
+      const snackSpy = vi.spyOn(snackBar, 'open');
+
+      fixture.detectChanges();
+      flushCourse({ status: 'DRAFT' });
+      fixture.detectChanges();
+
+      deleteButton()!.click();
+      fixture.detectChanges();
+
+      const req = httpTesting.expectOne(req => req.url.includes('/api/courses/1') && req.method === 'DELETE');
+      req.flush({ detail: 'Course is published' }, { status: 409, statusText: 'Conflict' });
+
+      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(snackSpy).toHaveBeenCalledWith('Course is published', 'Close', expect.objectContaining({ panelClass: 'snackbar-error' }));
     });
   });
 

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -50,6 +50,7 @@ export class CourseOverviewComponent implements OnInit {
   protected course = signal<CourseDetail | null>(null);
   protected loading = signal(true);
   protected publishing = signal(false);
+  protected deleting = signal(false);
   protected enrollments = signal<EnrollmentListItem[]>([]);
   protected activeTabIndex = signal(0);
 
@@ -184,6 +185,25 @@ export class CourseOverviewComponent implements OnInit {
       },
       error: (err: HttpErrorResponse) => {
         this.snackBar.open(extractErrorMessage(err, errorFallback), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
+      },
+    });
+  }
+
+  protected onDelete(): void {
+    const c = this.course();
+    if (!c || c.status !== 'DRAFT') return;
+    if (!confirm(`Delete "${c.title}"? This cannot be undone.`)) return;
+
+    this.deleting.set(true);
+    this.courseService.deleteCourse(c.id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.deleting.set(false);
+        this.snackBar.open('Course deleted', 'Close', { duration: 3000, panelClass: 'snackbar-success' });
+        this.router.navigate(['/app/courses']);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.deleting.set(false);
+        this.snackBar.open(extractErrorMessage(err, 'Failed to delete course'), 'Close', { duration: 5000, panelClass: 'snackbar-error' });
       },
     });
   }


### PR DESCRIPTION
Closes #316.

## Summary

- Adds a Delete action on the course overview, visible only when the course is DRAFT. Placed beside Publish in the header.
- Native `window.confirm()` for the dialog — matches the existing `unsaved-changes.guard.ts` pattern and avoids introducing MatDialog infrastructure for a single button.
- On accept: `DELETE /api/courses/{id}` → snackbar + navigate to `/app/courses`. On 409 (race with publish): surface the server's RFC 7807 `detail` via snackbar, stay on the page.
- Unit tests for the service (happy path + error propagation) and the overview (button visibility DRAFT vs OPEN/RUNNING/FINISHED, confirm cancel, confirm accept → navigate, 409 error → snackbar).

Backend guardrail already shipped in #313. Sibling #314 (edit guardrails) merged in parallel; this PR rebased on top.

## Deviations from issue body

- **`window.confirm()` over `MatDialog`:** the issue draft specified MatDialog, but no existing MatDialog pattern exists in the codebase. Using the native dialog matches `unsaved-changes.guard.ts` and keeps scope tight.
- **No separate "is delete visible?" signal/computed:** visibility is a single inline template expression (`c.status === 'DRAFT'`), same pattern as the existing Publish-button condition. DOM-level visibility tests cover the same contract.

## Test plan

- [x] `npx ng test` — 148 tests pass
- [x] Visual: DRAFT course shows Delete + Publish side-by-side (Delete in error color)
- [x] Visual: OPEN/RUNNING course shows neither Delete nor Publish
- [x] Visual: end-to-end delete → course removed from list, Active count 6→5

🤖 Generated with [Claude Code](https://claude.com/claude-code)