### PR TITLE
Students: add read-only detail page at /app/students/:id (#328)

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -21,6 +21,10 @@ export const routes: Routes = [
       { path: 'dashboard', loadComponent: () => import('./dashboard/dashboard').then(m => m.DashboardComponent) },
       { path: 'students', loadComponent: () => import('./students/students').then(m => m.StudentsComponent) },
       {
+        path: 'students/:id',
+        loadComponent: () => import('./students/detail/student-detail').then(m => m.StudentDetailComponent),
+      },
+      {
         path: 'my-school/edit',
         loadComponent: () => import('./my-school/edit/my-school-edit').then(m => m.MySchoolEditComponent),
         canDeactivate: [unsavedChangesGuard],

--- a/frontend/src/app/students/detail/student-detail.html
+++ b/frontend/src/app/students/detail/student-detail.html
@@ -1,0 +1,45 @@
+@if (!loading()) {
+  @let s = student();
+  @if (s) {
+    <div class="detail-header">
+      <a class="back-link" routerLink="/app/students">← Back to Students</a>
+      <h1 class="detail-title">{{ s.name }}</h1>
+    </div>
+
+    <div class="detail-card">
+      <h2 class="detail-card-title">Contact</h2>
+      <dl class="contact-grid">
+        <div class="contact-item">
+          <dt>Email</dt>
+          <dd>{{ s.email }}</dd>
+        </div>
+        <div class="contact-item">
+          <dt>Phone</dt>
+          <dd>{{ s.phoneNumber || '—' }}</dd>
+        </div>
+      </dl>
+    </div>
+
+    <div class="detail-card">
+      <h2 class="detail-card-title">Dance Levels</h2>
+      @if (s.danceLevels.length > 0) {
+        <ul class="dance-level-list">
+          @for (row of s.danceLevels; track row.danceStyle) {
+            <li class="dance-level-row">
+              <span class="dance-level-style">{{ row.danceStyle | titlecase }}</span>
+              <span class="ds-chip" [ngClass]="levelChipClass(row.level)">
+                {{ formatLevel(row.level) }}
+              </span>
+            </li>
+          }
+        </ul>
+      } @else {
+        <p class="dance-level-empty">No dance levels recorded for this student yet.</p>
+      }
+    </div>
+  }
+} @else {
+  <div class="loading">
+    <p>Loading student...</p>
+  </div>
+}

--- a/frontend/src/app/students/detail/student-detail.scss
+++ b/frontend/src/app/students/detail/student-detail.scss
@@ -1,0 +1,110 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-6);
+}
+
+.detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+}
+
+.back-link {
+  font: var(--mat-sys-label-large);
+  color: var(--mat-sys-primary);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.detail-title {
+  font: var(--mat-sys-headline-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.detail-card {
+  background: var(--mat-sys-surface);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: var(--ds-radius-lg);
+  padding: var(--ds-card-padding);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-4);
+}
+
+.detail-card-title {
+  font: var(--mat-sys-title-medium);
+  color: var(--mat-sys-on-surface);
+  margin: 0;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--ds-spacing-4);
+  margin: 0;
+}
+
+.contact-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-1);
+
+  dt {
+    font: var(--mat-sys-label-medium);
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  dd {
+    font: var(--mat-sys-body-large);
+    color: var(--mat-sys-on-surface);
+    margin: 0;
+  }
+}
+
+.dance-level-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-spacing-2);
+}
+
+.dance-level-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-spacing-4);
+  padding: var(--ds-spacing-3) 0;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.dance-level-style {
+  font: var(--mat-sys-body-large);
+  color: var(--mat-sys-on-surface);
+}
+
+.dance-level-empty {
+  font: var(--mat-sys-body-medium);
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--ds-spacing-24);
+  color: var(--mat-sys-on-surface-variant);
+  font: var(--mat-sys-body-large);
+}

