### PR TITLE
Enforce single-school-per-user invariant (#353)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -3,6 +3,7 @@ package ch.ruppen.danceschool.school;
 import ch.ruppen.danceschool.schoolmember.MemberRole;
 import ch.ruppen.danceschool.schoolmember.SchoolMember;
 import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
+import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
 import ch.ruppen.danceschool.shared.error.ResourceNotFoundException;
 import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import ch.ruppen.danceschool.shared.storage.ImageStorageService;
@@ -34,6 +35,10 @@ public class SchoolService {
     public SchoolDetailDto createSchool(SchoolUpdateDto dto, Long userId) {
         AppUser user = userService.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        if (schoolMemberService.existsByUserId(userId)) {
+            throw new DomainRuleViolationException("User already belongs to a school");
+        }
 
         School school = new School();
         applyDto(school, dto);

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberRepository.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberRepository.java
@@ -10,4 +10,6 @@ interface SchoolMemberRepository extends JpaRepository<SchoolMember, Long> {
     List<SchoolMember> findByUserId(Long userId);
 
     Optional<SchoolMember> findByUserIdAndSchoolId(Long userId, Long schoolId);
+
+    boolean existsByUserId(Long userId);
 }

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
@@ -1,5 +1,6 @@
 package ch.ruppen.danceschool.schoolmember;
 
+import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
 import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,10 @@ public class SchoolMemberService {
         return schoolMemberRepository.findByUserIdAndSchoolId(userId, schoolId);
     }
 
+    public boolean existsByUserId(Long userId) {
+        return schoolMemberRepository.existsByUserId(userId);
+    }
+
     /**
      * Phase 1 assumes a single school per user (enforced by a unique constraint on
      * {@code school_member.user_id}). Phase 2 will revisit when users can belong to multiple
@@ -39,6 +44,9 @@ public class SchoolMemberService {
 
     @BusinessOperation(event = "MembershipCreated")
     public SchoolMember createMembership(SchoolMember member) {
+        if (existsByUserId(member.getUser().getId())) {
+            throw new DomainRuleViolationException("User already belongs to a school");
+        }
         return schoolMemberRepository.save(member);
     }
 }

--- a/backend/src/main/resources/db/changelog/022-school-member-unique-user-id.yaml
+++ b/backend/src/main/resources/db/changelog/022-school-member-unique-user-id.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 022-school-member-unique-user-id
+      author: claude
+      comment: >
+        Enforce Phase 1 single-school-per-user invariant at the DB level.
+        Replaces the composite unique on (user_id, school_id) with a stricter
+        unique on (user_id) alone. Phase 2 will drop this when multi-school
+        admin is introduced.
+      preConditions:
+        - onFail: HALT
+        - sqlCheck:
+            expectedResult: 0
+            sql: SELECT COUNT(*) FROM (SELECT user_id FROM school_member GROUP BY user_id HAVING COUNT(*) > 1)
+      changes:
+        - dropUniqueConstraint:
+            tableName: school_member
+            constraintName: uk_school_member_user_school
+        - addUniqueConstraint:
+            tableName: school_member
+            columnNames: user_id
+            constraintName: uk_school_member_user

--- a/backend/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -41,3 +41,5 @@ databaseChangeLog:
       file: db/changelog/020-drop-enrolled-students-from-course.yaml
   - include:
       file: db/changelog/021-drop-role-balancing-enabled.yaml
+  - include:
+      file: db/changelog/022-school-member-unique-user-id.yaml

--- a/backend/src/test/java/ch/ruppen/danceschool/schoolmember/SingleSchoolInvariantTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/schoolmember/SingleSchoolInvariantTest.java
@@ -1,0 +1,101 @@
+package ch.ruppen.danceschool.schoolmember;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class SingleSchoolInvariantTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private SchoolMemberRepository schoolMemberRepository;
+
+    private AppUser testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new AppUser();
+        testUser.setEmail("test@example.com");
+        testUser.setName("Test User");
+        testUser.setFirebaseUid("test-firebase-uid");
+        entityManager.persist(testUser);
+        entityManager.flush();
+    }
+
+    @Test
+    void postSchoolsTwice_secondCallReturns409() throws Exception {
+        mockMvc.perform(post("/api/schools")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                { "name": "First School" }
+                                """))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/schools")
+                        .with(authentication(authToken(testUser)))
+                        .contentType("application/json")
+                        .content("""
+                                { "name": "Second School" }
+                                """))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void savingDuplicateSchoolMember_violatesUniqueConstraint() {
+        School school1 = new School();
+        school1.setName("School 1");
+        entityManager.persist(school1);
+
+        School school2 = new School();
+        school2.setName("School 2");
+        entityManager.persist(school2);
+
+        SchoolMember first = new SchoolMember();
+        first.setUser(testUser);
+        first.setSchool(school1);
+        first.setRole(MemberRole.OWNER);
+        schoolMemberRepository.saveAndFlush(first);
+
+        SchoolMember duplicate = new SchoolMember();
+        duplicate.setUser(testUser);
+        duplicate.setSchool(school2);
+        duplicate.setRole(MemberRole.OWNER);
+
+        assertThatThrownBy(() -> schoolMemberRepository.saveAndFlush(duplicate))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private UsernamePasswordAuthenticationToken authToken(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}


### PR DESCRIPTION
Closes #353.

## Summary
- Liquibase migration `022` replaces the composite `UNIQUE(user_id, school_id)` on `school_member` with a stricter `UNIQUE(user_id)`. A `sqlCheck` precondition halts the migration (with a clear error) if duplicate `user_id` rows already exist.
- `SchoolService.createSchool(...)` fails fast with `DomainRuleViolationException` (→ 409) when the caller already has a membership — avoids creating an orphan `school` row.
- `SchoolMemberService.createMembership(...)` performs the same check (defense in depth via `existsByUserId` on the repository).

## Test plan
- [x] New `SingleSchoolInvariantTest`:
  - `POST /api/schools` twice for the same user → second call returns 409.
  - Direct repository save of a duplicate `SchoolMember.user_id` → `DataIntegrityViolationException`.
- [x] Full backend suite (`./mvnw test`) — 243 / 243 passing.

Backend-only; no UI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)