### PR TITLE
Add MIT + Commons Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,44 @@
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined
+below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the
+License will not include, and the License does not grant to you, the right to
+Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the rights
+granted to you under the License to provide to third parties, for a fee or
+other consideration (including without limitation fees for hosting or
+consulting/support services related to the Software), a product or service
+whose value derives, entirely or substantially, from the functionality of the
+Software. Any license notice or attribution required by the License must also
+include this Commons Clause License Condition notice.
+
+Software: Dance School
+License: MIT
+Licensor: Leon Ruppen
+
+---
+
+MIT License
+
+Copyright (c) 2026 Leon Ruppen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -10,9 +10,9 @@ Sell the Software.
 For purposes of the foregoing, "Sell" means practicing any or all of the rights
 granted to you under the License to provide to third parties, for a fee or
 other consideration (including without limitation fees for hosting or
-consulting/support services related to the Software), a product or service
+consulting/ support services related to the Software), a product or service
 whose value derives, entirely or substantially, from the functionality of the
-Software. Any license notice or attribution required by the License must also
+Software.  Any license notice or attribution required by the License must also
 include this Commons Clause License Condition notice.
 
 Software: Dance School

--- a/README.md
+++ b/README.md
@@ -132,3 +132,9 @@ Runs on `http://localhost:4200`. The Angular dev server proxies `/api` to the ba
 - `backend/src/CLAUDE.md` — Spring Boot architecture and authz guardrails
 - `docs/GLOSSARY.md` — domain language
 - `docs/TESTING_WORKFLOWS.md` — manual end-to-end scenarios
+
+## License
+
+MIT with [Commons Clause](https://commonsclause.com/) — see [`LICENSE`](./LICENSE).
+
+You can read, fork, modify, and contribute to the code freely. **You may not sell the software** or offer a paid product or service whose value derives substantially from it (including paid hosting or consulting around it). For commercial use, contact the author.


### PR DESCRIPTION
## Summary
- Add `LICENSE` at the repo root: MIT base + Commons Clause rider (canonical text from commonsclause.com)
- Add a "License" section to the README linking to it and summarising the restriction
- Allows: read, fork, modify, contribute, build commercial products on top. Forbids: reselling the software itself.

## Test plan
- [x] `LICENSE` matches the canonical Commons Clause v1.0 text + standard MIT
- [x] Copyright line: `2026 Leon Ruppen`
- [x] README license section links to `LICENSE` and to commonsclause.com
- [x] GitHub will label this "Other" / source-available, not OSI open source — expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)