### PR TITLE
fix(courses): allow Next when all step controls are locked (#324)

### DIFF
--- a/frontend/src/app/courses/create/course-form.service.spec.ts
+++ b/frontend/src/app/courses/create/course-form.service.spec.ts
@@ -172,6 +172,86 @@ describe('CourseFormService.isFieldLocked (edit-tier signal)', () => {
   });
 });
 
+describe('CourseFormService.isStepValid', () => {
+  let service: CourseFormService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [CourseFormService] });
+    service = TestBed.inject(CourseFormService);
+  });
+
+  function populateWithTier(editTier: string): void {
+    service.populate({
+      title: 'T',
+      danceStyle: 'BACHATA',
+      level: 'BEGINNER',
+      courseType: 'PARTNER',
+      description: '',
+      startDate: '2030-01-01',
+      recurrenceType: 'WEEKLY',
+      numberOfSessions: 8,
+      startTime: '19:30',
+      endTime: '20:45',
+      location: 'Studio A',
+      teachers: '',
+      maxParticipants: 20,
+      roleBalanceThreshold: null,
+      priceModel: 'FIXED_COURSE',
+      price: 100,
+      editTier,
+    });
+  }
+
+  it('RESTRICTED tier: pricing step is valid even though all its controls are locked', () => {
+    // Regression: both priceModel and price are in LOCKED_IN_RESTRICTED, so the
+    // pricing FormGroup becomes DISABLED and `.valid` returns false. Without the
+    // disabled-aware check, Next on the Pricing step would be blocked for OPEN courses.
+    populateWithTier('RESTRICTED');
+    expect(service.form.controls.pricing.disabled).toBe(true);
+    expect(service.isStepValid(3)).toBe(true);
+  });
+
+  it('READ_ONLY tier: all steps are valid (every control disabled)', () => {
+    populateWithTier('READ_ONLY');
+    expect(service.isStepValid(0)).toBe(true);
+    expect(service.isStepValid(1)).toBe(true);
+    expect(service.isStepValid(2)).toBe(true);
+    expect(service.isStepValid(3)).toBe(true);
+  });
+
+  it('FULLY_EDITABLE tier: invalid group fails validity check', () => {
+    // Fresh form — all required fields empty.
+    expect(service.isStepValid(0)).toBe(false);
+    expect(service.isStepValid(3)).toBe(false);
+  });
+
+  it('RESTRICTED tier: all steps valid when editable fields are filled', () => {
+    populateWithTier('RESTRICTED');
+    expect(service.isStepValid(0)).toBe(true);
+    expect(service.isStepValid(1)).toBe(true);
+    expect(service.isStepValid(2)).toBe(true);
+    expect(service.isStepValid(3)).toBe(true);
+  });
+
+  it('RESTRICTED tier: Details step is invalid when editable title is cleared', () => {
+    populateWithTier('RESTRICTED');
+    service.form.controls.details.controls.title.setValue('');
+    expect(service.isStepValid(0)).toBe(false);
+  });
+
+  it('RESTRICTED tier: Schedule step is invalid when editable location is cleared', () => {
+    populateWithTier('RESTRICTED');
+    service.form.controls.schedule.controls.location.setValue('');
+    expect(service.isStepValid(1)).toBe(false);
+  });
+
+  it('RESTRICTED tier: Registration step is invalid when maxParticipants is cleared', () => {
+    populateWithTier('RESTRICTED');
+    service.form.controls.registration.controls.maxParticipants.setValue(null);
+    expect(service.isStepValid(2)).toBe(false);
+  });
+});
+
 describe('CourseFormService role-balancing toggle', () => {
   let service: CourseFormService;
 

--- a/frontend/src/app/courses/create/course-form.service.ts
+++ b/frontend/src/app/courses/create/course-form.service.ts
@@ -67,7 +67,9 @@ export class CourseFormService {
   isStepValid(index: number): boolean {
     const group = this.stepGroups[index];
     if (!group) return true; // Review step is always "valid"
-    return group.valid;
+    // A group with all children disabled has status DISABLED (and `valid === false`),
+    // but the user has nothing to fix — treat it as valid so the stepper can advance.
+    return group.valid || group.disabled;
   }
 
   markStepTouched(index: number): void {


### PR DESCRIPTION
## Summary

- On an OPEN course (RESTRICTED tier), every control on the **Pricing** step (`priceModel`, `price`) is locked. Disabled children make the FormGroup's status `DISABLED`, so `group.valid` returns `false`, `next()` short-circuits, and users can't reach the Review step to save their edits.
- Fix: treat a fully-disabled FormGroup as a valid step in `CourseFormService.isStepValid`. The check is generic — if editable/locked field lists ever shift and another step ends up with all controls locked, Next will still work.
- Added unit tests covering: Pricing valid under RESTRICTED, all steps valid under READ_ONLY, and (regression guard) validity still gated by editable required fields when only some controls are locked.

Closes #324

## Test plan

- [x] `npx ng test --browsers chromium --no-watch` — 155 tests pass
- [ ] Open an OPEN course → Edit → advance through wizard → Next clickable on Pricing step → Save works
- [ ] Open a DRAFT course (FULLY_EDITABLE) → clearing a required field still blocks Next

🤖 Generated with [Claude Code](https://claude.com/claude-code)