### PR TITLE
Cleanup from triage #318: dead code, payments path, SecurityConfig

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseDetailDto.java
@@ -28,7 +28,6 @@ public record CourseDetailDto(
         CourseLifecycleStatus status,
         LocalDate publishedAt,
         int enrolledStudents,
-        int completedSessions,
         CourseEditPolicy.Tier editTier
 ) {
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseListDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseListDto.java
@@ -22,7 +22,6 @@ public record CourseListDto(
         int followCount,
         int maxParticipants,
         BigDecimal price,
-        CourseLifecycleStatus status,
-        int completedSessions
+        CourseLifecycleStatus status
 ) {
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseService.java
@@ -261,9 +261,7 @@ public class CourseService {
                 course.getMaxParticipants(),
                 course.getPrice(),
                 CourseStatusDerivation.deriveStatus(
-                        course.getPublishedAt(), course.getStartDate(), course.getEndDate(), today),
-                CourseStatusDerivation.deriveCompletedSessions(
-                        course.getStartDate(), course.getDayOfWeek(), course.getNumberOfSessions(), today)
+                        course.getPublishedAt(), course.getStartDate(), course.getEndDate(), today)
         );
     }
 
@@ -296,8 +294,6 @@ public class CourseService {
                 status,
                 course.getPublishedAt(),
                 enrolledStudents,
-                CourseStatusDerivation.deriveCompletedSessions(
-                        course.getStartDate(), course.getDayOfWeek(), course.getNumberOfSessions(), today),
                 editTier
         );
     }

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseStatusDerivation.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseStatusDerivation.java
@@ -1,11 +1,9 @@
 package ch.ruppen.danceschool.course;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
 
 /**
- * Pure functions for deriving course lifecycle status and session progress from date fields.
+ * Pure functions for deriving course lifecycle status from date fields.
  *
  * <h2>Derived Status Model</h2>
  * Course lifecycle status is never stored — it is computed from three fields:
@@ -52,27 +50,5 @@ public final class CourseStatusDerivation {
             return CourseLifecycleStatus.RUNNING;
         }
         return CourseLifecycleStatus.OPEN;
-    }
-
-    public static int deriveCompletedSessions(LocalDate startDate, DayOfWeek dayOfWeek,
-                                              int numberOfSessions, LocalDate today) {
-        if (today.isBefore(startDate)) {
-            return 0;
-        }
-
-        // Find the first session day (should be startDate itself if it matches dayOfWeek,
-        // otherwise the next occurrence)
-        LocalDate firstSession = startDate.getDayOfWeek() == dayOfWeek
-                ? startDate
-                : startDate.with(TemporalAdjusters.next(dayOfWeek));
-
-        if (today.isBefore(firstSession)) {
-            return 0;
-        }
-
-        // Number of weeks between first session and today, plus 1 for the first session itself
-        long weeksBetween = (today.toEpochDay() - firstSession.toEpochDay()) / 7;
-        int completed = (int) Math.min(weeksBetween + 1, numberOfSessions);
-        return completed;
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
@@ -10,14 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/me/payments")
+@RequestMapping("/api/payments")
 @RequiredArgsConstructor
 public class PaymentController {
 
     private final PaymentService paymentService;
 
-    @GetMapping
-    public List<PaymentDto> list(@AuthenticationPrincipal AuthenticatedUser principal) {
+    @GetMapping("/me")
+    public List<PaymentDto> listMine(@AuthenticationPrincipal AuthenticatedUser principal) {
         return paymentService.listForCurrentUser(principal.userId());
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevSecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/DevSecurityConfig.java
@@ -57,8 +57,8 @@ public class DevSecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
-                        .requestMatchers("/api/**").authenticated()
-                        .anyRequest().permitAll())
+                        .requestMatchers("/error").permitAll()
+                        .anyRequest().authenticated())
                 .formLogin(form -> form
                         .loginProcessingUrl("/api/auth/login")
                         .successHandler(devAuthSuccessHandler())

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/SecurityConfig.java
@@ -45,9 +45,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/uploads/**").permitAll()
-                        .requestMatchers("/api/**").authenticated()
-                        .anyRequest().permitAll())
+                        .requestMatchers("/error").permitAll()
+                        .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(firebaseJwtAuthenticationConverter)))
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
@@ -11,8 +11,6 @@ import java.util.Optional;
 
 interface StudentRepository extends JpaRepository<Student, Long> {
 
-    List<Student> findAllBySchoolId(Long schoolId);
-
     Optional<Student> findByIdAndSchoolId(Long id, Long schoolId);
 
     boolean existsBySchoolId(Long schoolId);

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
@@ -91,11 +91,6 @@ public class StudentService {
     }
 
     @Transactional(readOnly = true)
-    public List<Student> findAllBySchool(School school) {
-        return studentRepository.findAllBySchoolId(school.getId());
-    }
-
-    @Transactional(readOnly = true)
     public boolean hasStudentsForSchool(Long userId) {
         School school = schoolService.findSchoolByMember(userId);
         return studentRepository.existsBySchoolId(school.getId());

--- a/backend/src/main/java/ch/ruppen/danceschool/user/UserService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/user/UserService.java
@@ -4,17 +4,21 @@ import ch.ruppen.danceschool.schoolmember.MembershipDto;
 import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    // Dedicated business logger — findOrCreateByFirebaseUid fires on every request, so
+    // @BusinessOperation can't be used (it would log on every call, not only on create).
+    private static final Logger businessLog = LoggerFactory.getLogger("business");
 
     private final UserRepository userRepository;
     private final SchoolMemberService schoolMemberService;
@@ -32,7 +36,7 @@ public class UserService {
                     user.setEmail(email);
                     user.setName(name);
                     AppUser saved = userRepository.save(user);
-                    log.info("BUSINESS | UserOnboarded | userId={} email=\"{}\"", saved.getId(), email);
+                    businessLog.info("event=UserOnboarded userId={} email=\"{}\"", saved.getId(), email);
                     return saved;
                 });
     }

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
@@ -89,8 +89,7 @@ class CourseControllerIntegrationTest {
                 .andExpect(jsonPath("$[0].maxParticipants").value(15))
                 .andExpect(jsonPath("$[0].price").value(180.00))
                 .andExpect(jsonPath("$[0].status").value("OPEN"))
-                .andExpect(jsonPath("$[0].startDate").exists())
-                .andExpect(jsonPath("$[0].completedSessions").isNumber());
+                .andExpect(jsonPath("$[0].startDate").exists());
     }
 
     @Test

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseCrudIntegrationTest.java
@@ -197,8 +197,7 @@ class CourseCrudIntegrationTest {
                     .andExpect(jsonPath("$.priceModel").value("FIXED_COURSE"))
                     .andExpect(jsonPath("$.price").value(310.00))
                     .andExpect(jsonPath("$.status").value("OPEN"))
-                    .andExpect(jsonPath("$.enrolledStudents").value(0))
-                    .andExpect(jsonPath("$.completedSessions").value(0));
+                    .andExpect(jsonPath("$.enrolledStudents").value(0));
         }
 
         @Test

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseFilterIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseFilterIntegrationTest.java
@@ -136,12 +136,11 @@ class CourseFilterIntegrationTest {
     }
 
     @Test
-    void dtoIncludesStartDateAndCompletedSessions() throws Exception {
+    void dtoIncludesStartDate() throws Exception {
         mockMvc.perform(get("/api/courses/me?status=RUNNING")
                         .with(authentication(authToken(ownerA))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].startDate").exists())
-                .andExpect(jsonPath("$[0].completedSessions").isNumber());
+                .andExpect(jsonPath("$[0].startDate").exists());
     }
 
     private AppUser createUser(String email, String name, String firebaseUid) {

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseStatusDerivationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseStatusDerivationTest.java
@@ -1,131 +1,67 @@
 package ch.ruppen.danceschool.course;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CourseStatusDerivationTest {
 
-    @Nested
-    class DeriveStatus {
+    private final LocalDate startDate = LocalDate.of(2026, 5, 4);   // Monday
+    private final LocalDate endDate = LocalDate.of(2026, 6, 22);    // Monday, 8 weeks later
 
-        private final LocalDate startDate = LocalDate.of(2026, 5, 4);   // Monday
-        private final LocalDate endDate = LocalDate.of(2026, 6, 22);    // Monday, 8 weeks later
-
-        @Test
-        void draft_whenPublishedAtIsNull() {
-            assertThat(CourseStatusDerivation.deriveStatus(null, startDate, endDate, LocalDate.of(2026, 4, 1)))
-                    .isEqualTo(CourseLifecycleStatus.DRAFT);
-        }
-
-        @Test
-        void draft_whenUnpublishedEvenPastEndDate() {
-            assertThat(CourseStatusDerivation.deriveStatus(null, startDate, endDate, LocalDate.of(2026, 7, 1)))
-                    .isEqualTo(CourseLifecycleStatus.DRAFT);
-        }
-
-        @Test
-        void open_whenPublishedAndTodayBeforeStartDate() {
-            LocalDate publishedAt = LocalDate.of(2026, 4, 1);
-            assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, LocalDate.of(2026, 4, 15)))
-                    .isEqualTo(CourseLifecycleStatus.OPEN);
-        }
-
-        @Test
-        void running_whenTodayEqualsStartDate() {
-            LocalDate publishedAt = LocalDate.of(2026, 4, 1);
-            assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, startDate))
-                    .isEqualTo(CourseLifecycleStatus.RUNNING);
-        }
-
-        @Test
-        void running_whenTodayBetweenStartAndEnd() {
-            LocalDate publishedAt = LocalDate.of(2026, 4, 1);
-            assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, LocalDate.of(2026, 5, 20)))
-                    .isEqualTo(CourseLifecycleStatus.RUNNING);
-        }
-
-        @Test
-        void running_whenTodayEqualsEndDate() {
-            LocalDate publishedAt = LocalDate.of(2026, 4, 1);
-            assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, endDate))
-                    .isEqualTo(CourseLifecycleStatus.RUNNING);
-        }
-
-        @Test
-        void finished_whenTodayIsOneDayAfterEndDate() {
-            LocalDate publishedAt = LocalDate.of(2026, 4, 1);
-            assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, endDate.plusDays(1)))
-                    .isEqualTo(CourseLifecycleStatus.FINISHED);
-        }
-
-        @Test
-        void finished_whenTodayWellPastEndDate() {
-            LocalDate publishedAt = LocalDate.of(2026, 4, 1);
-            assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, LocalDate.of(2026, 12, 1)))
-                    .isEqualTo(CourseLifecycleStatus.FINISHED);
-        }
+    @Test
+    void draft_whenPublishedAtIsNull() {
+        assertThat(CourseStatusDerivation.deriveStatus(null, startDate, endDate, LocalDate.of(2026, 4, 1)))
+                .isEqualTo(CourseLifecycleStatus.DRAFT);
     }
 
-    @Nested
-    class DeriveCompletedSessions {
+    @Test
+    void draft_whenUnpublishedEvenPastEndDate() {
+        assertThat(CourseStatusDerivation.deriveStatus(null, startDate, endDate, LocalDate.of(2026, 7, 1)))
+                .isEqualTo(CourseLifecycleStatus.DRAFT);
+    }
 
-        private final LocalDate startDate = LocalDate.of(2026, 5, 4);  // Monday
-        private final DayOfWeek dayOfWeek = DayOfWeek.MONDAY;
-        private final int numberOfSessions = 8;
+    @Test
+    void open_whenPublishedAndTodayBeforeStartDate() {
+        LocalDate publishedAt = LocalDate.of(2026, 4, 1);
+        assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, LocalDate.of(2026, 4, 15)))
+                .isEqualTo(CourseLifecycleStatus.OPEN);
+    }
 
-        @Test
-        void zero_whenTodayBeforeStartDate() {
-            assertThat(CourseStatusDerivation.deriveCompletedSessions(startDate, dayOfWeek, numberOfSessions,
-                    LocalDate.of(2026, 4, 15)))
-                    .isEqualTo(0);
-        }
+    @Test
+    void running_whenTodayEqualsStartDate() {
+        LocalDate publishedAt = LocalDate.of(2026, 4, 1);
+        assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, startDate))
+                .isEqualTo(CourseLifecycleStatus.RUNNING);
+    }
 
-        @Test
-        void one_whenTodayIsFirstSessionDay() {
-            assertThat(CourseStatusDerivation.deriveCompletedSessions(startDate, dayOfWeek, numberOfSessions,
-                    startDate))
-                    .isEqualTo(1);
-        }
+    @Test
+    void running_whenTodayBetweenStartAndEnd() {
+        LocalDate publishedAt = LocalDate.of(2026, 4, 1);
+        assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, LocalDate.of(2026, 5, 20)))
+                .isEqualTo(CourseLifecycleStatus.RUNNING);
+    }
 
-        @Test
-        void one_whenTodayBetweenFirstAndSecondSession() {
-            assertThat(CourseStatusDerivation.deriveCompletedSessions(startDate, dayOfWeek, numberOfSessions,
-                    startDate.plusDays(3)))  // Thursday of first week
-                    .isEqualTo(1);
-        }
+    @Test
+    void running_whenTodayEqualsEndDate() {
+        LocalDate publishedAt = LocalDate.of(2026, 4, 1);
+        assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, endDate))
+                .isEqualTo(CourseLifecycleStatus.RUNNING);
+    }
 
-        @Test
-        void two_whenTodayIsSecondSessionDay() {
-            assertThat(CourseStatusDerivation.deriveCompletedSessions(startDate, dayOfWeek, numberOfSessions,
-                    startDate.plusWeeks(1)))
-                    .isEqualTo(2);
-        }
+    @Test
+    void finished_whenTodayIsOneDayAfterEndDate() {
+        LocalDate publishedAt = LocalDate.of(2026, 4, 1);
+        assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, endDate.plusDays(1)))
+                .isEqualTo(CourseLifecycleStatus.FINISHED);
+    }
 
-        @Test
-        void allSessions_whenTodayAfterLastSession() {
-            assertThat(CourseStatusDerivation.deriveCompletedSessions(startDate, dayOfWeek, numberOfSessions,
-                    startDate.plusWeeks(10)))
-                    .isEqualTo(8);
-        }
-
-        @Test
-        void cappedAtNumberOfSessions() {
-            assertThat(CourseStatusDerivation.deriveCompletedSessions(startDate, dayOfWeek, numberOfSessions,
-                    startDate.plusWeeks(100)))
-                    .isEqualTo(8);
-        }
-
-        @Test
-        void correctCount_midCourse() {
-            // After 4 weeks: sessions on week 0, 1, 2, 3, 4 = 5 sessions
-            assertThat(CourseStatusDerivation.deriveCompletedSessions(startDate, dayOfWeek, numberOfSessions,
-                    startDate.plusWeeks(4)))
-                    .isEqualTo(5);
-        }
+    @Test
+    void finished_whenTodayWellPastEndDate() {
+        LocalDate publishedAt = LocalDate.of(2026, 4, 1);
+        assertThat(CourseStatusDerivation.deriveStatus(publishedAt, startDate, endDate, LocalDate.of(2026, 12, 1)))
+                .isEqualTo(CourseLifecycleStatus.FINISHED);
     }
 }

--- a/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentIntegrationTest.java
@@ -82,7 +82,7 @@ class PaymentIntegrationTest {
                 EnrollmentStatus.CONFIRMED, t1, t2);
         entityManager.flush();
 
-        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+        mockMvc.perform(get("/api/payments/me").with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
                 // Default order: billingDate DESC → paid (t2) before open (t1)
@@ -106,7 +106,7 @@ class PaymentIntegrationTest {
                 EnrollmentStatus.CONFIRMED, enrolled, paid);
         entityManager.flush();
 
-        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+        mockMvc.perform(get("/api/payments/me").with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
                 // First row (paid, sorted by billingDate=paid DESC)
                 .andExpect(jsonPath("$[0].billingDate").value(paid.toString()))
@@ -128,7 +128,7 @@ class PaymentIntegrationTest {
         Long openId = createEnrollment(course, s4, EnrollmentStatus.PENDING_PAYMENT, now, null);
         entityManager.flush();
 
-        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+        mockMvc.perform(get("/api/payments/me").with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].enrollmentId").value(openId))
@@ -143,7 +143,7 @@ class PaymentIntegrationTest {
         Long id = createEnrollment(course, student, EnrollmentStatus.REJECTED, t.minusSeconds(60), t);
         entityManager.flush();
 
-        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+        mockMvc.perform(get("/api/payments/me").with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].enrollmentId").value(id))
@@ -164,7 +164,7 @@ class PaymentIntegrationTest {
                 base.minus(1, ChronoUnit.DAYS), null);
         entityManager.flush();
 
-        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+        mockMvc.perform(get("/api/payments/me").with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].enrollmentId").value(newest))
                 .andExpect(jsonPath("$[1].enrollmentId").value(middle))
@@ -181,12 +181,12 @@ class PaymentIntegrationTest {
         Long otherId = createEnrollment(otherCourse, otherStudent, EnrollmentStatus.PENDING_PAYMENT, now, null);
         entityManager.flush();
 
-        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner))))
+        mockMvc.perform(get("/api/payments/me").with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].courseTitle").value("Bachata Beginners"));
 
-        mockMvc.perform(get("/api/me/payments").with(authentication(authToken(owner2))))
+        mockMvc.perform(get("/api/payments/me").with(authentication(authToken(owner2))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].enrollmentId").value(otherId))

--- a/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
@@ -44,7 +44,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Proves /api/me/payments fires a constant number of SQL statements regardless of
+ * Proves /api/payments/me fires a constant number of SQL statements regardless of
  * payment count — the JPQL constructor expression projects scalar fields directly,
  * so no per-row lazy load is triggered.
  */
