### PR TITLE
Code reviewer: ignore stray untracked .png files

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -53,6 +53,7 @@ Use `git -C <worktree-path>` for every git command. Do NOT `cd` — it's not nee
 - Don't flag Phase 2 deferred work (multi-school, OWNER/TEACHER split, student login) as missing
 - Don't flag known tech-debt shortcuts as bugs
 - Don't be exhaustive on nits — top 3 max
+- Ignore stray untracked `.png` files in `git status` — these are leftover Playwright screenshots, not part of the diff
 
 ## Output format
 


### PR DESCRIPTION
## Summary
- Tell the code-reviewer agent to ignore stray untracked `.png` files in `git status` — they're leftover Playwright screenshots, not part of the diff

## Test plan
- [x] Docs-only change to `.claude/agents/code-reviewer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)