### PR TITLE
Students: auto-approve pending enrollments on dance-level raise

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentRepository.java
@@ -1,11 +1,13 @@
 package ch.ruppen.danceschool.enrollment;
 
+import ch.ruppen.danceschool.course.DanceStyle;
 import ch.ruppen.danceschool.payment.PaymentDto;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,6 +26,9 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     long countByCourseIdAndDanceRoleAndStatusIn(Long courseId, DanceRole danceRole, List<EnrollmentStatus> statuses);
 
     List<Enrollment> findByCourseIdAndStatusOrderByWaitlistPositionAsc(Long courseId, EnrollmentStatus status);
+
+    List<Enrollment> findByStudentIdAndStatusAndCourseDanceStyleIn(
+            Long studentId, EnrollmentStatus status, Collection<DanceStyle> styles);
 
     @Query("SELECT COUNT(e) FROM Enrollment e WHERE e.course.id = :courseId AND e.status = ch.ruppen.danceschool.enrollment.EnrollmentStatus.WAITLISTED")
     long countWaitlistedByCourse(@Param("courseId") Long courseId);

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentService.java
@@ -14,7 +14,7 @@ import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
 import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import ch.ruppen.danceschool.student.Student;
 import ch.ruppen.danceschool.student.StudentDanceLevel;