@@ -89,14 +89,14 @@ class PaymentListSqlBudgetTest {
         stats.setStatisticsEnabled(true);
         stats.clear();
 
-        mockMvc.perform(get("/api/me/payments")
+        mockMvc.perform(get("/api/payments/me")
                         .with(authentication(authToken(owner))))
                 .andExpect(status().isOk());
 
         // 1 query for school resolution + 1 for the payment list = 2.
         // Allow a small headroom for security/auth bookkeeping.
         assertThat(stats.getPrepareStatementCount())
-                .as("SQL budget for /api/me/payments with N=%d", n)
+                .as("SQL budget for /api/payments/me with N=%d", n)
                 .isLessThanOrEqualTo(3);
     }
 

--- a/frontend/src/app/courses/course.service.ts
+++ b/frontend/src/app/courses/course.service.ts
@@ -22,7 +22,6 @@ export interface CourseListItem {
   maxParticipants: number;
   price: number;
   status: string;
-  completedSessions: number;
 }
 
 export type CourseEditTier = 'FULLY_EDITABLE' | 'RESTRICTED' | 'READ_ONLY';
@@ -50,7 +49,6 @@ export interface CourseDetail {
   status: string;
   publishedAt: string | null;
   enrolledStudents: number;
-  completedSessions: number;
   editTier: CourseEditTier;
 }
 

--- a/frontend/src/app/courses/courses.spec.ts
+++ b/frontend/src/app/courses/courses.spec.ts
@@ -24,7 +24,6 @@ function makeCourse(overrides: Partial<CourseListItem> = {}): CourseListItem {
     maxParticipants: 20,
     price: 166.5,
     status: 'RUNNING',
-    completedSessions: 3,
     ...overrides,
   };
 }

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -31,7 +31,6 @@ function makeCourseDetail(overrides: Partial<CourseDetail> = {}): CourseDetail {
     status: 'OPEN',
     publishedAt: null,
     enrolledStudents: 12,
-    completedSessions: 0,
     editTier: 'FULLY_EDITABLE',
     ...overrides,
   };

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -105,7 +105,6 @@ export class CourseOverviewComponent implements OnInit {
       dayOfWeek: formatDayFull(c.dayOfWeek),
       recurrenceType: c.recurrenceType,
       numberOfSessions: c.numberOfSessions,
-      completedSessions: c.completedSessions,
       status: c.status,
       publishedAt: formatDate(c.publishedAt ?? ''),
       endDate: formatDate(c.endDate),

--- a/frontend/src/app/courses/shared/course-summary.html
+++ b/frontend/src/app/courses/shared/course-summary.html
@@ -72,13 +72,7 @@
       </div>
       <div class="summary-field">
         <span class="summary-label">Sessions</span>
-        <span class="summary-value">
-          @if (d.status === 'RUNNING' && d.completedSessions != null) {
-            Session {{ d.completedSessions }}/{{ d.numberOfSessions }}
-          } @else {
-            {{ d.numberOfSessions }}
-          }
-        </span>
+        <span class="summary-value">{{ d.numberOfSessions }}</span>
       </div>
       <div class="summary-field">
         <span class="summary-label">Time</span>

--- a/frontend/src/app/courses/shared/course-summary.ts
+++ b/frontend/src/app/courses/shared/course-summary.ts
@@ -15,7 +15,6 @@ export interface CourseSummaryData {
   dayOfWeek: string;
   recurrenceType: string;
   numberOfSessions: number;
-  completedSessions?: number;
   status?: string;
   publishedAt?: string | null;
   endDate?: string | null;

--- a/frontend/src/app/payments/payment.service.ts
+++ b/frontend/src/app/payments/payment.service.ts
@@ -20,6 +20,6 @@ export class PaymentService {
   private http = inject(HttpClient);
 
   getPayments(): Observable<Payment[]> {
-    return this.http.get<Payment[]>(`${environment.apiUrl}/api/me/payments`);
+    return this.http.get<Payment[]>(`${environment.apiUrl}/api/payments/me`);
   }
 }

--- a/frontend/src/app/payments/payments.spec.ts
+++ b/frontend/src/app/payments/payments.spec.ts
@@ -43,7 +43,7 @@ describe('PaymentsComponent', () => {
   });
 
   function flushPayments(payments: Payment[]): void {
-    httpTesting.expectOne(req => req.url.includes('/api/me/payments')).flush(payments);
+    httpTesting.expectOne(req => req.url.includes('/api/payments/me')).flush(payments);
   }
 
   it('shows loading state then renders the table when payments arrive', () => {
@@ -195,7 +195,7 @@ describe('PaymentsComponent', () => {
     markPaidReq.flush({ enrollmentId: 99, status: 'CONFIRMED' });
 
     // Refetch
-    httpTesting.expectOne(req => req.url.includes('/api/me/payments')).flush([]);
+    httpTesting.expectOne(req => req.url.includes('/api/payments/me')).flush([]);
   });
 
   it('Mark Paid error path shows snackbar and does not refetch', () => {
@@ -240,7 +240,7 @@ describe('PaymentsComponent', () => {
 
   it('shows error state when the payments request fails', () => {
     fixture.detectChanges();
-    httpTesting.expectOne(req => req.url.includes('/api/me/payments'))
+    httpTesting.expectOne(req => req.url.includes('/api/payments/me'))
       .flush({ detail: 'oops' }, { status: 500, statusText: 'Server Error' });
     fixture.detectChanges();
 


### PR DESCRIPTION
## Summary
Acts on the validated findings from #318. Five misclassifications in that issue were dismissed (documented in the issue thread); the real problems are fixed here. Plus one follow-on: tighten `anyRequest()` to `authenticated()` as a fail-safe default.

- **Dead code:** delete `StudentService.findAllBySchool` + repo method (zero callers)
- **Remove `deriveCompletedSessions`** end-to-end — `"Session X/Y"` display dropped from course summary (user-approved)
- **Logging:** `UserService` onboarding event moved to the dedicated `business` logger (can't use `@BusinessOperation` because `findOrCreateByFirebaseUid` fires on every request)
- **Payments URL:** `/api/me/payments` → `/api/payments/me` for `/me`-suffix consistency (updated tests + frontend caller)
- **SecurityConfig hygiene:**
  - Drop `/uploads/**` matcher from prod (endpoint is `@Profile("!prod")`)
  - Flip `anyRequest().permitAll()` → `authenticated()`; permit `/error` explicitly. Any future endpoint added outside `/api/**` is now denied by default instead of silently public.

Closes #318.

## Test plan
- [x] Backend: `./mvnw test` — 235/235 pass
- [x] Frontend: `npx ng test --browsers chromium --no-watch` — 141/141 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)