### PR TITLE
Code reviewer: use git -C to skip cd permission prompts

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -10,23 +10,26 @@ You are a staff engineer reviewing a diff before it is committed. Your job is to
 
 The invoker will give you:
 - **Issue number** — fetch with `gh issue view <N> --comments`
+- **Worktree path** — absolute or repo-relative path to the worktree holding the diff (e.g. `.claude/worktrees/fix-foo`)
 - **One-line summary** of the chosen approach (only present for non-trivial issues)
 
-If the issue number is missing, ask before proceeding.
+If the issue number or worktree path is missing, ask before proceeding.
 
 ## Procedure
 
+Use `git -C <worktree-path>` for every git command. Do NOT `cd` — it's not needed and triggers permission prompts. For Read/Grep/Glob, pass the full path (prefix with the worktree path when inspecting files in the diff).
+
 1. **Read the issue** so you know what success looks like.
-2. **Read the diff in full** with `git diff origin/main...HEAD` from the current working directory (you are already in the worktree the implementer used). Also run `git status` to catch untracked files that should have been added.
-3. **Load conventions** — read these for project rules:
-   - `CLAUDE.md` (root)
-   - `frontend/CLAUDE.md` — only if the diff touches `frontend/`
-   - `backend/src/CLAUDE.md` — only if the diff touches `backend/`
-   - `docs/GLOSSARY.md` — for domain terminology
-   - `.claude/rules/product-roadmap.md` — **read the Phase 1 assumptions section**; do not flag deliberately deferred work
+2. **Read the diff in full** with `git -C <worktree-path> diff origin/main...HEAD`. Also run `git -C <worktree-path> status` to catch untracked files that should have been added.
+3. **Load conventions** — read these from the worktree for project rules:
+   - `<worktree-path>/CLAUDE.md` (root)
+   - `<worktree-path>/frontend/CLAUDE.md` — only if the diff touches `frontend/`
+   - `<worktree-path>/backend/src/CLAUDE.md` — only if the diff touches `backend/`
+   - `<worktree-path>/docs/GLOSSARY.md` — for domain terminology
+   - `<worktree-path>/.claude/rules/product-roadmap.md` — **read the Phase 1 assumptions section**; do not flag deliberately deferred work
 4. **Conditionally load:**
-   - `docs/TECH_DEBT.md` if the diff touches Course domain, repositories, or enrollment counts — known shortcuts there are not bugs
-   - `.claude/rules/figma-design-system.md` if the diff includes Figma-derived UI work
+   - `<worktree-path>/docs/TECH_DEBT.md` if the diff touches Course domain, repositories, or enrollment counts — known shortcuts there are not bugs
+   - `<worktree-path>/.claude/rules/figma-design-system.md` if the diff includes Figma-derived UI work
 5. **Review.** For each finding, locate the exact `file:line`.
 6. **Return the report** in the format below. Do not edit files. Do not commit.
 

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -55,9 +55,8 @@ Skip for trivial issues (same heuristic as Phase 2). For everything else:
 
 1. **Invoke the reviewer:** Use the `Agent` tool with `subagent_type: code-reviewer`. Pass:
    - The issue number
+   - The absolute worktree path (e.g. `/home/leon_/projects/danceschool/.claude/worktrees/<name>`) — the reviewer uses `git -C <path>` instead of `cd`, so this is required
    - A one-line summary of the chosen approach (from the Phase 2 plan)
-
-   The subagent inherits this worktree, so it diffs `origin/main...HEAD` itself — don't pass the branch name.
 
 2. **Triage the findings:**
    - **Blockers** — fix, then re-invoke the reviewer on the updated diff


### PR DESCRIPTION
## Summary
- `code-reviewer` agent now requires a worktree path from the invoker and uses `git -C <path>` for every git call, avoiding the `cd` permission prompt that fired every invocation when the subagent didn't start in the worktree cwd.
- `/start-issue` Phase 4.5 updated to pass the absolute worktree path when invoking the reviewer.

## Test plan
- [x] Smoke-tested end-to-end: created a throwaway worktree, planted a WHAT-comment, invoked `code-reviewer` via the `Agent` tool with the new inputs. No `cd` prompts; agent ran `git -C …`, loaded conventions from worktree paths, and correctly flagged the planted comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)