### PR TITLE
Code review fixes: exception hierarchy + tokenize select widths

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/shared/error/CourseEditPolicyViolationException.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/error/CourseEditPolicyViolationException.java
@@ -2,7 +2,7 @@ package ch.ruppen.danceschool.shared.error;
 
 import java.util.List;
 
-public class CourseEditPolicyViolationException extends RuntimeException {
+public class CourseEditPolicyViolationException extends DomainRuleViolationException {
 
     private final String tier;
     private final List<String> rejectedFields;

--- a/frontend/src/app/students/detail/student-detail.scss
+++ b/frontend/src/app/students/detail/student-detail.scss
@@ -95,11 +95,11 @@
 }
 
 .dance-level-style-select {
-  width: 240px;
+  width: var(--ds-size-form-select-wide);
 }
 
 .dance-level-select {
-  width: 200px;
+  width: var(--ds-size-form-select);
   margin-left: auto;
 }
 

--- a/frontend/src/styles/_tokens.scss
+++ b/frontend/src/styles/_tokens.scss
@@ -41,6 +41,8 @@
   // ── Semantic size tokens ──
   --ds-size-step-indicator: 28px;
   --ds-size-filter-select: 150px;
+  --ds-size-form-select: 200px;
+  --ds-size-form-select-wide: 240px;
   --ds-form-field-dense-height: 36px;
 
   // ── Focus ring ──


### PR DESCRIPTION
## Summary
- `CourseEditPolicyViolationException` now extends `DomainRuleViolationException` so the 409 domain-rule hierarchy has a single root. Zero behavior change — the dedicated `@ExceptionHandler` in `GlobalExceptionHandler` still wins.
- Hardcoded `240px` / `200px` select widths in `student-detail.scss` replaced with new `--ds-size-form-select` / `--ds-size-form-select-wide` tokens, per the frontend no-hardcoded-px rule.

## Test plan
- [x] `./mvnw test` passes
- [x] `npx ng test --browsers chromium --no-watch` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)