### PR TITLE
Students: shrink dance-level dropdowns; add level to DevTools course picker (#346)

### DIFF
--- a/frontend/src/app/dev-tools/dev-tools.html
+++ b/frontend/src/app/dev-tools/dev-tools.html
@@ -11,7 +11,7 @@
     <mat-select (selectionChange)="onCourseSelected($event.value)">
       @for (course of courses(); track course.id) {
         <mat-option [value]="course.id">
-          {{ course.title }} ({{ course.status | lowercase }}) — {{ course.enrolledStudents }}/{{ course.maxParticipants }}
+          {{ course.title }} ({{ course.status | lowercase }}) — {{ course.enrolledStudents }}/{{ course.maxParticipants }} · {{ formatLevel(course.level) }}
         </mat-option>
       }
     </mat-select>

--- a/frontend/src/app/dev-tools/dev-tools.ts
+++ b/frontend/src/app/dev-tools/dev-tools.ts
@@ -16,6 +16,7 @@ import { environment } from '../../environments/environment';
 import { CourseDetail, CourseListItem, CourseService } from '../courses/course.service';
 import { EnrollmentListItem, EnrollmentService, EnrollStudentRequest } from '../courses/enrollment.service';
 import { enrollmentStatusChipClass, formatEnrollmentStatus } from '../courses/shared/format-utils';
+import { COURSE_LEVELS, CourseLevel, labelOf } from '../shared/course-constants';
 
 const FIRST_NAMES = ['Anna', 'Marco', 'Laura', 'David', 'Sofia', 'Jan', 'Yuki', 'Elena', 'Thomas', 'Mia',
   'Lukas', 'Sarah', 'Alex', 'Nina', 'Felix', 'Julia', 'Max', 'Lena', 'Tobias', 'Clara'];
@@ -244,6 +245,10 @@ export class DevToolsComponent implements OnInit {
 
   protected formatStatus = formatEnrollmentStatus;
   protected enrollmentStatusChipClass = enrollmentStatusChipClass;
+
+  protected formatLevel(level: CourseLevel): string {
+    return labelOf(COURSE_LEVELS, level);
+  }
 
   protected formatWaitlistInfo(row: EnrollmentListItem): string {
     if (row.status !== 'WAITLISTED' || row.waitlistPosition == null) return '—';

--- a/frontend/src/app/students/detail/student-detail.scss
+++ b/frontend/src/app/students/detail/student-detail.scss
@@ -79,7 +79,7 @@
 .dance-level-row {
   display: flex;
   align-items: center;
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-spacing-2);
   padding: var(--ds-spacing-2) 0;
   border-bottom: 1px solid var(--mat-sys-outline-variant);
 
@@ -89,18 +89,23 @@
 }
 
 .dance-level-style {
-  flex: 1;
+  min-width: var(--ds-size-filter-select);
   font: var(--mat-sys-body-large);
   color: var(--mat-sys-on-surface);
 }
 
 .dance-level-style-select {
-  width: var(--ds-size-form-select-wide);
+  width: var(--ds-size-filter-select);
+
+  --mat-form-field-container-height: var(--ds-form-field-dense-height);
+  --mat-form-field-container-vertical-padding: var(--ds-spacing-1-5);
 }
 
 .dance-level-select {
-  width: var(--ds-size-form-select);
-  margin-left: auto;
+  width: var(--ds-size-filter-select);
+
+  --mat-form-field-container-height: var(--ds-form-field-dense-height);
+  --mat-form-field-container-vertical-padding: var(--ds-spacing-1-5);
 }
 
 .dance-level-empty {


### PR DESCRIPTION
## Summary
- Student detail: dance-style / level selects are now dense and narrower, and the level select no longer uses `margin-left: auto` — the two selects sit next to each other instead of spreading across the row.
- DevTools course picker: appends the course level to each option label (e.g. `Course X (open) — 20/20 · Advanced`).

Closes #346.

## Test plan
- [x] `ng build` passes
- [x] `ng test` passes (179/179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)