### PR TITLE
Mechanical guardrails for admin authz (#356)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -135,6 +135,12 @@
       <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/CLAUDE.md
+++ b/backend/src/CLAUDE.md
@@ -78,6 +78,22 @@ Each domain feature gets its own package under `ch.ruppen.danceschool.<feature>`
 - `DEV_AUTH` — `true` for form login, `false` for Firebase JWT
 - `FIREBASE_PROJECT_ID` — default: `dance-school-ch`
 
+### Authz guardrails (ArchUnit)
+
+Admin-side authz rules are enforced mechanically by `src/test/java/ch/ruppen/danceschool/archunit/AdminAuthzArchTest.java`. Read it before adding or touching a controller — the test fails the build with loud, multi-line banners that tell you exactly what to change.
+
+Rules enforced:
+1. **`@TenantScoped` controllers don't reach unscoped finders** — no transitive call from a `@TenantScoped` class into `findById`/`existsById`/`deleteById`/`getReferenceById` on `CourseRepository`/`StudentRepository`/`EnrollmentRepository`. Use the `*AndSchoolId` variant.
+2. **Every `@TenantScoped` method has `@PreAuthorize`** — directly or via class-level annotation.
+3. **Id-taking repo methods returning a tenant entity take `schoolId` too** — prevents adding new id-scoped finders that bypass tenant isolation.
+4. **`@TenantScoped` controllers don't depend on `*Repository` directly** — data access goes through a service.
+5. **Every `@RestController` is either `@TenantScoped` or on the open-controller allowlist** — forces an explicit authz classification when a new controller appears.
+6. **`@PreAuthorize("@schoolAuthz.hasMembership()")` implies `@TenantScoped`** — catches the membership-gate SpEL copy-pasted onto an open controller.
+
+**Adding a new admin controller:** annotate the class `@TenantScoped` and apply `@PreAuthorize("@schoolAuthz.hasMembership()")` at the class level.
+
+**Adding a new open controller** (e.g., webhooks, Phase 1.5 `/api/public/**`): add the class simple name to `AdminAuthzArchTest.OPEN_CONTROLLER_ALLOWLIST` with a Javadoc note on the controller explaining why it's open.
+
 ## Testing
 
 **When to write tests:**

--- a/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/course/CourseController.java
@@ -1,6 +1,7 @@
 package ch.ruppen.danceschool.course;
 
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.security.TenantScoped;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/courses")
 @PreAuthorize("@schoolAuthz.hasMembership()")
+@TenantScoped
 @RequiredArgsConstructor
 public class CourseController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/enrollment/EnrollmentController.java
@@ -1,6 +1,7 @@
 package ch.ruppen.danceschool.enrollment;
 
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.security.TenantScoped;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 @PreAuthorize("@schoolAuthz.hasMembership()")
+@TenantScoped
 @RequiredArgsConstructor
 public class EnrollmentController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/image/ImageController.java
@@ -1,6 +1,7 @@
 package ch.ruppen.danceschool.image;
 
 import ch.ruppen.danceschool.shared.error.ImageUploadException;
+import ch.ruppen.danceschool.shared.security.TenantScoped;
 import ch.ruppen.danceschool.shared.storage.ImageStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import java.util.Set;
 @RestController
 @RequestMapping("/api/images")
 @PreAuthorize("@schoolAuthz.hasMembership()")
+@TenantScoped
 @RequiredArgsConstructor
 class ImageController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/payment/PaymentController.java
@@ -1,6 +1,7 @@
 package ch.ruppen.danceschool.payment;
 
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.security.TenantScoped;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,6 +14,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/payments")
 @PreAuthorize("@schoolAuthz.hasMembership()")
+@TenantScoped
 @RequiredArgsConstructor
 public class PaymentController {
 

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolController.java
@@ -1,45 +1,32 @@
 package ch.ruppen.danceschool.school;
 
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.security.TenantScoped;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/schools")
+@PreAuthorize("@schoolAuthz.hasMembership()")
+@TenantScoped
 @RequiredArgsConstructor
 public class SchoolController {
 
     private final SchoolService schoolService;
 
-    /**
-     * Onboarding entrypoint that creates the caller's first {@code SchoolMember}, so callers
-     * reach this with no membership yet — intentionally not guarded by
-     * {@code @schoolAuthz.hasMembership()}. All other admin endpoints require membership.
-     */
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public SchoolDetailDto create(@Valid @RequestBody SchoolUpdateDto dto, @AuthenticationPrincipal AuthenticatedUser principal) {
-        return schoolService.createSchool(dto, principal.userId());
-    }
-
     @GetMapping("/me")
-    @PreAuthorize("@schoolAuthz.hasMembership()")
     public SchoolDetailDto me(@AuthenticationPrincipal AuthenticatedUser principal) {
         return schoolService.getByMemberUserId(principal.userId());
     }
 
     @PutMapping("/me")
-    @PreAuthorize("@schoolAuthz.hasMembership()")
     public SchoolDetailDto updateMe(@Valid @RequestBody SchoolUpdateDto dto,
                                     @AuthenticationPrincipal AuthenticatedUser principal) {
         return schoolService.updateSchool(principal.userId(), dto);

--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolOnboardingController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolOnboardingController.java
@@ -1,0 +1,34 @@
+package ch.ruppen.danceschool.school;
+
+import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Onboarding entrypoint that creates the caller's first {@code SchoolMember}. Callers reach
+ * this with no membership yet, so the endpoint is intentionally not gated by
+ * {@code @schoolAuthz.hasMembership()} and the controller is deliberately not
+ * {@code @TenantScoped} — admin-authz rules only kick in once the school exists. Every
+ * other school endpoint lives on {@code SchoolController} and requires membership.
+ */
+@RestController
+@RequestMapping("/api/schools")
+@RequiredArgsConstructor
+public class SchoolOnboardingController {
+
+    private final SchoolService schoolService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SchoolDetailDto create(@Valid @RequestBody SchoolUpdateDto dto,
+                                  @AuthenticationPrincipal AuthenticatedUser principal) {
+        return schoolService.createSchool(dto, principal.userId());
+    }
+}

--- a/backend/src/main/java/ch/ruppen/danceschool/shared/security/TenantScoped.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/shared/security/TenantScoped.java
@@ -1,0 +1,28 @@
+package ch.ruppen.danceschool.shared.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker for {@code @RestController} classes whose endpoints are gated on school
+ * membership. Apply at the class level to every controller that requires an admin
+ * (school-member) caller — i.e., any controller that reads or mutates a tenant's
+ * {@code Course}, {@code Student}, {@code Enrollment}, or school-scoped aggregate.
+ * <p>
+ * The annotation itself is inert at runtime. Its purpose is to give the ArchUnit
+ * guardrails in {@code ch.ruppen.danceschool.archunit.AdminAuthzArchTest} a stable,
+ * explicit target set, replacing the brittle "all {@code *Controller} except an
+ * allowlist" pattern. Adding {@code @TenantScoped} to a new controller automatically
+ * opts it in to the whole set of authz rules: every public method must carry
+ * {@code @PreAuthorize}, the controller must not reach past services into
+ * repositories, and it must not call unscoped finders on tenant entities.
+ * <p>
+ * Controllers that intentionally expose open endpoints (e.g., {@code UserController}'s
+ * {@code /api/auth/me}, or {@code SchoolOnboardingController} which bootstraps the tenant
+ * before any membership exists) are <b>not</b> annotated. See PRD #226.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TenantScoped {}

--- a/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/student/StudentController.java
@@ -1,6 +1,7 @@
 package ch.ruppen.danceschool.student;
 
 import ch.ruppen.danceschool.shared.security.AuthenticatedUser;
+import ch.ruppen.danceschool.shared.security.TenantScoped;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/students")
 @PreAuthorize("@schoolAuthz.hasMembership()")
+@TenantScoped
 @RequiredArgsConstructor
 public class StudentController {
 

--- a/backend/src/test/java/ch/ruppen/danceschool/archunit/AdminAuthzArchTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/archunit/AdminAuthzArchTest.java
@@ -1,0 +1,428 @@
+package ch.ruppen.danceschool.archunit;
+
+import ch.ruppen.danceschool.shared.security.TenantScoped;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Mechanical guardrails for admin authorization. These rules fail the build when a change
+ * silently weakens tenant isolation — e.g., a new {@code @RestController} that forgets
+ * {@code @PreAuthorize}, a controller reaching past services into a repository, or an
+ * unscoped {@code findById} on a tenant entity.
+ * <p>
+ * <b>Context:</b> PRD #226 — Role-based authorization for admin endpoints. Gap identified
+ * and scoped in issue #356 (follow-up to #352, which shipped the initial pattern).
+ * <p>
+ * <b>Canonical examples in the codebase:</b>
+ * <ul>
+ *     <li>Correct {@code @TenantScoped} class: {@code CourseController}</li>
+ *     <li>Correct scoped finder: {@code CourseRepository#findByIdAndSchoolId}</li>
+ *     <li>Correct onboarding-style open controller: {@code SchoolOnboardingController}</li>
+ * </ul>
+ * Every rule below prints a multi-line banner on failure. Read the banner; it tells you
+ * exactly which file to change and how.
+ */
+@AnalyzeClasses(
+        packages = "ch.ruppen.danceschool",
+        importOptions = ImportOption.DoNotIncludeTests.class)
+public class AdminAuthzArchTest {
+
+    private static final String ROOT_PACKAGE = "ch.ruppen.danceschool";
+
+    /** Repositories that manage tenant-owned entities. Unscoped finders on these leak across schools. */
+    private static final Set<String> TENANT_REPOSITORIES = Set.of(
+            "CourseRepository",
+            "StudentRepository",
+            "EnrollmentRepository");
+
+    /** Spring Data finders that ignore any {@code schoolId} filter. */
+    private static final Set<String> UNSCOPED_FINDER_METHODS = Set.of(
+            "findById",
+            "existsById",
+            "deleteById",
+            "getReferenceById");
+
+    /** Tenant entity simple names — the return types that trigger rule 3. */
+    private static final Set<String> TENANT_ENTITIES = Set.of(
+            "Course",
+            "Student",
+            "Enrollment");
+
+    /**
+     * Collection wrapper types that rule 3 unwraps when inspecting repository return types.
+     * A method returning {@code Optional<Course>} or {@code List<Course>} is still an "id lookup
+     * that returns a tenant entity" as far as scoping is concerned.
+     */
+    private static final Set<String> WRAPPER_TYPES = Set.of(
+            "Optional",
+            "List",
+            "Collection",
+            "Iterable",
+            "Set");
+
+    /**
+     * {@code @RestController} classes that intentionally expose open endpoints (no school
+     * membership required). Adding to this list is a deliberate decision — document the
+     * reason in the controller's Javadoc.
+     */
+    private static final Set<String> OPEN_CONTROLLER_ALLOWLIST = Set.of(
+            "UserController",             // GET /api/auth/me — any authenticated user
+            "SchoolOnboardingController"  // POST /api/schools — bootstraps the first school
+    );
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // Rule 1 — controllers must not reach an unscoped finder on a tenant entity
+    // ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * No {@code @TenantScoped} class may transitively call {@code findById}/{@code existsById}/
+     * {@code deleteById}/{@code getReferenceById} on the tenant repositories. PRD #226; canonical
+     * scoped finder: {@link ch.ruppen.danceschool.course.CourseRepository#findByIdAndSchoolId}.
+     */
+    @ArchTest
+    public static final ArchRule tenant_scoped_controllers_must_not_call_unscoped_finders_on_tenant_entities =
+            classes()
+                    .that().areAnnotatedWith(TenantScoped.class)
+                    .should(new ArchCondition<JavaClass>(
+                            "not reach findById/existsById/deleteById/getReferenceById on CourseRepository, StudentRepository, or EnrollmentRepository through any transitive call") {
+                        @Override
+                        public void check(JavaClass controller, ConditionEvents events) {
+                            for (JavaMethod entry : controller.getMethods()) {
+                                for (Violation v : findUnscopedFinderReachedFrom(entry)) {
+                                    events.add(SimpleConditionEvent.violated(controller,
+                                            banner(
+                                                    "TENANT ISOLATION VIOLATION — unscoped repository call from controller",
+                                                    renderChain(v.chain) + "   ← FORBIDDEN",
+                                                    "replace " + v.target + " with the *AndSchoolId scoped variant"
+                                                            + " (see CourseRepository.findByIdAndSchoolId).",
+                                                    "any @TenantScoped controller path that resolves a Course/Student/Enrollment by id"
+                                                            + " must go through a schoolId-filtered query. Unscoped finders are a cross-tenant data-leak risk.",
+                                                    "EnrollmentService.confirmPayment"
+                                            )));
+                                }
+                            }
+                        }
+                    });
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // Rule 2 — every public method on a @TenantScoped class must carry @PreAuthorize
+    // ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Every public method on a {@code @TenantScoped} class must carry {@code @PreAuthorize}
+     * (directly or inherited from the class). PRD #226; canonical example: {@code CourseController}
+     * uses a class-level {@code @PreAuthorize("@schoolAuthz.hasMembership()")} covering all methods.
+     */
+    @ArchTest
+    public static final ArchRule tenant_scoped_controller_methods_must_declare_preauthorize =
+            classes()
+                    .that().areAnnotatedWith(TenantScoped.class)
+                    .should(new ArchCondition<JavaClass>(
+                            "have @PreAuthorize on every public method (directly or via class-level annotation)") {
+                        @Override
+                        public void check(JavaClass controller, ConditionEvents events) {
+                            boolean classLevel = controller.isAnnotatedWith(PreAuthorize.class);
+                            for (JavaMethod m : controller.getMethods()) {
+                                if (!m.getModifiers().contains(JavaModifier.PUBLIC)) continue;
+                                if (classLevel || m.isAnnotatedWith(PreAuthorize.class)) continue;
+
+                                events.add(SimpleConditionEvent.violated(m,
+                                        banner(
+                                                "AUTHZ VIOLATION — @TenantScoped method without @PreAuthorize",
+                                                controller.getSimpleName() + "." + m.getName() + "(…)"
+                                                        + "   ← MISSING @PreAuthorize",
+                                                "add @PreAuthorize(\"@schoolAuthz.hasMembership()\") to the method,"
+                                                        + " or apply it at the class level for all methods at once.",
+                                                "every @TenantScoped controller method is a membership-gated admin endpoint."
+                                                        + " Missing @PreAuthorize means any authenticated user reaches it.",
+                                                "CourseController (class-level @PreAuthorize covers all methods)"
+                                        )));
+                            }
+                        }
+                    });
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // Rule 3 — id-taking repository methods returning a tenant entity must also take schoolId
+    // ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Any {@code *Repository} method that returns a {@code Course}/{@code Student}/{@code Enrollment}
+     * (or an {@code Optional}/{@code List}/etc. of one) and accepts a {@code Long id} must also
+     * accept a {@code Long schoolId}. PRD #226; canonical example:
+     * {@link ch.ruppen.danceschool.course.CourseRepository#findByIdAndSchoolId}.
+     */
+    @ArchTest
+    public static final ArchRule admin_id_taking_repository_methods_must_be_tenant_scoped =
+            methods()
+                    .that().areDeclaredInClassesThat().haveSimpleNameEndingWith("Repository")
+                    .and().areDeclaredInClassesThat().resideInAPackage(ROOT_PACKAGE + "..")
+                    .should(new ArchCondition<JavaMethod>(
+                            "accept a Long schoolId parameter whenever they return a Course/Student/Enrollment and take a Long id") {
+                        @Override
+                        public void check(JavaMethod m, ConditionEvents events) {
+                            if (!returnsTenantEntity(m)) return;
+                            if (!hasLongParameterNamed(m, "id")) return;
+                            if (hasLongParameterNamed(m, "schoolId")) return;
+
+                            events.add(SimpleConditionEvent.violated(m,
+                                    banner(
+                                            "TENANT ISOLATION VIOLATION — id-taking repository method missing schoolId",
+                                            m.getOwner().getSimpleName() + "." + m.getName() + "(Long id, …)"
+                                                    + "   ← MISSING Long schoolId",
+                                            "add a Long schoolId parameter and filter on it — e.g., findByIdAndSchoolId(id, schoolId).",
+                                            "a Repository returning a tenant entity from a bare id is a cross-tenant data-leak"
+                                                    + " waiting to happen — any caller can fetch another tenant's row.",
+                                            "CourseRepository.findByIdAndSchoolId"
+                                    )));
+                        }
+                    });
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // Rule 4 — controllers must not depend on repositories directly
+    // ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * {@code @TenantScoped} classes must not depend on any {@code *Repository} — data access
+     * belongs in a service. Enforces Architectural Rules 3 &amp; 4 (see backend/src/CLAUDE.md) as a
+     * build-time check. PRD #226; canonical example: {@code CourseController} injects
+     * {@code CourseService}, not {@code CourseRepository}.
+     */
+    @ArchTest
+    public static final ArchRule tenant_scoped_controllers_must_not_call_repositories_directly =
+            noClasses()
+                    .that().areAnnotatedWith(TenantScoped.class)
+                    .should().dependOnClassesThat().haveSimpleNameEndingWith("Repository")
+                    .because(banner(
+                            "LAYERING VIOLATION — @TenantScoped controller depends on a Repository",
+                            "controller injects / references a *Repository type directly",
+                            "move the data access into a Service. Controllers should be pure HTTP adapters that call one"
+                                    + " service method. See backend/src/CLAUDE.md § Architectural Rules 3 & 4.",
+                            "scoping logic lives in services. Letting controllers reach past services into repositories"
+                                    + " lets a caller bypass the scoped-finder discipline.",
+                            "CourseController → CourseService (not CourseRepository)"
+                    ));
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // Rule 5 — every @RestController is either @TenantScoped or on the open-controller allowlist
+    // ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Every {@code @RestController} under {@code ch.ruppen.danceschool} must either carry
+     * {@code @TenantScoped} or appear on {@link #OPEN_CONTROLLER_ALLOWLIST}. Forces an explicit
+     * authz classification when a new controller appears. PRD #226; canonical examples:
+     * {@code CourseController} ({@code @TenantScoped}) and {@code SchoolOnboardingController}
+     * (allowlisted, open).
+     */
+    @ArchTest
+    public static final ArchRule rest_controllers_must_be_marked_tenant_scoped_or_allowlisted =
+            classes()
+                    .that().areAnnotatedWith(RestController.class)
+                    .and().resideInAPackage(ROOT_PACKAGE + "..")
+                    .should(new ArchCondition<JavaClass>(
+                            "carry @TenantScoped or appear on the explicit open-controller allowlist") {
+                        @Override
+                        public void check(JavaClass controller, ConditionEvents events) {
+                            if (controller.isAnnotatedWith(TenantScoped.class)) return;
+                            if (OPEN_CONTROLLER_ALLOWLIST.contains(controller.getSimpleName())) return;
+
+                            events.add(SimpleConditionEvent.violated(controller,
+                                    banner(
+                                            "AUTHZ CLASSIFICATION MISSING — @RestController is neither @TenantScoped nor allowlisted",
+                                            controller.getName() + "   ← needs an explicit authz classification",
+                                            "either add @TenantScoped (admin endpoint, gated by school membership) or"
+                                                    + " add the class simple name to AdminAuthzArchTest.OPEN_CONTROLLER_ALLOWLIST"
+                                                    + " with a short justification in the controller's Javadoc.",
+                                            "this rule forces an explicit decision whenever a new controller appears."
+                                                    + " A silent @RestController is how the tenant-isolation contract quietly erodes.",
+                                            "CourseController (@TenantScoped) vs SchoolOnboardingController (on the allowlist)"
+                                    )));
+                        }
+                    });
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // Rule 6 — @PreAuthorize referencing @schoolAuthz.hasMembership() must be on @TenantScoped
+    // ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Any class carrying class-level {@code @PreAuthorize} whose value references
+     * {@code @schoolAuthz.hasMembership()} must also be {@code @TenantScoped}. Catches the
+     * membership-gate SpEL copy-pasted onto an open controller, which would silently break
+     * onboarding. PRD #226; canonical example: {@code CourseController} carries both.
+     */
+    @ArchTest
+    public static final ArchRule preauthorize_with_has_membership_must_be_on_tenant_scoped_class =
+            classes()
+                    .that().resideInAPackage(ROOT_PACKAGE + "..")
+                    .should(new ArchCondition<JavaClass>(
+                            "carry @TenantScoped whenever @PreAuthorize references @schoolAuthz.hasMembership()") {
+                        @Override
+                        public void check(JavaClass clazz, ConditionEvents events) {
+                            if (!hasClassLevelHasMembershipPreAuthorize(clazz)) return;
+                            if (clazz.isAnnotatedWith(TenantScoped.class)) return;
+
+                            events.add(SimpleConditionEvent.violated(clazz,
+                                    banner(
+                                            "AUTHZ MISMATCH — membership gate without @TenantScoped marker",
+                                            clazz.getName() + "   ← @PreAuthorize(\"@schoolAuthz.hasMembership()\") but not @TenantScoped",
+                                            "add @TenantScoped to the class. If this controller is genuinely open, remove"
+                                                    + " the @PreAuthorize; if it is an admin endpoint, the marker belongs there"
+                                                    + " so the rest of the ArchUnit rules apply.",
+                                            "the membership-gate SpEL only makes sense for admin/tenant-scoped surface area."
+                                                    + " Copy-pasting it onto an open controller silently breaks onboarding.",
+                                            "CourseController carries both @PreAuthorize and @TenantScoped"
+                                    )));
+                        }
+                    });
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * BFS across {@code entry}'s transitive method calls, recording the call chain to every
+     * unscoped finder on a tenant repository. Returns one {@link Violation} per reached
+     * forbidden call (deduped by call path's final element).
+     */
+    private static List<Violation> findUnscopedFinderReachedFrom(JavaMethod entry) {
+        List<Violation> violations = new ArrayList<>();
+        Set<JavaMethod> visited = new HashSet<>();
+        // parent map lets us reconstruct the call chain when we hit a violation
+        Map<JavaMethod, JavaMethod> parent = new LinkedHashMap<>();
+        Deque<JavaMethod> queue = new ArrayDeque<>();
+        queue.add(entry);
+        visited.add(entry);
+
+        while (!queue.isEmpty()) {
+            JavaMethod current = queue.poll();
+            for (JavaMethodCall call : current.getMethodCallsFromSelf()) {
+                String targetOwner = call.getTargetOwner().getSimpleName();
+                String targetName = call.getName();
+
+                if (TENANT_REPOSITORIES.contains(targetOwner)
+                        && UNSCOPED_FINDER_METHODS.contains(targetName)) {
+                    List<String> chain = reconstructChain(entry, current, parent);
+                    chain.add(targetOwner + "." + targetName + "(…)");
+                    violations.add(new Violation(chain, targetOwner + "." + targetName));
+                    continue;
+                }
+
+                // Only recurse into methods declared in our own package — avoids exploring
+                // the whole JDK / Spring when we just want admin-path reachability.
+                JavaMethod resolved = resolveOwnMethod(call);
+                if (resolved != null && visited.add(resolved)) {
+                    parent.put(resolved, current);
+                    queue.add(resolved);
+                }
+            }
+        }
+        return violations;
+    }
+
+    private static JavaMethod resolveOwnMethod(JavaMethodCall call) {
+        if (!call.getTargetOwner().getPackageName().startsWith(ROOT_PACKAGE)) return null;
+        return call.getTarget().resolveMember().orElse(null) instanceof JavaMethod jm ? jm : null;
+    }
+
+    private static List<String> reconstructChain(JavaMethod entry, JavaMethod current, Map<JavaMethod, JavaMethod> parent) {
+        Deque<JavaMethod> stack = new ArrayDeque<>();
+        for (JavaMethod m = current; m != null; m = parent.get(m)) stack.push(m);
+        List<String> chain = new ArrayList<>();
+        for (JavaMethod m : stack) {
+            chain.add(m.getOwner().getSimpleName() + "." + m.getName() + "(…)");
+        }
+        return chain;
+    }
+
+    private static String renderChain(List<String> chain) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < chain.size(); i++) {
+            if (i == 0) sb.append("  ").append(chain.get(i));
+            else sb.append("\n      → ").append(chain.get(i));
+        }
+        return sb.toString();
+    }
+
+    private static boolean returnsTenantEntity(JavaMethod m) {
+        JavaClass raw = m.getRawReturnType();
+        String rawName = raw.getSimpleName();
+        if (TENANT_ENTITIES.contains(rawName)) return true;
+        if (!WRAPPER_TYPES.contains(rawName)) return false;
+        // Inspect the first generic argument via reflection — ArchUnit's JavaType exposes
+        // the signature but reflection is simpler here.
+        try {
+            Method reflected = m.reflect();
+            java.lang.reflect.Type generic = reflected.getGenericReturnType();
+            String s = generic.getTypeName();
+            for (String entity : TENANT_ENTITIES) {
+                if (s.contains("." + entity + ">") || s.contains("." + entity + ",")) return true;
+            }
+        } catch (Throwable ignored) {
+            // Reflection miss (e.g., class not loadable) — fall through to false. Worst case the
+            // rule is a bit less strict; it still catches the raw-return-type cases.
+        }
+        return false;
+    }
+
+    private static boolean hasLongParameterNamed(JavaMethod method, String name) {
+        try {
+            Method reflected = method.reflect();
+            for (Parameter p : reflected.getParameters()) {
+                if (!p.isNamePresent()) continue; // -parameters not enabled for this class
+                if (!Long.class.equals(p.getType()) && !long.class.equals(p.getType())) continue;
+                if (p.getName().equals(name)) return true;
+            }
+        } catch (Throwable ignored) {
+            // Reflection miss (class not loadable, etc.). Fall through to false — when looking for
+            // `id`, this means rule 3 doesn't apply (safe); when looking for `schoolId`, rule 3 fires
+            // on the assumption the param isn't there (also safe).
+        }
+        return false;
+    }
+
+    private static boolean hasClassLevelHasMembershipPreAuthorize(JavaClass clazz) {
+        if (!clazz.isAnnotatedWith(PreAuthorize.class)) return false;
+        String value = clazz.getAnnotationOfType(PreAuthorize.class).value();
+        return value != null && value.contains("@schoolAuthz.hasMembership()");
+    }
+
+    private static String banner(String title, String body, String fix, String why, String example) {
+        String bar = "══════════════════════════════════════════════════════════════════════";
+        return "\n" + bar + "\n"
+                + "  " + title + "\n"
+                + bar + "\n\n"
+                + body + "\n\n"
+                + "  Why: " + why + "\n"
+                + "  Fix: " + fix + "\n"
+                + "  Context: PRD #226 — Role-based authorization for admin endpoints\n"
+                + "  Pattern: see " + example + "\n"
+                + bar;
+    }
+
+    private record Violation(List<String> chain, String target) {}
+}

--- a/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
+++ b/backend/src/test/java/ch/ruppen/danceschool/enrollment/EnrollmentIntegrationTest.java
@@ -878,6 +878,46 @@ class EnrollmentIntegrationTest {
                 .andExpect(status().isNotFound());
     }
 
+    @Test
+    void approve_otherOwnersEnrollment_returns404() throws Exception {
+        // Create a PENDING_APPROVAL enrollment as owner1.
+        Long enrollmentId = createPendingApprovalForInsufficientLevel();
+
+        // Owner2 (different school) tries to approve it.
+        AppUser owner2 = createUser("owner2@example.com", "Owner 2", "firebase-owner-2");
+        createSchoolWithOwner("Other School", owner2);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/enrollments/{id}/approve", enrollmentId)
+                        .with(authentication(authToken(owner2))))
+                .andExpect(status().isNotFound());
+
+        // Contract: no mutation under cross-tenant access — status must still be PENDING_APPROVAL.
+        entityManager.flush();
+        entityManager.clear();
+        Enrollment untouched = entityManager.find(Enrollment.class, enrollmentId);
+        org.junit.jupiter.api.Assertions.assertEquals(EnrollmentStatus.PENDING_APPROVAL, untouched.getStatus());
+        org.junit.jupiter.api.Assertions.assertNull(untouched.getApprovedAt());
+    }
+
+    @Test
+    void reject_otherOwnersEnrollment_returns404() throws Exception {
+        Long enrollmentId = createPendingApprovalForInsufficientLevel();
+
+        AppUser owner2 = createUser("owner2@example.com", "Owner 2", "firebase-owner-2");
+        createSchoolWithOwner("Other School", owner2);
+        entityManager.flush();
+
+        mockMvc.perform(put("/api/enrollments/{id}/reject", enrollmentId)
+                        .with(authentication(authToken(owner2))))
+                .andExpect(status().isNotFound());
+
+        entityManager.flush();
+        entityManager.clear();
+        Enrollment untouched = entityManager.find(Enrollment.class, enrollmentId);
+        org.junit.jupiter.api.Assertions.assertEquals(EnrollmentStatus.PENDING_APPROVAL, untouched.getStatus());
+    }
+
     // --- Helpers ---
 
     private AppUser createUser(String email, String name, String firebaseUid) {


### PR DESCRIPTION
## Summary

Closes #356. Follow-up to #352 — adds build-time enforcement of the tenant-isolation contract so future changes can't silently weaken it.

- New `@TenantScoped` marker applied to all 6 school-member-gated controllers.
- Split `SchoolController`: `POST /api/schools` moved to a new `SchoolOnboardingController` (open endpoint — bootstraps the first `SchoolMember` before any membership exists, so it can't be membership-gated). `SchoolController` retains the two `/me` methods, gains class-level `@PreAuthorize` + `@TenantScoped`.
- **6 ArchUnit rules** with multi-line banner failure messages (file + full call chain + Why / Fix / Context / Pattern). Loudness verified locally by inducing violations; see issue #356 AC.
- **Docs:** backend `CLAUDE.md` gains an *Authz guardrails (ArchUnit)* section pointing future agents at the test class.

### Rule 6 — addition on top of the issue's 5

The issue originally listed 5 rules. During implementation I added a sixth with the user's approval:

> **Rule 6** — any class carrying `@PreAuthorize("@schoolAuthz.hasMembership()")` must also carry `@TenantScoped`.

Catches the membership-gate SpEL copy-pasted onto an open controller (e.g., `SchoolOnboardingController`), which would silently break onboarding.

### Scope note on Part B

The issue listed 6 missing cross-tenant 404 tests. Four already existed (audit was done post-issue-write):

| Endpoint | Existing test |
|---|---|
| `GET /api/courses/{id}` | `CourseCrudIntegrationTest.getDetail_returns404_forOtherSchoolsCourse` |
| `POST /api/courses/{id}/publish` | `CoursePublishTest.publish_returns404_forCourseInAnotherSchool` |
| `PUT /api/courses/{id}` | `CourseCrudIntegrationTest.updateCourse_returns404_forOtherSchoolsCourse` |
| `DELETE /api/courses/{id}` | `CourseCrudIntegrationTest.deleteCourse_returns404_forOtherSchoolsCourse` |
| `PUT /api/enrollments/{id}/approve` | **added** in `EnrollmentIntegrationTest` |
| `PUT /api/enrollments/{id}/reject` | **added** in `EnrollmentIntegrationTest` |

New tests also assert DB state is unchanged after the cross-tenant 404 (no mutation under unauthorized access).

## Test plan

- [x] `./mvnw test` — 277 tests pass (269 prior + 6 ArchUnit + 2 new integration tests)
- [x] Deliberate-violation sanity check — rules 1, 5, 6 produced loud actionable banners
- [x] Visual sanity check — logged in as owner, walked courses → course detail → mark-paid flow per `docs/TESTING_WORKFLOWS.md`, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)