### PR TITLE
Gate admin endpoints behind a SchoolMember check (#352)

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/courses")
+@PreAuthorize("@schoolAuthz.hasMembership()")
 @RequiredArgsConstructor
 public class CourseController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,6 +19,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api")
+@PreAuthorize("@schoolAuthz.hasMembership()")
 @RequiredArgsConstructor
 public class EnrollmentController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
@@ -5,6 +5,7 @@ import ch.ruppen.danceschool.shared.storage.ImageStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +18,7 @@ import java.util.Set;
 
 @RestController
 @RequestMapping("/api/images")
+@PreAuthorize("@schoolAuthz.hasMembership()")
 @RequiredArgsConstructor
 class ImageController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
@@ -2,6 +2,7 @@ package ch.ruppen.danceschool.payment;
 
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/payments")
+@PreAuthorize("@schoolAuthz.hasMembership()")
 @RequiredArgsConstructor
 public class PaymentController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,6 +21,11 @@ public class SchoolController {
 
     private final SchoolService schoolService;
 
+    /**
+     * Onboarding entrypoint that creates the caller's first {@code SchoolMember}, so callers
+     * reach this with no membership yet — intentionally not guarded by
+     * {@code @schoolAuthz.hasMembership()}. All other admin endpoints require membership.
+     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public SchoolDetailDto create(@Valid @RequestBody SchoolUpdateDto dto, @AuthenticationPrincipal AuthenticatedUser principal) {
@@ -27,11 +33,13 @@ public class SchoolController {
     }
 
     @GetMapping("/me")
+    @PreAuthorize("@schoolAuthz.hasMembership()")
     public SchoolDetailDto me(@AuthenticationPrincipal AuthenticatedUser principal) {
         return schoolService.getByMemberUserId(principal.userId());
     }
 
     @PutMapping("/me")
+    @PreAuthorize("@schoolAuthz.hasMembership()")
     public SchoolDetailDto updateMe(@Valid @RequestBody SchoolUpdateDto dto,
                                     @AuthenticationPrincipal AuthenticatedUser principal) {
         return schoolService.updateSchool(principal.userId(), dto);

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/MethodSecurityConfig.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/MethodSecurityConfig.java
@@ -1,0 +1,13 @@
+package ch.ruppen.danceschool.shared.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Enables {@code @PreAuthorize} on controller methods. Kept in a standalone config so both
+ * {@link DevSecurityConfig} and {@link SecurityConfig} pick it up regardless of auth mode.
+ */
+@Configuration
+@EnableMethodSecurity
+class MethodSecurityConfig {
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/SchoolAuthz.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/SchoolAuthz.java
@@ -1,0 +1,40 @@
+package ch.ruppen.danceschool.shared.security;
+
+import ch.ruppen.danceschool.schoolmember.SchoolMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Authorization bean exposed as SpEL name {@code schoolAuthz}. Controllers guard admin
+ * endpoints with {@code @PreAuthorize("@schoolAuthz.hasMembership()")}.
+ * <p>
+ * Phase 1 treats OWNER and TEACHER identically and assumes a single {@code SchoolMember}
+ * per user; the check collapses to "does the caller have any membership?". Phase 2 will
+ * parameterize this (e.g., {@code isMemberOf(#schoolId)}).
+ * <p>
+ * The check queries {@code SchoolMemberRepository} on every call rather than trusting
+ * {@code AuthenticatedUser.schoolId()} off the principal. This is load-bearing for the
+ * onboarding flow under session-based dev auth: the principal is built once at login with
+ * {@code schoolId = null} and never refreshed, so a caller who logs in and then creates
+ * their first school in the same session still sees a stale {@code null}. Costs one extra
+ * query per admin request; acceptable at current scale.
+ */
+@Component("schoolAuthz")
+@RequiredArgsConstructor
+public class SchoolAuthz {
+
+    private final SchoolMemberService schoolMemberService;
+
+    public boolean hasMembership() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            return false;
+        }
+        if (!(auth.getPrincipal() instanceof AuthenticatedUser user)) {
+            return false;
+        }
+        return schoolMemberService.findSchoolIdByUserId(user.userId()).isPresent();
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +20,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/students")
+@PreAuthorize("@schoolAuthz.hasMembership()")
 @RequiredArgsConstructor
 public class StudentController {
 

--- a/backend/src/test/java/ch/ruppen/danceschool/WithMockAppUser.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/WithMockAppUser.java
@@ -1,0 +1,44 @@
+package ch.ruppen.danceschool;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.security.DevAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Installs an {@link AuthenticatedUser} principal wrapped in a {@link DevAuthenticationToken},
+ * matching what the dev-auth filter emits under the dev profile. Use on tests that only need
+ * a synthesized principal (e.g. to exercise the membership gate without persisting a user).
+ * Tests that care about the user row existing in the database should continue to build it
+ * and attach the principal via {@code .with(authentication(...))}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@WithSecurityContext(factory = WithMockAppUser.Factory.class)
+public @interface WithMockAppUser {
+
+    long userId() default 1L;
+
+    String email() default "test@example.com";
+
+    class Factory implements WithSecurityContextFactory<WithMockAppUser> {
+        @Override
+        public SecurityContext createSecurityContext(WithMockAppUser annotation) {
+            AuthenticatedUser principal = new AuthenticatedUser(
+                    annotation.userId(), annotation.email(), null);
+            DevAuthenticationToken token = new DevAuthenticationToken(
+                    principal, AuthorityUtils.createAuthorityList("ROLE_USER"));
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(token);
+            return context;
+        }
+    }
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseControllerIntegrationTest.java
@@ -156,13 +156,13 @@ class CourseControllerIntegrationTest {
     }
 
     @Test
-    void getMe_returns404_whenUserHasNoSchool() throws Exception {
+    void getMe_returns403_whenUserHasNoSchool() throws Exception {
         AppUser orphan = createUser("orphan@example.com", "Orphan", "firebase-orphan");
         entityManager.flush();
 
         mockMvc.perform(get("/api/courses/me")
                         .with(authentication(authToken(orphan))))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/course/CourseTenantIsolationTest.java
@@ -89,13 +89,13 @@ class CourseTenantIsolationTest {
     }
 
     @Test
-    void getMe_returns404_forUserWithNoSchool() throws Exception {
+    void getMe_returns403_forUserWithNoSchool() throws Exception {
         AppUser orphan = createUser("orphan@example.com", "Orphan", "firebase-orphan");
         entityManager.flush();
 
         mockMvc.perform(get("/api/courses/me")
                         .with(authentication(authToken(orphan))))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     private AppUser createUser(String email, String name, String firebaseUid) {

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentListSqlBudgetTest.java
@@ -94,9 +94,12 @@ class EnrollmentListSqlBudgetTest {
                         .with(authentication(authToken(owner))))
                 .andExpect(status().isOk());
 
+        // Budget: 1 SchoolAuthz membership check + 1 load the caller's school +
+        // 1 load the course (tenant-scoped) + 1 load the enrollments list.
+        // The point is O(1) in N, not a specific number.
         assertThat(stats.getPrepareStatementCount())
                 .as("SQL budget for /enrollments with N=%d", n)
-                .isLessThanOrEqualTo(3);
+                .isLessThanOrEqualTo(4);
     }
 
     private AppUser createUser(String email, String name, String firebaseUid) {

--- a/backend/src/test/java/ch/ruppen/danceschool/image/ImageControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/image/ImageControllerIntegrationTest.java
@@ -1,6 +1,9 @@
 package ch.ruppen.danceschool.image;
 
 import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
 import ch.ruppen.danceschool.user.AppUser;
 import jakarta.persistence.EntityManager;
@@ -43,6 +46,19 @@ class ImageControllerIntegrationTest {
         testUser.setName("Test User");
         testUser.setFirebaseUid("test-firebase-uid");
         entityManager.persist(testUser);
+
+        // Image upload is gated by @schoolAuthz.hasMembership() — give the caller a
+        // membership so these tests exercise the upload path, not the authz gate.
+        School school = new School();
+        school.setName("Test School");
+        entityManager.persist(school);
+
+        SchoolMember member = new SchoolMember();
+        member.setUser(testUser);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+
         entityManager.flush();
     }
 

--- a/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/payment/PaymentListSqlBudgetTest.java
@@ -93,11 +93,11 @@ class PaymentListSqlBudgetTest {
                         .with(authentication(authToken(owner))))
                 .andExpect(status().isOk());
 
-        // 1 query for school resolution + 1 for the payment list = 2.
+        // 1 SchoolAuthz membership check + 1 school resolution + 1 payment list = 3.
         // Allow a small headroom for security/auth bookkeeping.
         assertThat(stats.getPrepareStatementCount())
                 .as("SQL budget for /api/payments/me with N=%d", n)
-                .isLessThanOrEqualTo(3);
+                .isLessThanOrEqualTo(4);
     }
 
     private AppUser createUser(String email, String name, String firebaseUid) {

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolControllerIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolControllerIntegrationTest.java
@@ -139,10 +139,10 @@ class SchoolControllerIntegrationTest {
     }
 
     @Test
-    void getMe_returns404_whenUserHasNoSchool() throws Exception {
+    void getMe_returns403_whenUserHasNoSchool() throws Exception {
         mockMvc.perform(get("/api/schools/me")
                         .with(authentication(authToken(testUser))))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -255,14 +255,14 @@ class SchoolControllerIntegrationTest {
     }
 
     @Test
-    void updateMe_returns404_whenUserHasNoSchool() throws Exception {
+    void updateMe_returns403_whenUserHasNoSchool() throws Exception {
         mockMvc.perform(put("/api/schools/me")
                         .with(authentication(authToken(testUser)))
                         .contentType("application/json")
                         .content("""
                                 { "name": "Some School" }
                                 """))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/backend/src/test/java/ch/ruppen/danceschool/school/SchoolTenantIsolationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/school/SchoolTenantIsolationTest.java
@@ -85,13 +85,13 @@ class SchoolTenantIsolationTest {
     }
 
     @Test
-    void getMe_returns404_forUserWithNoSchool() throws Exception {
+    void getMe_returns403_forUserWithNoSchool() throws Exception {
         AppUser orphan = createUser("orphan@example.com", "Orphan", "firebase-orphan");
         entityManager.flush();
 
         mockMvc.perform(get("/api/schools/me")
                         .with(authentication(authToken(orphan))))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/backend/src/test/java/ch/ruppen/danceschool/shared/security/AdminAuthzIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/shared/security/AdminAuthzIntegrationTest.java
@@ -1,0 +1,310 @@
+package ch.ruppen.danceschool.shared.security;
+
+import ch.ruppen.danceschool.TestSecurityConfig;
+import ch.ruppen.danceschool.WithMockAppUser;
+import ch.ruppen.danceschool.school.School;
+import ch.ruppen.danceschool.schoolmember.MemberRole;
+import ch.ruppen.danceschool.schoolmember.SchoolMember;
+import ch.ruppen.danceschool.user.AppUser;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Exercises the admin-endpoint authorization gate end-to-end: the real
+ * {@code securityFilterChain} is in play, {@code @PreAuthorize} runs,
+ * {@code SchoolAuthz} queries {@code SchoolMemberRepository}. No mocks.
+ *
+ * <p>Covers the three acceptance-criteria buckets from #352:
+ * <ul>
+ *   <li>Unauthenticated → 401 (sampled per controller).</li>
+ *   <li>Authenticated-no-membership → 403 on admin endpoints; 200 on self-info /
+ *       onboarding.</li>
+ *   <li>Authenticated-with-membership → 200 on own resources.</li>
+ * </ul>
+ *
+ * <p>Cross-tenant 404 assertions live in the per-feature tenant-isolation tests
+ * (CourseTenantIsolationTest, StudentTenantIsolationTest, EnrollmentIntegrationTest).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestSecurityConfig.class)
+class AdminAuthzIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    // ---- Unauthenticated → 401 (sampled per controller) ----
+
+    @Test
+    void unauthenticated_coursesMe_returns401() throws Exception {
+        mockMvc.perform(get("/api/courses/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticated_schoolsMe_returns401() throws Exception {
+        mockMvc.perform(get("/api/schools/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticated_students_returns401() throws Exception {
+        mockMvc.perform(get("/api/students"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticated_paymentsMe_returns401() throws Exception {
+        mockMvc.perform(get("/api/payments/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticated_enrollments_returns401() throws Exception {
+        mockMvc.perform(put("/api/enrollments/{id}/mark-paid", 1L))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticated_imageUpload_returns401() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "photo.jpg", MediaType.IMAGE_JPEG_VALUE,
+                new byte[]{(byte) 0xFF, (byte) 0xD8});
+        mockMvc.perform(multipart("/api/images").file(file))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticated_createSchool_returns401() throws Exception {
+        mockMvc.perform(post("/api/schools")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "Some School" }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticated_authMe_returns401() throws Exception {
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ---- Authenticated without membership → 403 on admin endpoints ----
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_coursesMe_returns403() throws Exception {
+        mockMvc.perform(get("/api/courses/me"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_schoolsMe_returns403() throws Exception {
+        mockMvc.perform(get("/api/schools/me"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_updateSchoolMe_returns403() throws Exception {
+        mockMvc.perform(put("/api/schools/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "Not Mine" }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_listStudents_returns403() throws Exception {
+        mockMvc.perform(get("/api/students"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_getStudent_returns403() throws Exception {
+        mockMvc.perform(get("/api/students/{id}", 1L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_createStudent_returns403() throws Exception {
+        mockMvc.perform(post("/api/students")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "X", "email": "x@example.com" }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_enrollmentMarkPaid_returns403() throws Exception {
+        mockMvc.perform(put("/api/enrollments/{id}/mark-paid", 1L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_enrollmentApprove_returns403() throws Exception {
+        mockMvc.perform(put("/api/enrollments/{id}/approve", 1L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_enrollmentReject_returns403() throws Exception {
+        mockMvc.perform(put("/api/enrollments/{id}/reject", 1L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_listCourseEnrollments_returns403() throws Exception {
+        mockMvc.perform(get("/api/courses/{id}/enrollments", 1L))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_paymentsMe_returns403() throws Exception {
+        mockMvc.perform(get("/api/payments/me"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockAppUser(userId = 9999L, email = "stranger@example.com")
+    void noMembership_imageUpload_returns403() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "photo.jpg", MediaType.IMAGE_JPEG_VALUE,
+                new byte[]{(byte) 0xFF, (byte) 0xD8});
+        mockMvc.perform(multipart("/api/images").file(file))
+                .andExpect(status().isForbidden());
+    }
+
+    // ---- Authenticated without membership → 200 on onboarding / self-info ----
+
+    @Test
+    void noMembership_createSchool_isAllowed() throws Exception {
+        AppUser user = persistUser("onboarder@example.com", "Onboarder", "firebase-onboard");
+        entityManager.flush();
+
+        mockMvc.perform(post("/api/schools")
+                        .with(authentication(tokenFor(user)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "First School" }
+                                """))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void noMembership_authMe_isAllowed() throws Exception {
+        AppUser user = persistUser("selfinfo@example.com", "Self Info", "firebase-self");
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/auth/me")
+                        .with(authentication(tokenFor(user))))
+                .andExpect(status().isOk());
+    }
+
+    // ---- Authenticated with membership → 200 on own resources (smoke) ----
+
+    @Test
+    void withMembership_coursesMe_isAllowed() throws Exception {
+        AppUser user = persistUser("member@example.com", "Member", "firebase-member");
+        persistSchoolWithOwner("Member School", user);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/courses/me")
+                        .with(authentication(tokenFor(user))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void withMembership_schoolsMe_isAllowed() throws Exception {
+        AppUser user = persistUser("member2@example.com", "Member 2", "firebase-member2");
+        persistSchoolWithOwner("Member School 2", user);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/schools/me")
+                        .with(authentication(tokenFor(user))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void withMembership_listStudents_isAllowed() throws Exception {
+        AppUser user = persistUser("member3@example.com", "Member 3", "firebase-member3");
+        persistSchoolWithOwner("Member School 3", user);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/students")
+                        .with(authentication(tokenFor(user))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void withMembership_paymentsMe_isAllowed() throws Exception {
+        AppUser user = persistUser("member4@example.com", "Member 4", "firebase-member4");
+        persistSchoolWithOwner("Member School 4", user);
+        entityManager.flush();
+
+        mockMvc.perform(get("/api/payments/me")
+                        .with(authentication(tokenFor(user))))
+                .andExpect(status().isOk());
+    }
+
+    // ---- Helpers ----
+
+    private AppUser persistUser(String email, String name, String firebaseUid) {
+        AppUser user = new AppUser();
+        user.setEmail(email);
+        user.setName(name);
+        user.setFirebaseUid(firebaseUid);
+        entityManager.persist(user);
+        return user;
+    }
+
+    private void persistSchoolWithOwner(String name, AppUser owner) {
+        School school = new School();
+        school.setName(name);
+        entityManager.persist(school);
+        SchoolMember member = new SchoolMember();
+        member.setUser(owner);
+        member.setSchool(school);
+        member.setRole(MemberRole.OWNER);
+        entityManager.persist(member);
+    }
+
+    private static UsernamePasswordAuthenticationToken tokenFor(AppUser user) {
+        AuthenticatedUser principal = new AuthenticatedUser(user.getId(), user.getEmail(), null);
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, AuthorityUtils.createAuthorityList("ROLE_USER"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `@PreAuthorize("@schoolAuthz.hasMembership()")` to every admin controller method. Authenticated-but-unlinked callers (pre-onboarding, or principals without a `SchoolMember`) now get 403 at the controller boundary instead of leaking through to service-level `/me` lookups that used to 404.
- New `SchoolAuthz` bean + `MethodSecurityConfig` (enables method security once, for both dev and prod filter chains).
- Leaves `POST /api/schools` and `GET /api/auth/me` authenticated-only — both are legitimately called before the caller has any membership.
- Repo scoping was already in place across admin paths (`findByIdAndSchoolId` / `findByIdAndCourseSchoolId`), so cross-tenant ID guesses still produce 404 via the scoped repository miss. Confirmed by audit; no repo changes needed.
- Test helper: `@WithMockAppUser(userId, email)` meta-annotation.
- New `AdminAuthzIntegrationTest` (26 tests) — 401/403/200 matrix per controller.

## Notes
- `SchoolAuthz.hasMembership()` intentionally consults the DB each call rather than reading `principal.schoolId()`. The dev session's principal is frozen at login with `schoolId = null`, so a user who creates their first school in-session would otherwise be stuck at 403. Javadoc spells this out. Costs one extra query per admin request.
- Five "no school → 404" tests updated to expect 403 — that's the intended behavior change.
- `Enrollment`/`Payment` SQL-budget tests bumped by +1 for the membership-check query. Could be rewritten as O(1)-in-N invariants in a follow-up.

## Out of scope (pre-existing gaps, worth a follow-up)
Cross-tenant 404 tests exist for students, enrollments, mark-paid, and course `/me`, but not for `GET|PUT|DELETE /api/courses/{id}`, `POST /api/courses/{id}/publish`, or `PUT /api/enrollments/{id}/approve|reject`. Code is safe (same `findByIdAndSchoolId` calls), but the tests don't prove it.

## Test plan
- [x] `./mvnw test` — 267 tests, all green
- [x] AdminAuthzIntegrationTest covers: unauthenticated → 401 per controller, authenticated-no-membership → 403 on admin endpoints (incl. `/api/images`), authenticated-no-membership → 200 on `POST /api/schools` + `GET /api/auth/me`, authenticated-with-membership → 200 on own resources
- [x] Existing tenant-isolation tests still pass (cross-tenant ID → 404)
- [x] Existing per-controller integration tests still pass

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)