### PR TITLE
Fix logging: restore PID, drop commons-logging conflict (#317)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -106,6 +106,12 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,18 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Adds schoolId/userId MDC keys (populated by TenantContextFilter) to every log line so log
-  aggregators can filter/group by tenant. Keys render empty for unauthenticated requests
-  (login, health, static resources) and for non-request threads (startup, shutdown).
+  Inherits Spring Boot's default logback config (pattern, colors, PID, thread, logger) and
+  only extends LOG_LEVEL_PATTERN to append [schoolId=… userId=…] from the MDC. Keys are
+  populated per-request by TenantContextFilter and render empty on non-request threads.
 -->
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-
-    <property name="CONSOLE_LOG_PATTERN"
-              value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([schoolId=%X{schoolId:-} userId=%X{userId:-}]){faint} %clr(${PID: }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
-
-    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
-
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-    </root>
+    <property name="LOG_LEVEL_PATTERN" value="%5p [schoolId=%X{schoolId:-} userId=%X{userId:-}]"/>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
 </configuration>


### PR DESCRIPTION
## Summary

Fixes #317 — two logging issues that show up on every startup and in tests:

- **`PID: _IS_UNDEFINED`** — `logback-spring.xml` had `${PID: }` (colon-space) instead of `${PID:- }` (colon-dash). Missing dash broke Logback's default-value resolution and the PID column never rendered. Not test-specific; showed in all runs.
- **commons-logging conflict** — `awssdk:s3` → `apache-client` → `httpclient` → `commons-logging:1.2` clashes with Spring Boot's `spring-jcl`. Triggered the "Standard Commons Logging discovery in action" warning on every boot.

## Approach

Rather than fix the `${PID: }` typo in place, took the opportunity to shrink the config. The old file hand-rolled the full `CONSOLE_LOG_PATTERN` just to inject tenant MDC. Now we include Spring Boot's `base.xml` and only override `LOG_LEVEL_PATTERN`:

```xml
<configuration>
    <property name="LOG_LEVEL_PATTERN" value="%5p [schoolId=%X{schoolId:-} userId=%X{userId:-}]"/>
    <include resource="org/springframework/boot/logging/logback/base.xml"/>
</configuration>
```

Everything else — timestamp format, colors, PID slot, thread, logger — comes from Spring Boot and stays in sync with upgrades.

For commons-logging, added an exclusion on the `s3` dependency.

## Output before/after

Before:
```
2026-04-20T16:10:50  INFO [schoolId= userId=] PID: _IS_UNDEFINED --- [main] ch.ruppen… : …
```

After:
```
2026-04-20T22:45:29  INFO [schoolId= userId=4] 463072 --- [main] ch.ruppen… : …
```

## Test plan

- [x] `./mvnw test` — 235/235 pass
- [x] Boot logs inspected: PID renders as actual process ID; `[schoolId=…]` populated during requests, empty on startup threads
- [x] `dependency:tree | grep commons-logging` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)