### PR TITLE
Point frontend at api.aquisebaila.ch (closes #351 partial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ Multi-tenant B2B SaaS for dance school management. Each **School** is a tenant. 
 
 - **Branch protection** is enabled on `main` — all changes go through PRs
 - CI workflows in `.github/workflows/`: `ci.yml` (tests), `codeql.yml` (code scanning)
-- **Frontend** deployed on Render (static site): https://danceschool-2g1m.onrender.com/
-- **Backend** deployed on Render (Docker): https://danceschool-api.onrender.com/ (API base: `/api`)
+- **Frontend** deployed on Render (static site): https://app.aquisebaila.ch/ (Render URL: `danceschool-2g1m.onrender.com`)
+- **Backend** deployed on Render (Docker): https://api.aquisebaila.ch/ (API base: `/api`; Render URL: `danceschool-api.onrender.com`)
 
 ## Issue Workflow
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://danceschool-api.onrender.com',
+  apiUrl: 'https://api.aquisebaila.ch',
   firebase: {
     apiKey: 'AIzaSyB8btpaR5aCsfi1nEThcKE6IfxkoHEGkPQ',
     authDomain: 'dance-school-ch.firebaseapp.com',


### PR DESCRIPTION
## Summary
- Switch `environment.prod.ts` apiUrl from `https://danceschool-api.onrender.com` to `https://api.aquisebaila.ch`
- Update root CLAUDE.md to reflect the custom domains (kept Render hostnames as internal reference)

## Out-of-band changes (already done in Render / Firebase)
- Added custom domains `app.aquisebaila.ch` → admin service, `api.aquisebaila.ch` → backend service; SSL certs issued
- Added `https://app.aquisebaila.ch` to `CORS_ALLOWED_ORIGINS` on the backend
- Added `app.aquisebaila.ch` to Firebase authorized domains
- Verified login + API calls work end-to-end at `https://app.aquisebaila.ch` (403 on accounts without a SchoolMember row is expected given #352)

## Follow-ups (separate work)
- Detach apex + www from the admin Render service (reserved for the public pilot frontend in #349)
- Apex + `mail.` subdomain setup deferred to #349 and #348

Refs #351

## Test plan
- [x] Local production build succeeds (`ng build --configuration=production`)
- [ ] After merge + Render auto-deploy, confirm admin at `https://app.aquisebaila.ch` loads and calls `https://api.aquisebaila.ch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)