-import ch.ruppen.danceschool.student.StudentService;
+import ch.ruppen.danceschool.student.StudentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -42,7 +42,7 @@ public class EnrollmentService {
     private final EnrollmentRepository enrollmentRepository;
     private final SchoolService schoolService;
     private final CourseRepository courseRepository;
-    private final StudentService studentService;
+    private final StudentRepository studentRepository;
     private final SchoolMemberService schoolMemberService;
     private final Clock clock;
 
@@ -51,7 +51,8 @@ public class EnrollmentService {
     public EnrollmentResponseDto enrollStudent(Long userId, Long courseId, EnrollStudentDto dto) {
         School school = schoolService.findSchoolByMember(userId);
         Course course = loadCourseInSchool(courseId, school);
-        Student student = studentService.findStudentByIdAndSchool(dto.studentId(), school);
+        Student student = studentRepository.findByIdAndSchoolId(dto.studentId(), school.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Student", dto.studentId()));
 
         validateDanceRole(course, dto.danceRole());
         validateNoDuplicate(student.getId(), course.getId());

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
@@ -44,9 +44,9 @@ public class StudentController {
     }
 
     @PutMapping("/{id}/dance-levels")
-    public StudentDetailDto updateDanceLevels(@PathVariable Long id,
-                                              @Valid @RequestBody UpdateDanceLevelsDto dto,
-                                              @AuthenticationPrincipal AuthenticatedUser principal) {
+    public UpdateDanceLevelsResultDto updateDanceLevels(@PathVariable Long id,
+                                                        @Valid @RequestBody UpdateDanceLevelsDto dto,
+                                                        @AuthenticationPrincipal AuthenticatedUser principal) {
         return studentService.updateDanceLevels(principal.userId(), id, dto);
     }
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentRepository.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-interface StudentRepository extends JpaRepository<Student, Long> {
+public interface StudentRepository extends JpaRepository<Student, Long> {
 
     Optional<Student> findByIdAndSchoolId(Long id, Long schoolId);
 

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentService.java
@@ -1,6 +1,12 @@
 package ch.ruppen.danceschool.student;
 
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
 import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.enrollment.Enrollment;
+import ch.ruppen.danceschool.enrollment.EnrollmentRepository;
+import ch.ruppen.danceschool.enrollment.EnrollmentResponseDto;
+import ch.ruppen.danceschool.enrollment.EnrollmentService;
 import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.school.SchoolService;
@@ -13,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +33,8 @@ public class StudentService {
 
     private final StudentRepository studentRepository;
     private final SchoolService schoolService;
+    private final EnrollmentRepository enrollmentRepository;
+    private final EnrollmentService enrollmentService;
     private final Clock clock;
 
     @Transactional
@@ -72,7 +81,7 @@ public class StudentService {
 
     @Transactional
     @BusinessOperation(event = "StudentDanceLevelsUpdated")
-    public StudentDetailDto updateDanceLevels(Long userId, Long studentId, UpdateDanceLevelsDto dto) {
+    public UpdateDanceLevelsResultDto updateDanceLevels(Long userId, Long studentId, UpdateDanceLevelsDto dto) {
         School school = schoolService.findSchoolByMember(userId);
         Student student = studentRepository.findByIdAndSchoolId(studentId, school.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Student", studentId));
@@ -85,6 +94,16 @@ public class StudentService {
         Set<DanceStyle> incoming = dto.danceLevels().stream()
                 .map(UpdateDanceLevelsDto.DanceLevelEntry::danceStyle)
                 .collect(Collectors.toSet());
+
+        // Only a level that's added or raised can unblock a pending approval; tracking these up
+        // front lets us restrict the re-evaluation query to the enrollments actually affected.
+        Set<DanceStyle> raisedStyles = EnumSet.noneOf(DanceStyle.class);
+        for (UpdateDanceLevelsDto.DanceLevelEntry entry : dto.danceLevels()) {
+            StudentDanceLevel current = existing.get(entry.danceStyle());
+            if (current == null || entry.level().ordinal() > current.getLevel().ordinal()) {
+                raisedStyles.add(entry.danceStyle());
+            }
+        }
 
         student.getDanceLevels().removeIf(dl -> !incoming.contains(dl.getDanceStyle()));
 
@@ -101,13 +120,44 @@ public class StudentService {
             }
         }
 
-        return toDetailDto(student);
+        int autoConfirmedCount = autoConfirmPendingForRaisedStyles(userId, student, raisedStyles);
+
+        return new UpdateDanceLevelsResultDto(toDetailDto(student), autoConfirmedCount);
     }
 
-    @Transactional(readOnly = true)
-    public Student findStudentByIdAndSchool(Long studentId, School school) {
-        return studentRepository.findByIdAndSchoolId(studentId, school.getId())
-                .orElseThrow(() -> new ResourceNotFoundException("Student", studentId));
+    private int autoConfirmPendingForRaisedStyles(Long userId, Student student, Set<DanceStyle> raisedStyles) {
+        if (raisedStyles.isEmpty()) {
+            return 0;
+        }
+        List<Enrollment> candidates = enrollmentRepository.findByStudentIdAndStatusAndCourseDanceStyleIn(
+                student.getId(), EnrollmentStatus.PENDING_APPROVAL, raisedStyles);
+
+        int count = 0;
+        for (Enrollment enrollment : candidates) {
+            Course course = enrollment.getCourse();
+            CourseLevel newLevel = findLevel(student, course.getDanceStyle());
+            // Skip enrollments whose course still outranks the new level — those stay pending.
+            // Also guards approveEnrollment's upsertStudentDanceLevel from silently promoting
+            // the student past what the owner explicitly set.
+            if (newLevel == null || newLevel.ordinal() < course.getLevel().ordinal()) {
+                continue;
+            }
+            EnrollmentResponseDto result = enrollmentService.approveEnrollment(userId, enrollment.getId());
+            // WAITLISTED means the re-evaluation promoted the enrollment past approval but
+            // couldn't seat it (capacity/role-balance); not a user-visible "auto-confirmed".
+            if (EnrollmentStatus.SEAT_HOLDING_STATI.contains(result.status())) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private CourseLevel findLevel(Student student, DanceStyle style) {
+        return student.getDanceLevels().stream()
+                .filter(dl -> dl.getDanceStyle() == style)
+                .map(StudentDanceLevel::getLevel)
+                .findFirst()
+                .orElse(null);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/ch/ruppen/danceschool/student/UpdateDanceLevelsResultDto.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/UpdateDanceLevelsResultDto.java
@@ -1,0 +1,6 @@
+package ch.ruppen.danceschool.student;
+
+public record UpdateDanceLevelsResultDto(
+        StudentDetailDto student,
+        int autoConfirmedCount
+) {}

--- a/backend/src/test/java/ch/ruppen/danceschool/student/StudentCrudIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/student/StudentCrudIntegrationTest.java
@@ -1,6 +1,15 @@
 package ch.ruppen.danceschool.student;
 
 import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.course.Course;
+import ch.ruppen.danceschool.course.CourseLevel;
+import ch.ruppen.danceschool.course.CourseType;
+import ch.ruppen.danceschool.course.DanceStyle;
+import ch.ruppen.danceschool.course.PriceModel;
+import ch.ruppen.danceschool.course.RecurrenceType;
+import ch.ruppen.danceschool.enrollment.DanceRole;
+import ch.ruppen.danceschool.enrollment.Enrollment;
+import ch.ruppen.danceschool.enrollment.EnrollmentStatus;
 import ch.ruppen.danceschool.school.School;
 import ch.ruppen.danceschool.schoolmember.MemberRole;
 import ch.ruppen.danceschool.schoolmember.SchoolMember;
@@ -18,6 +27,12 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -151,9 +166,10 @@ class StudentCrudIntegrationTest {
                                 """)
                         .with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.danceLevels.length()").value(2))
-                .andExpect(jsonPath("$.danceLevels[?(@.danceStyle=='SALSA')].level").value("ADVANCED"))
-                .andExpect(jsonPath("$.danceLevels[?(@.danceStyle=='KIZOMBA')].level").value("STARTER"));
+                .andExpect(jsonPath("$.student.danceLevels.length()").value(2))
+                .andExpect(jsonPath("$.student.danceLevels[?(@.danceStyle=='SALSA')].level").value("ADVANCED"))
+                .andExpect(jsonPath("$.student.danceLevels[?(@.danceStyle=='KIZOMBA')].level").value("STARTER"))
+                .andExpect(jsonPath("$.autoConfirmedCount").value(0));
     }
 
     @Test
@@ -171,7 +187,8 @@ class StudentCrudIntegrationTest {
                                 """)
                         .with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.danceLevels.length()").value(0));
+                .andExpect(jsonPath("$.student.danceLevels.length()").value(0))
+                .andExpect(jsonPath("$.autoConfirmedCount").value(0));
     }
 
     @Test
@@ -194,10 +211,11 @@ class StudentCrudIntegrationTest {
                                 """)
                         .with(authentication(authToken(owner))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.danceLevels.length()").value(3))
-                .andExpect(jsonPath("$.danceLevels[?(@.danceStyle=='SALSA')].level").value("INTERMEDIATE"))
-                .andExpect(jsonPath("$.danceLevels[?(@.danceStyle=='BACHATA')].level").value("BEGINNER"))
-                .andExpect(jsonPath("$.danceLevels[?(@.danceStyle=='KIZOMBA')].level").value("STARTER"));
+                .andExpect(jsonPath("$.student.danceLevels.length()").value(3))
+                .andExpect(jsonPath("$.student.danceLevels[?(@.danceStyle=='SALSA')].level").value("INTERMEDIATE"))
+                .andExpect(jsonPath("$.student.danceLevels[?(@.danceStyle=='BACHATA')].level").value("BEGINNER"))
+                .andExpect(jsonPath("$.student.danceLevels[?(@.danceStyle=='KIZOMBA')].level").value("STARTER"))
+                .andExpect(jsonPath("$.autoConfirmedCount").value(0));
     }
 
     @Test
@@ -207,6 +225,157 @@ class StudentCrudIntegrationTest {
                         .content("""
                                 {
                                     "danceLevels": []
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateDanceLevels_raisingLevel_autoConfirmsPendingApproval() throws Exception {
+        Student student = createStudent("Anna Müller", "anna@example.com", null);
+        addDanceLevel(student, "SALSA", "BEGINNER");
+        Course advancedSalsa = createCourse("Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED);
+        Enrollment pending = createPendingApprovalEnrollment(student, advancedSalsa, DanceRole.LEAD);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/students/{id}/dance-levels", student.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "ADVANCED"}
+                                    ]
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.autoConfirmedCount").value(1));
+
+        entityManager.refresh(pending);
+        org.junit.jupiter.api.Assertions.assertEquals(
+                EnrollmentStatus.PENDING_PAYMENT, pending.getStatus());
+        org.junit.jupiter.api.Assertions.assertNotNull(pending.getApprovedAt());
+    }
+
+    @Test
+    void updateDanceLevels_loweringLevel_leavesEnrollmentsUnchanged() throws Exception {
+        Student student = createStudent("Anna Müller", "anna@example.com", null);
+        addDanceLevel(student, "SALSA", "INTERMEDIATE");
+        Course advancedSalsa = createCourse("Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED);
+        Enrollment pending = createPendingApprovalEnrollment(student, advancedSalsa, DanceRole.LEAD);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/students/{id}/dance-levels", student.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "BEGINNER"}
+                                    ]
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.autoConfirmedCount").value(0));
+
+        entityManager.refresh(pending);
+        org.junit.jupiter.api.Assertions.assertEquals(
+                EnrollmentStatus.PENDING_APPROVAL, pending.getStatus());
+        org.junit.jupiter.api.Assertions.assertNull(pending.getApprovedAt());
+    }
+
+    @Test
+    void updateDanceLevels_onlyTouchedStylesReEvaluated() throws Exception {
+        Student student = createStudent("Anna Müller", "anna@example.com", null);
+        addDanceLevel(student, "SALSA", "BEGINNER");
+        addDanceLevel(student, "BACHATA", "BEGINNER");
+        Course salsaAdvanced = createCourse("Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED);
+        Course bachataAdvanced = createCourse("Bachata Advanced", DanceStyle.BACHATA, CourseLevel.ADVANCED);
+        Enrollment salsaPending = createPendingApprovalEnrollment(student, salsaAdvanced, DanceRole.LEAD);
+        Enrollment bachataPending = createPendingApprovalEnrollment(student, bachataAdvanced, DanceRole.LEAD);
+        entityManager.flush();
+
+        // Raising only SALSA must flip exactly the Salsa enrollment; the Bachata pending
+        // stays untouched even though both started from identical BEGINNER levels.
+        mockMvc.perform(put("/api/students/{id}/dance-levels", student.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "ADVANCED"},
+                                        {"danceStyle": "BACHATA", "level": "BEGINNER"}
+                                    ]
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.autoConfirmedCount").value(1));
+
+        entityManager.refresh(salsaPending);
+        entityManager.refresh(bachataPending);
+        org.junit.jupiter.api.Assertions.assertEquals(
+                EnrollmentStatus.PENDING_PAYMENT, salsaPending.getStatus());
+        org.junit.jupiter.api.Assertions.assertEquals(
+                EnrollmentStatus.PENDING_APPROVAL, bachataPending.getStatus());
+    }
+
+    @Test
+    void updateDanceLevels_approveRoutedToWaitlist_doesNotCount() throws Exception {
+        Student student = createStudent("Anna Müller", "anna@example.com", null);
+        addDanceLevel(student, "SALSA", "BEGINNER");
+        Course fullCourse = createCourse("Salsa Advanced", DanceStyle.SALSA, CourseLevel.ADVANCED);
+        fullCourse.setMaxParticipants(1);
+        // Seat the only slot, so approving the pending enrollment will route to WAITLISTED
+        // (CAPACITY) rather than PENDING_PAYMENT — that must not count as auto-confirmed.
+        Student other = createStudent("Bob", "bob@example.com", null);
+        Enrollment seat = new Enrollment();
+        seat.setStudent(other);
+        seat.setCourse(fullCourse);
+        seat.setDanceRole(DanceRole.FOLLOW);
+        seat.setStatus(EnrollmentStatus.CONFIRMED);
+        seat.setEnrolledAt(Instant.now());
+        entityManager.persist(seat);
+        Enrollment pending = createPendingApprovalEnrollment(student, fullCourse, DanceRole.LEAD);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/students/{id}/dance-levels", student.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "ADVANCED"}
+                                    ]
+                                }
+                                """)
+                        .with(authentication(authToken(owner))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.autoConfirmedCount").value(0));
+
+        entityManager.flush();
+        entityManager.refresh(pending);
+        org.junit.jupiter.api.Assertions.assertEquals(
+                EnrollmentStatus.WAITLISTED, pending.getStatus());
+    }
+
+    @Test
+    void updateDanceLevels_crossTenant_returns404() throws Exception {
+        AppUser otherOwner = createUser("other@example.com", "Other", "firebase-other");
+        School otherSchool = createSchoolWithOwner("Other School", otherOwner);
+        Student otherStudent = new Student();
+        otherStudent.setSchool(otherSchool);
+        otherStudent.setName("Not Yours");
+        otherStudent.setEmail("notyours@example.com");
+        entityManager.persist(otherStudent);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/students/{id}/dance-levels", otherStudent.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "danceLevels": [
+                                        {"danceStyle": "SALSA", "level": "ADVANCED"}
+                                    ]
                                 }
                                 """)
                         .with(authentication(authToken(owner))))
@@ -254,10 +423,51 @@ class StudentCrudIntegrationTest {
     private void addDanceLevel(Student student, String style, String level) {
         StudentDanceLevel dl = new StudentDanceLevel();
         dl.setStudent(student);
-        dl.setDanceStyle(ch.ruppen.danceschool.course.DanceStyle.valueOf(style));
-        dl.setLevel(ch.ruppen.danceschool.course.CourseLevel.valueOf(level));
+        dl.setDanceStyle(DanceStyle.valueOf(style));
+        dl.setLevel(CourseLevel.valueOf(level));
         student.getDanceLevels().add(dl);
         entityManager.persist(dl);
+    }
+
+    private Course createCourse(String title, DanceStyle danceStyle, CourseLevel level) {
+        School school = entityManager.createQuery(
+                        "SELECT s FROM School s JOIN SchoolMember m ON m.school = s WHERE m.user = :user", School.class)
+                .setParameter("user", owner)
+                .getSingleResult();
+
+        Course c = new Course();
+        c.setSchool(school);
+        c.setTitle(title);
+        c.setDanceStyle(danceStyle);
+        c.setLevel(level);
+        c.setCourseType(CourseType.PARTNER);
+        c.setMaxParticipants(10);
+        c.setRoleBalanceThreshold(3);
+        c.setStartDate(LocalDate.now().plusWeeks(2));
+        c.setEndDate(LocalDate.now().plusWeeks(10));
+        c.setLocation("Studio A");
+        c.setTeachers("Test Teacher");
+        c.setStartTime(LocalTime.of(19, 0));
+        c.setEndTime(LocalTime.of(20, 0));
+        c.setDayOfWeek(DayOfWeek.MONDAY);
+        c.setRecurrenceType(RecurrenceType.WEEKLY);
+        c.setNumberOfSessions(8);
+        c.setPriceModel(PriceModel.FIXED_COURSE);
+        c.setPrice(new BigDecimal("200.00"));
+        c.setPublishedAt(LocalDate.now().minusDays(1));
+        entityManager.persist(c);
+        return c;
+    }
+
+    private Enrollment createPendingApprovalEnrollment(Student student, Course course, DanceRole role) {
+        Enrollment e = new Enrollment();
+        e.setStudent(student);
+        e.setCourse(course);
+        e.setDanceRole(role);
+        e.setStatus(EnrollmentStatus.PENDING_APPROVAL);
+        e.setEnrolledAt(Instant.now());
+        entityManager.persist(e);
+        return e;
     }
 
     private UsernamePasswordAuthenticationToken authToken(AppUser user) {

--- a/frontend/src/app/students/detail/student-detail.spec.ts
+++ b/frontend/src/app/students/detail/student-detail.spec.ts
@@ -5,7 +5,7 @@ import { provideHttpClientTesting, HttpTestingController } from '@angular/common
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { vi } from 'vitest';
 import { StudentDetailComponent } from './student-detail';
-import { StudentDetail } from '../student.service';
+import { StudentDetail, UpdateDanceLevelsResult } from '../student.service';
 
 function makeStudent(overrides: Partial<StudentDetail> = {}): StudentDetail {
   return {
@@ -19,6 +19,10 @@ function makeStudent(overrides: Partial<StudentDetail> = {}): StudentDetail {
     ],
     ...overrides,
   };
+}
+
+function makeUpdateResult(student: StudentDetail, autoConfirmedCount = 0): UpdateDanceLevelsResult {
+  return { student, autoConfirmedCount };
 }
 
 describe('StudentDetailComponent', () => {
@@ -184,12 +188,12 @@ describe('StudentDetailComponent', () => {
         { danceStyle: 'BACHATA', level: 'BEGINNER' },
       ],
     });
-    req.flush(makeStudent({
+    req.flush(makeUpdateResult(makeStudent({
       danceLevels: [
         { danceStyle: 'SALSA', level: 'ADVANCED' },
         { danceStyle: 'BACHATA', level: 'BEGINNER' },
       ],
-    }));
+    })));
   });
 
   it('Save sends appended rows (add-only)', () => {
@@ -212,12 +216,12 @@ describe('StudentDetailComponent', () => {
         { danceStyle: 'KIZOMBA', level: 'STARTER' },
       ],
     });
-    req.flush(makeStudent({
+    req.flush(makeUpdateResult(makeStudent({
       danceLevels: [
         { danceStyle: 'SALSA', level: 'INTERMEDIATE' },
         { danceStyle: 'KIZOMBA', level: 'STARTER' },
       ],
-    }));
+    })));
   });
 
   it('Save sends the merged set (mixed edit + add)', () => {
@@ -245,13 +249,13 @@ describe('StudentDetailComponent', () => {
         { danceStyle: 'ZOUK', level: 'BEGINNER' },
       ],
     });
-    req.flush(makeStudent({
+    req.flush(makeUpdateResult(makeStudent({
       danceLevels: [
         { danceStyle: 'SALSA', level: 'INTERMEDIATE' },
         { danceStyle: 'BACHATA', level: 'INTERMEDIATE' },
         { danceStyle: 'ZOUK', level: 'BEGINNER' },
       ],
-    }));
+    })));
   });
 
   it('Add-level is disabled once all 7 styles are assigned', () => {
@@ -317,13 +321,54 @@ describe('StudentDetailComponent', () => {
 
     const req = httpTesting.expectOne(r => r.url.endsWith('/api/students/1/dance-levels'));
     // Server trims/normalizes to a different set — UI must reflect the response, not the staged edits.
-    req.flush(makeStudent({
+    req.flush(makeUpdateResult(makeStudent({
       danceLevels: [{ danceStyle: 'SALSA', level: 'MASTERCLASS' }],
-    }));
+    })));
     fixture.detectChanges();
 
     expect(drive(component).edits()).toEqual([{ danceStyle: 'SALSA', level: 'MASTERCLASS' }]);
     expect(drive(component).hasValidChanges()).toBe(false);
+  });
+
+  it('Save success with autoConfirmedCount=0 shows the plain "Saved." snackbar', () => {
+    setup();
+    flushStudent(makeStudent({
+      danceLevels: [{ danceStyle: 'SALSA', level: 'INTERMEDIATE' }],
+    }));
+    const snackOpen = vi.spyOn(TestBed.inject(MatSnackBar), 'open');
+
+    drive(component).onLevelChange(0, 'ADVANCED');
+    drive(component).onSave();
+
+    httpTesting.expectOne(r => r.url.endsWith('/api/students/1/dance-levels'))
+      .flush(makeUpdateResult(makeStudent({
+        danceLevels: [{ danceStyle: 'SALSA', level: 'ADVANCED' }],
+      }), 0));
+    fixture.detectChanges();
+
+    expect(snackOpen).toHaveBeenCalledWith('Saved.', 'Close', expect.objectContaining({ duration: 3000 }));
+  });
+
+  it('Save success with autoConfirmedCount>0 surfaces the count in the snackbar', () => {
+    setup();
+    flushStudent(makeStudent({
+      danceLevels: [{ danceStyle: 'SALSA', level: 'BEGINNER' }],
+    }));
+    const snackOpen = vi.spyOn(TestBed.inject(MatSnackBar), 'open');
+
+    drive(component).onLevelChange(0, 'ADVANCED');
+    drive(component).onSave();
+
+    httpTesting.expectOne(r => r.url.endsWith('/api/students/1/dance-levels'))
+      .flush(makeUpdateResult(makeStudent({
+        danceLevels: [{ danceStyle: 'SALSA', level: 'ADVANCED' }],
+      }), 2));
+    fixture.detectChanges();
+
+    expect(snackOpen).toHaveBeenCalledTimes(1);
+    const message = snackOpen.mock.calls[0][0] as string;
+    expect(message).toContain('2');
+    expect(message.toLowerCase()).toContain('auto-confirmed');
   });
 
   it('shows an error snackbar on save failure and keeps staged edits', () => {

--- a/frontend/src/app/students/detail/student-detail.ts
+++ b/frontend/src/app/students/detail/student-detail.ts
@@ -117,10 +117,17 @@ export class StudentDetailComponent implements OnInit {
     this.studentService.updateDanceLevels(this.studentId, { danceLevels: payload })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (data) => {
-          this.applyStudent(data);
+        next: (result) => {
+          this.applyStudent(result.student);
           this.saving.set(false);
-          this.snackBar.open('Saved.', 'Close', { duration: 3000 });
+          // Drop focus so the last-edited mat-select doesn't linger in its focused/primary-colored
+          // state — combined with track $index on the list, the color can even bleed onto an
+          // unrelated row after the server reorders.
+          (document.activeElement as HTMLElement | null)?.blur();
+          const message = result.autoConfirmedCount > 0
+            ? `Saved. ${result.autoConfirmedCount} pending approval(s) auto-confirmed.`
+            : 'Saved.';
+          this.snackBar.open(message, 'Close', { duration: 3000 });
         },
         error: (err: HttpErrorResponse) => {
           this.saving.set(false);

--- a/frontend/src/app/students/student.service.ts
+++ b/frontend/src/app/students/student.service.ts
@@ -29,6 +29,11 @@ export interface UpdateDanceLevelsDto {
   danceLevels: StudentDanceLevel[];
 }
 
+export interface UpdateDanceLevelsResult {
+  student: StudentDetail;
+  autoConfirmedCount: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class StudentService {
   private http = inject(HttpClient);
@@ -41,7 +46,7 @@ export class StudentService {
     return this.http.get<StudentDetail>(`${environment.apiUrl}/api/students/${id}`);
   }
 
-  updateDanceLevels(id: number, dto: UpdateDanceLevelsDto): Observable<StudentDetail> {
-    return this.http.put<StudentDetail>(`${environment.apiUrl}/api/students/${id}/dance-levels`, dto);
+  updateDanceLevels(id: number, dto: UpdateDanceLevelsDto): Observable<UpdateDanceLevelsResult> {
+    return this.http.put<UpdateDanceLevelsResult>(`${environment.apiUrl}/api/students/${id}/dance-levels`, dto);
   }
 }


### PR DESCRIPTION
Closes #330.

## Summary
- When an owner raises a student's dance level, re-run the existing `EnrollmentService.approveEnrollment` against each PENDING_APPROVAL enrollment whose course style was touched by the edit and whose new level meets the course gate. Both flows now share the same state transitions (`approvedAt`, capacity/role-balance re-check, waitlist promote).
- The `PUT /api/students/{id}/dance-levels` response is wrapped: `{ student, autoConfirmedCount }`. The count increments only for seat-holding results (`PENDING_PAYMENT` / `CONFIRMED`) — `WAITLISTED` outcomes don't count because nothing seat-level changed for the user.
- Frontend snackbar: `"Saved. N pending approval(s) auto-confirmed."` when N > 0, else `"Saved."`.

## Design notes
- `EnrollmentService` previously depended on `StudentService` for a one-line lookup. Adding the reverse edge would create a cycle, so `EnrollmentService` now injects `StudentRepository` directly — no `@Lazy` ceremony needed.
- Re-evaluation is restricted to dance styles touched by the edit (tracked as an `EnumSet<DanceStyle>`) so unrelated pending enrollments stay untouched.

## Test plan
- [x] `StudentCrudIntegrationTest` — 15 tests green, including:
  - raising → auto-confirm + `PENDING_PAYMENT`
  - lowering → no-op
  - only touched styles re-evaluated (two identical BEGINNER→pending-ADVANCED, raise one)
  - approve routed to WAITLISTED (capacity) → `autoConfirmedCount=0`
  - cross-tenant update → 404
- [x] Full backend suite: 241 passed
- [x] Frontend unit tests: 179 passed (incl. two new snackbar tests)
- [x] Manual visual verification via Playwright (owner 1, two students) — snackbar renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)