### PR TITLE
Relax Phase 4 visual verification trigger; clarify scope

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -24,7 +24,9 @@ Implement the changes according to the plan (or directly for trivial issues). Fo
 
 ## Phase 4 — Visual Verification End to End
 
-**Always run this for frontend changes.** Skip only if the issue is purely backend with no UI impact.
+**Run this for non-trivial frontend changes.** Skip if the issue is purely backend with no UI impact, or if the frontend change is trivial (copy tweak, single-line style fix, etc.).
+
+Scope: visual correctness only — do not log in as a second owner to check tenant isolation (that belongs in backend tests).
 
 Multiple worktrees may run visual tests in parallel — using a random port avoids backend port conflicts.
 


### PR DESCRIPTION
## Summary
- Skip Phase 4 (Visual Verification) for trivial frontend changes, not just pure-backend work
- Clarify that Phase 4 is visual-correctness only — tenant isolation belongs in backend tests

## Test plan
- [x] Docs-only change to `.claude/commands/start-issue.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)