### PR TITLE
Disable spring.jpa.open-in-view

### DIFF
--- a/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/school/SchoolService.java
@@ -57,10 +57,12 @@ public class SchoolService {
         return schoolRepository.findByMemberUserId(userId).isPresent();
     }
 
+    @Transactional(readOnly = true)
     public SchoolDetailDto getByMemberUserId(Long userId) {
         return toDetailDto(findSchoolByMember(userId));
     }
 
+    @Transactional
     @BusinessOperation(event = "SchoolUpdated")
     public SchoolDetailDto updateSchool(Long userId, SchoolUpdateDto dto) {
         School school = findSchoolByMember(userId);

--- a/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
+++ b/backend/src/main/java/ch/ruppen/danceschool/schoolmember/SchoolMemberService.java
@@ -4,6 +4,7 @@ import ch.ruppen.danceschool.shared.error.DomainRuleViolationException;
 import ch.ruppen.danceschool.shared.logging.BusinessOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,7 @@ public class SchoolMemberService {
 
     private final SchoolMemberRepository schoolMemberRepository;
 
+    @Transactional(readOnly = true)
     public List<MembershipDto> findMembershipsByUserId(Long userId) {
         return schoolMemberRepository.findByUserId(userId).stream()
                 .map(member -> new MembershipDto(
@@ -36,6 +38,7 @@ public class SchoolMemberService {
      * {@code school_member.user_id}). Phase 2 will revisit when users can belong to multiple
      * schools — this method will need to change shape accordingly.
      */
+    @Transactional(readOnly = true)
     public Optional<Long> findSchoolIdByUserId(Long userId) {
         return schoolMemberRepository.findByUserId(userId).stream()
                 .findFirst()

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -4,6 +4,10 @@ spring:
   # JWT issuer-uri is configured in application-prod.yaml only.
   # In the default (dev) profile, DevSecurityConfig provides form login with
   # in-memory users — no Firebase emulator needed.
+  jpa:
+    # Disable OSIV so lazy loads fail fast in the service layer instead of firing
+    # during response serialization.
+    open-in-view: false
 
 app:
   security:

--- a/backend/src/test/resources/application.yaml
+++ b/backend/src/test/resources/application.yaml
@@ -3,6 +3,8 @@ app:
     dev-auth: false
 
 spring:
+  jpa:
+    open-in-view: false
   security:
     oauth2:
       resourceserver:


### PR DESCRIPTION
## Summary
- Sets `spring.jpa.open-in-view: false` in both main and test `application.yaml`, removing the startup warning and forcing lazy loads to fail fast in the service layer instead of during response serialization.
- Adds `@Transactional(readOnly = true)` / `@Transactional` to the three service methods that previously relied on OSIV to keep the Hibernate session open while DTOs serialized lazy collections:
  - `SchoolService.getByMemberUserId` / `updateSchool` (School → specialties, galleryImages, youtubeVideos)
  - `SchoolMemberService.findMembershipsByUserId` / `findSchoolIdByUserId` (SchoolMember → school)

Closes #359.

## Test plan
- [x] `./mvnw test` — 277 tests pass
- [x] Smoke-tested admin UI with Playwright (Dashboard, My School, Courses, Students, Student Detail, Payments) — all render cleanly, no LazyInitializationException in backend logs