### PR TITLE
Course Detail: merge Enrolled + Open Payment tabs; polish Approve chip (#323)

### DIFF
--- a/docs/TESTING_WORKFLOWS.md
+++ b/docs/TESTING_WORKFLOWS.md
@@ -21,7 +21,7 @@ Seed content (courses, students, enrollments, statuses) is defined in [`backend/
 **How to test:** In **Dev Tools**, pick a course and click "Add Student". For PARTNER courses, pick Leader or Follower with the role dropdown first.
 
 **Expected:**
-- On a BEGINNER/STARTER course with spare capacity → new enrollment lands in **Open Payment** tab (status `PENDING_PAYMENT`)
+- On a BEGINNER/STARTER course with spare capacity → new enrollment lands in the **Enrolled** tab as `PENDING_PAYMENT` (shown with a "Mark Paid" button)
 - On an INTERMEDIATE+ course → new enrollment lands in **Approve** tab (status `PENDING_APPROVAL`) because Dev Tools' generated students have no dance levels
 - Role selector is harmless for SOLO courses (the value is ignored)
 - The Course Overview tab counts update
@@ -36,7 +36,7 @@ Seed content (courses, students, enrollments, statuses) is defined in [`backend/
 
 **Expected:**
 - Students are created and enrolled sequentially until capacity is reached (alternating LEAD/FOLLOW for PARTNER courses)
-- All enrollments land in **Open Payment** (`PENDING_PAYMENT`)
+- All enrollments land in the **Enrolled** tab as `PENDING_PAYMENT` (each row has a "Mark Paid" button)
 - Clicking "Fill Course" on an already-full course shows the "Course is already full" snack bar
 - Trying "Add Student" on a full course sends the new enrollment to **Waitlist** with reason `CAPACITY` (see waitlist flow below)
 
@@ -50,12 +50,12 @@ Seed content (courses, students, enrollments, statuses) is defined in [`backend/
 
 **How to test (bulk, via Dev Tools):** Select a course with pending payments and click "Simulate Payment" to confirm all at once.
 
-**How to test (individual, via Course Overview):** Open a course → **Open Payment** tab → click "Mark Paid" on a row.
+**How to test (individual, via Course Overview):** Open a course → **Enrolled** tab → click "Mark Paid" on a `PENDING_PAYMENT` row.
 
 **Expected:**
-- Payment confirmation moves rows from **Open Payment** (`PENDING_PAYMENT`) → **Enrolled** (`CONFIRMED`)
+- Payment confirmation flips the row from `PENDING_PAYMENT` to `CONFIRMED` in place on the **Enrolled** tab
 - The Course Overview tab counts update
-- The **Enrolled** tab shows a Paid date on the row; Open Payment entries without an `approvedAt` show a "Mark Paid" button
+- On the **Enrolled** tab, `CONFIRMED` rows show the Paid date; `PENDING_PAYMENT` rows show a "Mark Paid" button in the same column
 
 ---
 
@@ -73,7 +73,7 @@ Seed content (courses, students, enrollments, statuses) is defined in [`backend/
 1. Use the seeded Salsa Advanced course (already has 2 PENDING_APPROVAL rows), **or** go to Dev Tools and Add Student to any INTERMEDIATE+ course
 2. Open the course → **Approve** tab → use the ✔ (approve) or ✖ (reject) icon buttons
 3. On approve: the student's dance level is upserted (registered if missing, upgraded if lower), then the enrollment re-checks capacity:
-   - Space available → `PENDING_PAYMENT` (moves to Open Payment tab)
+   - Space available → `PENDING_PAYMENT` (moves to Enrolled tab, shown with "Mark Paid" button)
    - Course full → `WAITLISTED` with reason `CAPACITY` (moves to Waitlist tab)
 4. On reject: enrollment becomes `REJECTED` and disappears from the Approve tab
 
@@ -128,10 +128,9 @@ Seed content (courses, students, enrollments, statuses) is defined in [`backend/
 
 | # | Tab | Shows | Last-column content |
 |---|---|---|---|
-| 0 | **Enrolled** | `CONFIRMED` rows only | Paid date |
+| 0 | **Enrolled** | `CONFIRMED` + `PENDING_PAYMENT` rows | Paid date for `CONFIRMED`, "Mark Paid" button for `PENDING_PAYMENT` |
 | 1 | **Waitlist** | `WAITLISTED` rows | Position chip + reason chip (Capacity / Role imbalance) |
-| 2 | **Approve** | `PENDING_APPROVAL` rows | Level chip + approve/reject icon buttons |
-| 3 | **Open Payment** | `PENDING_PAYMENT` rows | Approved-on date, or "Mark Paid" button if never approved |
+| 2 | **Approve** | `PENDING_APPROVAL` rows | Approval-reason chip (the student's dance level, or "No level" if unset) + approve/reject icon buttons |
 
 - Every tab shows a count badge next to the label
 - PARTNER course rows show a role chip in the Role column; SOLO course rows show "—"
@@ -158,8 +157,8 @@ Seed content (courses, students, enrollments, statuses) is defined in [`backend/
 **How to test:**
 1. Dev Tools → pick "Bachata Beginners" (empty, PARTNER, BEGINNER) → add one LEAD and one FOLLOW
 2. Simulate Payment → both move to **Enrolled**
-3. Add one more student (any role) → new row in **Open Payment**
-4. Open Payment tab → click "Mark Paid" → row moves to **Enrolled**
+3. Add one more student (any role) → new `PENDING_PAYMENT` row appears on the **Enrolled** tab with a "Mark Paid" button
+4. Click "Mark Paid" on that row → it flips to `CONFIRMED` in place (the Paid date replaces the button)
 5. Fill Course → remaining seats fill up with `PENDING_PAYMENT` rows
 6. Add one more student → lands on **Waitlist** (Capacity)
 

--- a/frontend/src/app/courses/overview/course-overview.html
+++ b/frontend/src/app/courses/overview/course-overview.html
@@ -87,13 +87,21 @@
                   @switch (activeTabIndex()) {
                     @case (0) { Paid }
                     @case (1) { Waitlist }
-                    @case (2) { Level }
+                    @case (2) { Approval Reason }
                     @default { }
                   }
                 </th>
                 <td mat-cell *matCellDef="let row">
                   @switch (activeTabIndex()) {
-                    @case (0) { {{ formatEnrollmentDate(row.paidAt) }} }
+                    @case (0) {
+                      @if (row.status === 'PENDING_PAYMENT') {
+                        <button mat-stroked-button class="mark-paid-button" (click)="onMarkPaid(row.id)">
+                          Mark Paid
+                        </button>
+                      } @else {
+                        {{ formatEnrollmentDate(row.paidAt) }}
+                      }
+                    }
                     @case (1) {
                       <div class="waitlist-cell">
                         <span class="ds-chip ds-chip-default">#{{ row.waitlistPosition }}</span>
@@ -119,11 +127,6 @@
                         </div>
                       </div>
                     }
-                    @case (3) {
-                      <button mat-stroked-button class="mark-paid-button" (click)="onMarkPaid(row.id)">
-                        Mark Paid
-                      </button>
-                    }
                   }
                 </td>
               </ng-container>
@@ -135,7 +138,6 @@
                     @case (0) { No enrolled students yet }
                     @case (1) { No students on the waitlist }
                     @case (2) { No students pending approval }
-                    @case (3) { No students with open payments }
                   }
                 </td>
               </tr>

--- a/frontend/src/app/courses/overview/course-overview.spec.ts
+++ b/frontend/src/app/courses/overview/course-overview.spec.ts
@@ -231,30 +231,76 @@ describe('CourseOverviewComponent', () => {
 
       httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
     });
-  });
 
-  describe('Open Payment tab', () => {
-    it('renders Mark Paid button for approved-then-pending-payment enrollments (approvedAt set)', () => {
+    it('shows "Approval Reason" as the last-column header', () => {
       fixture.detectChanges();
-      flushCourseWithEnrollments([
-        makeEnrollment({
-          id: 50, studentName: 'Paid Me', status: 'PENDING_PAYMENT',
-          approvedAt: '2026-04-15T12:00:00Z', paidAt: null,
-        }),
-      ]);
+      flushCourseWithEnrollments([makeEnrollment()]);
       fixture.detectChanges();
 
       const tabLinks = el.querySelectorAll('a[mat-tab-link]');
-      (tabLinks[3] as HTMLElement).click();
+      (tabLinks[2] as HTMLElement).click();
       fixture.detectChanges();
 
-      const row = el.querySelector('tr[mat-row]');
-      expect(row).toBeTruthy();
-      expect(row?.textContent).toContain('Paid Me');
+      const headers = Array.from(el.querySelectorAll('th[mat-header-cell]')).map(h => h.textContent?.trim());
+      expect(headers).toContain('Approval Reason');
+    });
 
-      const markPaidBtn = row?.querySelector('.mark-paid-button') as HTMLButtonElement;
+    it('uses ds-chip-warning for STARTER level', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([makeEnrollment({ studentDanceLevel: 'STARTER' })]);
+      fixture.detectChanges();
+
+      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
+      (tabLinks[2] as HTMLElement).click();
+      fixture.detectChanges();
+
+      const levelChip = el.querySelector('tr[mat-row] .approve-cell .ds-chip');
+      expect(levelChip?.textContent?.trim()).toBe('Starter');
+      expect(levelChip?.classList.contains('ds-chip-warning')).toBe(true);
+    });
+  });
+
+  describe('Enrolled tab', () => {
+    it('lists CONFIRMED and PENDING_PAYMENT rows together', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([
+        makeEnrollment({ id: 1, studentName: 'Confirmed Student', status: 'CONFIRMED', paidAt: '2026-04-12T10:00:00Z' }),
+        makeEnrollment({ id: 2, studentName: 'Unpaid Student', status: 'PENDING_PAYMENT', approvedAt: '2026-04-15T12:00:00Z', paidAt: null }),
+      ]);
+      fixture.detectChanges();
+
+      // Enrolled tab is the default (index 0)
+      const rows = el.querySelectorAll('tr[mat-row]');
+      expect(rows.length).toBe(2);
+      expect(rows[0].textContent).toContain('Confirmed Student');
+      expect(rows[1].textContent).toContain('Unpaid Student');
+    });
+
+    it('shows paidAt date for CONFIRMED rows and Mark Paid button for PENDING_PAYMENT rows', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([
+        makeEnrollment({ id: 1, studentName: 'Confirmed Student', status: 'CONFIRMED', paidAt: '2026-04-12T10:00:00Z' }),
+        makeEnrollment({ id: 2, studentName: 'Unpaid Student', status: 'PENDING_PAYMENT', approvedAt: '2026-04-15T12:00:00Z', paidAt: null }),
+      ]);
+      fixture.detectChanges();
+
+      const rows = el.querySelectorAll('tr[mat-row]');
+      // Confirmed row has a date, no Mark Paid button
+      expect(rows[0].querySelector('.mark-paid-button')).toBeFalsy();
+      expect(rows[0].textContent).toContain('Apr');
+      // Pending payment row has a Mark Paid button
+      const markPaidBtn = rows[1].querySelector('.mark-paid-button') as HTMLButtonElement;
       expect(markPaidBtn).toBeTruthy();
       expect(markPaidBtn.textContent?.trim()).toBe('Mark Paid');
+    });
+
+    it('shows "Paid" as the last-column header', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([makeEnrollment({ status: 'CONFIRMED' })]);
+      fixture.detectChanges();
+
+      const headers = Array.from(el.querySelectorAll('th[mat-header-cell]')).map(h => h.textContent?.trim());
+      expect(headers).toContain('Paid');
     });
 
     it('calls markPaid endpoint and refreshes list when Mark Paid clicked', () => {
@@ -262,10 +308,6 @@ describe('CourseOverviewComponent', () => {
       flushCourseWithEnrollments([
         makeEnrollment({ id: 99, status: 'PENDING_PAYMENT', approvedAt: '2026-04-15T12:00:00Z' }),
       ]);
-      fixture.detectChanges();
-
-      const tabLinks = el.querySelectorAll('a[mat-tab-link]');
-      (tabLinks[3] as HTMLElement).click();
       fixture.detectChanges();
 
       const markPaidBtn = el.querySelector('.mark-paid-button') as HTMLButtonElement;
@@ -277,6 +319,16 @@ describe('CourseOverviewComponent', () => {
       markPaidReq.flush({ enrollmentId: 99, status: 'CONFIRMED' });
 
       httpTesting.expectOne(req => req.url.includes('/api/courses/1/enrollments')).flush([]);
+    });
+
+    it('renders exactly three tabs (Enrolled, Waitlist, Approve)', () => {
+      fixture.detectChanges();
+      flushCourseWithEnrollments([]);
+      fixture.detectChanges();
+
+      const tabLabels = Array.from(el.querySelectorAll('a[mat-tab-link] .ds-tab-label'))
+        .map(e => e.textContent?.trim());
+      expect(tabLabels).toEqual(['Enrolled', 'Waitlist', 'Approve']);
     });
   });
 

--- a/frontend/src/app/courses/overview/course-overview.ts
+++ b/frontend/src/app/courses/overview/course-overview.ts
@@ -25,7 +25,6 @@ const ENROLLMENT_TABS: EnrollmentTab[] = [
   { label: 'Enrolled', key: 'CONFIRMED' },
   { label: 'Waitlist', key: 'WAITLISTED' },
   { label: 'Approve', key: 'PENDING_APPROVAL' },
-  { label: 'Open Payment', key: 'PENDING_PAYMENT' },
 ];
 
 @Component({
@@ -58,19 +57,16 @@ export class CourseOverviewComponent implements OnInit {
   protected readonly enrollmentColumns = ['name', 'phone', 'role', 'status', 'enrolledAt', 'lastColumn'];
 
   protected enrolledList = computed(() =>
-    this.enrollments().filter(e => e.status === 'CONFIRMED'));
+    this.enrollments().filter(e => e.status === 'CONFIRMED' || e.status === 'PENDING_PAYMENT'));
   protected waitlistList = computed(() =>
     this.enrollments().filter(e => e.status === 'WAITLISTED'));
   protected approveList = computed(() =>
     this.enrollments().filter(e => e.status === 'PENDING_APPROVAL'));
-  protected openPaymentList = computed(() =>
-    this.enrollments().filter(e => e.status === 'PENDING_PAYMENT'));
 
   protected tabCounts = computed(() => [
     this.enrolledList().length,
     this.waitlistList().length,
     this.approveList().length,
-    this.openPaymentList().length,
   ]);
 
   protected activeTabData = computed(() => {
@@ -78,7 +74,6 @@ export class CourseOverviewComponent implements OnInit {
       case 0: return this.enrolledList();
       case 1: return this.waitlistList();
       case 2: return this.approveList();
-      case 3: return this.openPaymentList();
       default: return [];
     }
   });

--- a/frontend/src/app/courses/shared/format-utils.spec.ts
+++ b/frontend/src/app/courses/shared/format-utils.spec.ts
@@ -109,8 +109,11 @@ describe('levelChipClass', () => {
     expect(levelChipClass('ADVANCED')).toBe('ds-chip-success');
   });
 
-  it('maps STARTER and null to default', () => {
-    expect(levelChipClass('STARTER')).toBe('ds-chip-default');
+  it('maps STARTER to warning', () => {
+    expect(levelChipClass('STARTER')).toBe('ds-chip-warning');
+  });
+
+  it('maps null to default', () => {
     expect(levelChipClass(null)).toBe('ds-chip-default');
   });
 });

--- a/frontend/src/app/courses/shared/format-utils.ts
+++ b/frontend/src/app/courses/shared/format-utils.ts
@@ -39,11 +39,11 @@ export function statusChipClass(status: string): string {
 /** Map a dance level to its chip class. Null → neutral "No level" variant. */
 export function levelChipClass(level: string | null): string {
   switch (level) {
+    case 'STARTER': return 'ds-chip-warning';
     case 'BEGINNER': return 'ds-chip-info';
     case 'INTERMEDIATE': return 'ds-chip-primary';
     case 'ADVANCED': return 'ds-chip-success';
     case 'MASTERCLASS': return 'ds-chip-primary';
-    case 'STARTER':
     default: return 'ds-chip-default';
   }
 }

--- a/frontend/src/styles/_table.scss
+++ b/frontend/src/styles/_table.scss
@@ -189,6 +189,11 @@
   color: var(--ds-chip-info);
 }
 
+.ds-chip-warning {
+  background: var(--ds-chip-warning-container);
+  color: var(--ds-chip-warning);
+}
+
 .ds-chip-default {
   background: var(--mat-sys-surface-variant);
   color: var(--mat-sys-on-surface-variant);

--- a/frontend/src/styles/_tokens.scss
+++ b/frontend/src/styles/_tokens.scss
@@ -65,6 +65,8 @@
   --ds-chip-primary-container: #eae0fc;
   --ds-chip-info: #d18519;
   --ds-chip-info-container: #fcefd8;
+  --ds-chip-warning: #b54708;
+  --ds-chip-warning-container: #fef0c7;
 
   // ── Shadows ──
   --ds-shadow-sm: 0 2px 4px rgb(0 0 0 / 0.1);


### PR DESCRIPTION
Closes #323

## Summary
- Merge **Open Payment** into **Enrolled** — course detail now shows 3 tabs. The `Paid` column renders `paidAt` for CONFIRMED rows and a `Mark Paid` button for PENDING_PAYMENT rows, so payment confirmation stays one click away without a dedicated tab.
- Rename the Approve tab's last-column header **Level → Approval Reason** (the chip already communicates *why* approval is needed).
- Give STARTER a distinct `ds-chip-warning` (amber) so every level has a colorful chip. Null stays `ds-chip-default` (gray) intentionally — "No level" represents unset/unknown data.
- Update `docs/TESTING_WORKFLOWS.md` to drop the old 4-tab layout references.

## Test plan
- [x] `npx ng test --browsers chromium --no-watch` — 154 tests pass (added Enrolled-tab merge, header rename, and STARTER-chip coverage)
- [x] `npx ng build` — clean
- [x] Playwright visual check on seeded data:
  - Salsa Solo (CONFIRMED + PENDING_PAYMENT) → 3 tabs, Mark Paid button inline with paid dates
  - Salsa Advanced (PENDING_APPROVAL) → "Approval Reason" header, Intermediate chip (primary purple) + "No level" chip (gray default)