--- a/frontend/src/app/students/detail/student-detail.spec.ts
+++ b/frontend/src/app/students/detail/student-detail.spec.ts
@@ -1,0 +1,138 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, ActivatedRoute, Router } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { vi } from 'vitest';
+import { StudentDetailComponent } from './student-detail';
+import { StudentDetail } from '../student.service';
+
+function makeStudent(overrides: Partial<StudentDetail> = {}): StudentDetail {
+  return {
+    id: 1,
+    name: 'Alice Anderson',
+    email: 'alice@example.com',
+    phoneNumber: '+41 79 000 00 00',
+    danceLevels: [
+      { danceStyle: 'SALSA', level: 'INTERMEDIATE' },
+      { danceStyle: 'BACHATA', level: 'BEGINNER' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('StudentDetailComponent', () => {
+  let fixture: ComponentFixture<StudentDetailComponent>;
+  let httpTesting: HttpTestingController;
+  let el: HTMLElement;
+
+  function setup(studentId = '1'): void {
+    TestBed.configureTestingModule({
+      imports: [StudentDetailComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => studentId } } },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(StudentDetailComponent);
+    httpTesting = TestBed.inject(HttpTestingController);
+    el = fixture.nativeElement;
+  }
+
+  afterEach(() => {
+    httpTesting?.verify();
+  });
+
+  function flushStudent(student: StudentDetail = makeStudent()): void {
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.endsWith(`/api/students/${student.id}`)).flush(student);
+    fixture.detectChanges();
+  }
+
+  it('shows loading state before the student request resolves', () => {
+    setup();
+    fixture.detectChanges();
+    expect(el.querySelector('.loading')).toBeTruthy();
+    httpTesting.expectOne(req => req.url.endsWith('/api/students/1')).flush(makeStudent());
+  });
+
+  it('renders name as H1 and email + phone', () => {
+    setup();
+    flushStudent(makeStudent({
+      name: 'Alice Anderson',
+      email: 'alice@example.com',
+      phoneNumber: '+41 79 000 00 00',
+    }));
+
+    expect(el.querySelector('h1.detail-title')?.textContent?.trim()).toBe('Alice Anderson');
+    const dds = Array.from(el.querySelectorAll('.contact-item dd')).map(n => n.textContent?.trim());
+    expect(dds).toEqual(['alice@example.com', '+41 79 000 00 00']);
+  });
+
+  it('renders em-dash for missing phone number', () => {
+    setup();
+    flushStudent(makeStudent({ phoneNumber: null }));
+
+    const dds = Array.from(el.querySelectorAll('.contact-item dd')).map(n => n.textContent?.trim());
+    expect(dds[1]).toBe('—');
+  });
+
+  it('renders a row per dance-level assignment with style + level chip', () => {
+    setup();
+    flushStudent(makeStudent({
+      danceLevels: [
+        { danceStyle: 'SALSA', level: 'INTERMEDIATE' },
+        { danceStyle: 'BACHATA', level: 'BEGINNER' },
+      ],
+    }));
+
+    const rows = Array.from(el.querySelectorAll('.dance-level-row'));
+    expect(rows.length).toBe(2);
+
+    const styles = rows.map(r => r.querySelector('.dance-level-style')?.textContent?.trim());
+    expect(styles).toEqual(['Salsa', 'Bachata']);
+
+    const chips = rows.map(r => r.querySelector('.ds-chip')?.textContent?.trim());
+    expect(chips).toEqual(['Intermediate', 'Beginner']);
+  });
+
+  it('renders the empty state when the student has no dance levels', () => {
+    setup();
+    flushStudent(makeStudent({ danceLevels: [] }));
+
+    expect(el.querySelector('.dance-level-list')).toBeNull();
+    expect(el.querySelector('.dance-level-empty')?.textContent?.trim())
+      .toBe('No dance levels recorded for this student yet.');
+  });
+
+  it('renders a back link to the students list', () => {
+    setup();
+    flushStudent();
+
+    const back = el.querySelector('a.back-link');
+    expect(back?.getAttribute('href')).toBe('/app/students');
+    expect(back?.textContent?.trim()).toBe('← Back to Students');
+  });
+
+  it('shows a snackbar and redirects to the list when the student is not accessible (404)', () => {
+    setup('99');
+    const snackBar = TestBed.inject(MatSnackBar);
+    const router = TestBed.inject(Router);
+    const snackOpen = vi.spyOn(snackBar, 'open');
+    const routerNavigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+    fixture.detectChanges();
+    httpTesting.expectOne(req => req.url.endsWith('/api/students/99'))
+      .flush({ detail: 'Student not found' }, { status: 404, statusText: 'Not Found' });
+    fixture.detectChanges();
+
+    expect(snackOpen).toHaveBeenCalledTimes(1);
+    expect(routerNavigate).toHaveBeenCalledWith(['/app/students']);
+  });
+});

--- a/frontend/src/app/students/detail/student-detail.ts
+++ b/frontend/src/app/students/detail/student-detail.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { NgClass, TitleCasePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { StudentDetail, StudentService } from '../student.service';
+import { formatLevel, levelChipClass } from '../../courses/shared/format-utils';
+import { extractErrorMessage } from '../../shared/error-utils';
+
+@Component({
+  selector: 'app-student-detail',
+  imports: [RouterLink, NgClass, TitleCasePipe, MatIconModule],
+  templateUrl: './student-detail.html',
+  styleUrl: './student-detail.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StudentDetailComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private snackBar = inject(MatSnackBar);
+  private studentService = inject(StudentService);
+  private destroyRef = inject(DestroyRef);
+
+  protected student = signal<StudentDetail | null>(null);
+  protected loading = signal(true);
+
+  protected levelChipClass = levelChipClass;
+  protected formatLevel = formatLevel;
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+    const parsed = id ? Number(id) : NaN;
+    if (!Number.isFinite(parsed)) {
+      this.router.navigate(['/app/students']);
+      return;
+    }
+
+    this.studentService.getStudent(parsed).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (data) => {
+        this.student.set(data);
+        this.loading.set(false);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.snackBar.open(extractErrorMessage(err, 'Failed to load student'), 'Close', {
+          duration: 5000, panelClass: 'snackbar-error',
+        });
+        this.router.navigate(['/app/students']);
+      },
+    });
+  }
+}

--- a/frontend/src/app/students/student.service.ts
+++ b/frontend/src/app/students/student.service.ts
@@ -11,11 +11,28 @@ export interface StudentListItem {
   activeCoursesCount: number;
 }
 
+export interface StudentDanceLevel {
+  danceStyle: string;
+  level: string;
+}
+
+export interface StudentDetail {
+  id: number;
+  name: string;
+  email: string;
+  phoneNumber: string | null;
+  danceLevels: StudentDanceLevel[];
+}
+
 @Injectable({ providedIn: 'root' })
 export class StudentService {
   private http = inject(HttpClient);
 
   getStudents(): Observable<StudentListItem[]> {
     return this.http.get<StudentListItem[]>(`${environment.apiUrl}/api/students`);
+  }
+
+  getStudent(id: number): Observable<StudentDetail> {
+    return this.http.get<StudentDetail>(`${environment.apiUrl}/api/students/${id}`);
   }
 }

--- a/frontend/src/app/students/students.html
+++ b/frontend/src/app/students/students.html
@@ -46,7 +46,7 @@
           </ng-container>
 
           <tr mat-header-row *matHeaderRowDef="columns; sticky: true"></tr>
-          <tr mat-row *matRowDef="let row; columns: columns;"></tr>
+          <tr mat-row *matRowDef="let row; columns: columns;" [routerLink]="['/app/students', row.id]" class="clickable-row"></tr>
         </table>
 
         <div class="ds-table-footer">


### PR DESCRIPTION
## Summary
- Adds `StudentDetailComponent` at `/app/students/:id` — name as H1, email + phone, dance-level chips, empty state.
- Extends `StudentService` with `getStudent(id)`; clicking a row in the Students list navigates to the detail page.
- Reuses `levelChipClass`/`formatLevel` from `courses/shared/format-utils` and the existing `ds-chip` + design-system tokens. No hardcoded spacing / colors / typography.
- Tenant isolation is enforced by the existing backend endpoint (`findByIdAndSchoolId` → 404); the frontend handles 404 with a snackbar + redirect to the list.
- Closes #328.

## Test plan
- [x] `ng build` passes
- [x] `ng test` passes (168 tests, 7 new component render tests including contact fields, chip rows, empty state, back link, and the 404 → snackbar+redirect path)
- [x] Visual verification in Playwright at 1440×900:
  - Clicked a student row → lands on `/app/students/:id`
  - Detail page renders H1 name, email, phone, and dance-level rows with chips (Anna Mueller: Salsa Intermediate, Bachata Beginner)
  - Empty state renders for a student with no levels (Jan de Vries)
  - Back link returns to the students list